### PR TITLE
use typescriptreact as filetype for .tsx files

### DIFF
--- a/settings/javascript-typescript-langserver.vim
+++ b/settings/javascript-typescript-langserver.vim
@@ -5,7 +5,7 @@ augroup vimlsp_settings_javascript_typescript_langserver
       \ 'cmd': {server_info->lsp_settings#get('javascript-typescript-langserver', 'cmd', [lsp_settings#exec_path('javascript-typescript-langserver')])},
       \ 'root_uri':{server_info->lsp_settings#get('javascript-typescript-langserver', 'root_uri', lsp_settings#root_uri(['.git/']))},
       \ 'initialization_options': lsp_settings#get('javascript-typescript-langserver', 'initialization_options', {"diagnostics": "true"}),
-      \ 'whitelist': lsp_settings#get('javascript-typescript-langserver', 'whitelist', ['javascript']),
+      \ 'whitelist': lsp_settings#get('javascript-typescript-langserver', 'whitelist', ['javascript', 'javascriptreact']),
       \ 'blacklist': lsp_settings#get('javascript-typescript-langserver', 'blacklist', []),
       \ 'config': lsp_settings#get('javascript-typescript-langserver', 'config', {}),
       \ 'workspace_config': lsp_settings#get('javascript-typescript-langserver', 'workspace_config', {}),

--- a/settings/typescript-language-server.vim
+++ b/settings/typescript-language-server.vim
@@ -5,7 +5,7 @@ augroup vimlsp_settings_typescript_language_server
       \ 'cmd': {server_info->lsp_settings#get('typescript-language-server', 'cmd', [lsp_settings#exec_path('typescript-language-server'), '--stdio'])},
       \ 'root_uri':{server_info->lsp_settings#get('typescript-language-server', 'root_uri', lsp_settings#root_uri(['.git/', 'package.json']))},
       \ 'initialization_options': lsp_settings#get('typescript-language-server', 'initialization_options', {"diagnostics": "true"}),
-      \ 'whitelist': lsp_settings#get('typescript-language-server', 'whitelist', ['typescript', 'typescript.tsx']),
+      \ 'whitelist': lsp_settings#get('typescript-language-server', 'whitelist', ['typescript', 'typescriptreact']),
       \ 'blacklist': lsp_settings#get('typescript-language-server', 'blacklist', []),
       \ 'config': lsp_settings#get('typescript-language-server', 'config', {}),
       \ 'workspace_config': lsp_settings#get('typescript-language-server', 'workspace_config', {}),


### PR DESCRIPTION
Seems like it now uses `typescriptreact` instead of `typescript.jsx`.

https://github.com/vim/vim/blob/a4ce82fe2e990eb9eaabf6ad400e2a74cce50ce6/runtime/filetype.vim#L1724

https://github.com/vim/vim/commit/92852cee3fcff1dc6ce12387b234634e73267b22