### PR TITLE
Fix solargraph installer

### DIFF
--- a/installer/install-solargraph.sh
+++ b/installer/install-solargraph.sh
@@ -7,13 +7,13 @@ cd $(dirname $0)
 mkdir ../servers/solargraph
 cd ../servers/solargraph
 git clone "https://github.com/castwide/solargraph" .
-call bundle install --path vendor/bundle
+bundle install --path vendor/bundle
 
 cat <<EOF > solargraph
 #!/bin/sh
 
 DIR=\$(cd \$(dirname \$0); pwd)
-bundle exec ruby \$DIR/bin/solargraph stdio
+cd $DIR && bundle exec ruby \$DIR/bin/solargraph stdio
 EOF
 
 chmod +x solargraph


### PR DESCRIPTION
I ran tha `:LspInstallServer` in ruby project. And I got the belaw message.

```
/home/vagrant/.vim/plugged/vim-lsp-settings/installer/install-solargraph.sh: line 10: call: command not found
```

I don't know what is `call` but I think that is not need. So delete it.
And `bundle exec` command should be probably called in where `bundle install` was called. 
So run `cd $DIR` before calling `solraraph stdio`.