### PR TITLE
feature: Support yaml-language-server and lsp4xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Currently, no way to uninstall/update server. Run this command again, newer vers
 | Bash       | bash-language-server                                        | Yes           |
 | Terraform  | terraform-lsp                                               | Yes           |
 | Dockerfile | dockerfile-language-server-nodejs                           | Yes           |
+| YAML       | yaml-language-server                                        | Yes           |
+| XML        | lsp4xml                                                     | Yes           |
 
 ## License
 

--- a/installer/install-lsp4xml.sh
+++ b/installer/install-lsp4xml.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+cd $(dirname $0)
+
+server_dir="../servers/lsp4xml"
+[ -d $server_dir ] && rm -rf $server_dir
+mkdir $server_dir && cd $server_dir
+
+version="0.9.1"
+url=https://dl.bintray.com/lsp4xml/releases/org/lsp4xml/org.eclipse.lsp4xml/${version}/org.eclipse.lsp4xml-${version}-uber.jar
+
+curl -LO "$url"
+
+cat <<EOF >lsp4xml
+#!/bin/sh
+
+DIR=\$(cd \$(dirname \$0); pwd)
+java -jar \$DIR/org.eclipse.lsp4xml-${version}-uber.jar
+EOF
+
+chmod +x lsp4xml

--- a/installer/install-yaml-language-server.sh
+++ b/installer/install-yaml-language-server.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+cd $(dirname $0)
+
+server_dir="../servers/yaml-language-server"
+[ -d $server_dir ] && rm -rf $server_dir
+mkdir $server_dir && cd $server_dir
+
+npm init -y
+cat <<EOF >package.json
+{"name": ""}
+EOF
+npm install yaml-language-server
+
+ln -s ./node_modules/.bin/yaml-language-server .

--- a/settings.json
+++ b/settings.json
@@ -156,5 +156,21 @@
         "npm"
       ]
     }
+  ],
+  "yaml": [
+    {
+      "command": "yaml-language-server",
+      "requires": [
+        "npm"
+      ]
+    }
+  ],
+  "xml": [
+    {
+      "command": "lsp4xml",
+      "requires": [
+        "java"
+      ]
+    }
   ]
 }

--- a/settings/lsp4xml.vim
+++ b/settings/lsp4xml.vim
@@ -1,0 +1,11 @@
+augroup vimlsp_settings_lsp4xml
+  au!
+  autocmd User lsp_setup ++once call lsp#register_server({
+      \ 'name': 'lsp4xml',
+      \ 'cmd': {server_info->lsp_settings#get('lsp4xml', 'cmd', [lsp_settings#exec_path('lsp4xml')])},
+      \ 'whitelist': lsp_settings#get('lsp4xml', 'whitelist', ['xml']),
+      \ 'blacklist': lsp_settings#get('lsp4xml', 'blacklist', []),
+      \ 'config': lsp_settings#get('lsp4xml', 'config', {}),
+      \ 'workspace_config': lsp_settings#get('lsp4xml', 'workspace_config', {}),
+      \ })
+augroup END

--- a/settings/yaml-language-server.vim
+++ b/settings/yaml-language-server.vim
@@ -1,0 +1,11 @@
+augroup vimlsp_settings_yaml_language_server
+  au!
+  autocmd User lsp_setup ++once call lsp#register_server({
+      \ 'name': 'yaml-language-server',
+      \ 'cmd': {server_info->lsp_settings#get('yaml-language-server', 'cmd', [lsp_settings#exec_path('yaml-language-server'), '--stdio'])},
+      \ 'whitelist': lsp_settings#get('yaml-language-server', 'whitelist', ['yaml']),
+      \ 'blacklist': lsp_settings#get('yaml-language-server', 'blacklist', []),
+      \ 'config': lsp_settings#get('yaml-language-server', 'config', {}),
+      \ 'workspace_config': lsp_settings#get('yaml-language-server', 'workspace_config', {}),
+      \ })
+augroup END


### PR DESCRIPTION
## Note
Installers for Windows are not included.
The yaml-language-server hardly be useless unless schema is configured at workspace_config.

Example config for Kubernetes YAML
```vim
let g:lsp_settings = {
    \ 'yaml-language-server': {
    \    'workspace_config': {
    \       'yaml': {
    \          'completion': v:true,
    \          'hover': v:true,
    \          'validate': v:true,
    \          'schemas': {
    \             'kubernetes': '/*',
    \           },
    \          'format': {
    \             'enable': v:true,
    \           }
    \        },
    \     },
    \  },
    \}
```

I think this setting is worth adding to the document or wiki in the future.