### PR TITLE
feature: Add servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,20 +35,23 @@ Currently, no way to uninstall/update server. Run this command again, newer vers
 
 ## Supported Languages
 
-|Language  |Language Server                                            |Local Install|
-|----------|-----------------------------------------------------------|:-----------:|
-|C/C++     |clangd                                                     |No           |
-|Clojure   |clojure-lsp                                                |Yes          |
-|TypeScript|typescript-language-server                                 |Yes          |
-|JavaScript|javascript-typescript-langserver/typescript-language-server|Yes          |
-|Python    |pyls                                                       |No           |
-|Rust      |rls                                                        |Yes          |
-|Go        |gopls                                                      |Yes          |
-|Ruby      |solargraph                                                 |Yes          |
-|PHP       |intelephense-server                                        |Yes          |
-|Java      |eclipse-jdt-ls                                             |Yes          |
-|Lua       |emmylua-ls                                                 |Yes          |
-|Vim       |vim-language-server                                        |Yes          |
+| Language   | Language Server                                             | Local Install |
+|------------|-------------------------------------------------------------|:-------------:|
+| C/C++      | clangd                                                      | No            |
+| Clojure    | clojure-lsp                                                 | Yes           |
+| TypeScript | typescript-language-server                                  | Yes           |
+| JavaScript | javascript-typescript-langserver/typescript-language-server | Yes           |
+| Python     | pyls                                                        | Yes           |
+| Rust       | rls                                                         | Yes           |
+| Go         | gopls                                                       | Yes           |
+| Ruby       | solargraph                                                  | Yes           |
+| PHP        | intelephense-server                                         | Yes           |
+| Java       | eclipse-jdt-ls                                              | Yes           |
+| Lua        | emmylua-ls                                                  | Yes           |
+| Vim        | vim-language-server                                         | Yes           |
+| Bash       | bash-language-server                                        | Yes           |
+| Terraform  | terraform-lsp                                               | Yes           |
+| Dockerfile | dockerfile-language-server-nodejs                           | Yes           |
 
 ## License
 

--- a/installer/install-bash-language-server.sh
+++ b/installer/install-bash-language-server.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+server_dir="../servers/bash-language-server"
+
+cd $(dirname $0)
+[ -d $server_dir ] && rm -rf $server_dir
+mkdir $server_dir && cd $server_dir
+
+npm init -y
+sed -i -e 's/\"name\":.*$/\"name\": \"\",/' package.json
+npm install bash-language-server
+
+ln -s ./node_modules/.bin/bash-language-server .

--- a/installer/install-docker-langserver.sh
+++ b/installer/install-docker-langserver.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+server_dir="../servers/docker-langserver"
+
+cd $(dirname $0)
+[ -d $server_dir ] && rm -rf $server_dir
+mkdir $server_dir && cd $server_dir
+
+npm init -y
+sed -i -e 's/\"name\":.*$/\"name\": \"\",/' package.json
+npm install dockerfile-language-server-nodejs
+
+ln -s ./node_modules/.bin/docker-langserver .

--- a/installer/install-pyls.sh
+++ b/installer/install-pyls.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+server_dir="../servers/pyls"
+
+cd $(dirname $0)
+[ -d $server_dir ] && rm -rf $server_dir
+mkdir $server_dir && cd $server_dir
+
+python3 -m venv ./venv
+./venv/bin/pip3 install python-language-server
+ln -s ./venv/bin/pyls .

--- a/installer/install-terraform-lsp.sh
+++ b/installer/install-terraform-lsp.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+os=$(uname -s | tr "[:upper:]" "[:lower:]")
+version="0.0.9"
+server_dir="../servers/terraform-lsp"
+
+cd $(dirname $0)
+[ -d $server_dir ] && rm -rf $server_dir
+mkdir $server_dir && cd $server_dir
+
+case $os in
+darwin | linux)
+  url="https://github.com/juliosueiras/terraform-lsp/releases/download/v${version}/terraform-lsp_${version}_${os}_amd64.tar.gz"
+  curl -L "$url" | tar zx
+  ;;
+*)
+  printf "%s doesn't supported" "$os"
+  exit 1
+  ;;
+
+esac

--- a/settings.json
+++ b/settings.json
@@ -43,7 +43,7 @@
     {
       "command": "pyls",
       "requires": [
-        "pip"
+        "python3"
       ]
     }
   ],
@@ -130,6 +130,28 @@
   "cs": [
     {
       "command": "omnisharp-node-client",
+      "requires": [
+        "npm"
+      ]
+    }
+  ],
+  "terraform": [
+    {
+      "command": "terraform-lsp",
+      "requires": []
+    }
+  ],
+  "dockerfile": [
+    {
+      "command": "docker-langserver",
+      "requires": [
+        "npm"
+      ]
+    }
+  ],
+  "sh": [
+    {
+      "command": "bash-language-server",
       "requires": [
         "npm"
       ]

--- a/settings/bash-language-server.vim
+++ b/settings/bash-language-server.vim
@@ -1,0 +1,11 @@
+augroup vimlsp_settings_bash_language_server
+  au!
+  autocmd User lsp_setup call lsp#register_server({
+      \ 'name': 'bash-language-server',
+      \ 'cmd': {server_info->lsp_settings#get('bash-language-server', 'cmd', [lsp_settings#exec_path('bash-language-server'), 'start'])},
+      \ 'whitelist': lsp_settings#get('bash-language-server', 'whitelist', ['sh']),
+      \ 'blacklist': lsp_settings#get('bash-language-server', 'blacklist', []),
+      \ 'config': lsp_settings#get('bash-language-server', 'config', {}),
+      \ 'workspace_config': lsp_settings#get('bash-language-server', 'workspace_config', {}),
+      \ })
+augroup END

--- a/settings/docker-langserver.vim
+++ b/settings/docker-langserver.vim
@@ -1,0 +1,11 @@
+augroup vimlsp_settings_dockerfile_language_server_nodejs
+  au!
+  autocmd User lsp_setup call lsp#register_server({
+      \ 'name': 'dockerfile-language-server-nodejs',
+      \ 'cmd': {server_info->lsp_settings#get('docker-langserver', 'cmd', [lsp_settings#exec_path('docker-langserver'), '--stdio'])},
+      \ 'whitelist': lsp_settings#get('docker-langserver', 'whitelist', ['dockerfile']),
+      \ 'blacklist': lsp_settings#get('docker-langserver', 'blacklist', []),
+      \ 'config': lsp_settings#get('docker-langserver', 'config', {}),
+      \ 'workspace_config': lsp_settings#get('docker-langserver', 'workspace_config', {}),
+      \ })
+augroup END

--- a/settings/terraform-lsp.vim
+++ b/settings/terraform-lsp.vim
@@ -1,0 +1,11 @@
+augroup vimlsp_settings_terraform_lsp
+  au!
+  autocmd User lsp_setup call lsp#register_server({
+      \ 'name': 'terraform-lsp',
+      \ 'cmd': {server_info->lsp_settings#get('terraform-lsp', 'cmd', [lsp_settings#exec_path('terraform-lsp')])},
+      \ 'whitelist': lsp_settings#get('terraform-lsp', 'whitelist', ['terraform']),
+      \ 'blacklist': lsp_settings#get('terraform-lsp', 'blacklist', []),
+      \ 'config': lsp_settings#get('terraform-lsp', 'config', {}),
+      \ 'workspace_config': lsp_settings#get('terraform-lsp', 'workspace_config', {}),
+      \ })
+augroup END


### PR DESCRIPTION
Added servers
- terraform-lsp
- dockerfile-language-server-nodejs
- bash-language-server

Fix pyls installer
Using venv (drop python2 support)

Installers for Windows are not included yet for this Pull Request, somebody's contributions are needed.