### PR TITLE
Fix support 3rd party library completion

### DIFF
--- a/settings/rls.vim
+++ b/settings/rls.vim
@@ -8,5 +8,6 @@ augroup vimlsp_settings_rls
       \ 'blacklist': lsp_settings#get('rls', 'blacklist', []),
       \ 'config': lsp_settings#get('rls', 'config', {}),
       \ 'workspace_config': lsp_settings#get('rls', 'workspace_config', {}),
+      \ 'root_uri': {server_info -> lsp#utils#path_to_uri(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), 'Cargo.toml'))},
       \ })
 augroup END


### PR DESCRIPTION
## Problem
Current `rls` settings can't complete 3rd party library.

## Before
![Kapture 2019-12-18 at 1 01 53](https://user-images.githubusercontent.com/56591/71012721-e0b10380-2132-11ea-8e32-616f1e5c04f9.gif)

## After
![Kapture 2019-12-18 at 1 05 40](https://user-images.githubusercontent.com/56591/71012734-e6a6e480-2132-11ea-918c-e187407da524.gif)
