### PR TITLE
Fix not enough arguments for printf

### DIFF
--- a/plugin/lsp_settings.vim
+++ b/plugin/lsp_settings.vim
@@ -97,7 +97,7 @@ function! s:vimlsp_settings_suggest() abort
   if empty(s:vimlsp_installer())
     return
   endif
-  echomsg printf('If you want to enable Language Server, please do :LspInstallServer')
+  echomsg 'If you want to enable Language Server, please do :LspInstallServer'
   command! -buffer LspInstallServer call s:vimlsp_install_server()
 endfunction
 


### PR DESCRIPTION
First of all, thanks for creating and sharing a wonderful vim plugin!

This pull requests fixes a minor error
```
Error detected while processing function <SNR>12_vimlsp_settings_suggest:
line    4:
E119: Not enough arguments for function: printf
E15: Invalid expression: printf('If you want to enable Language Server, please do :LspInst
allServer')
```
which occured when I tried to use [Fix can use old vim version by heavenshell · Pull Request #7 · mattn/vim-lsp-settings](https://github.com/mattn/vim-lsp-settings/pull/7)