### PR TITLE
add support for downloading reason-language-server on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Currently, no way to uninstall/update server. Run this command again, newer vers
 | JSON       | json-languageserver                                         | Yes           |
 | Swift      | sourcekit-lsp                                               | No            |
 | COBOL      | cobol-language-support                                      | Yes           |
+| Reason     | reason-language-server                                      | Yes           |
 
 ## License
 

--- a/installer/install-reason-language-server.cmd
+++ b/installer/install-reason-language-server.cmd
@@ -1,0 +1,18 @@
+@echo off
+
+setlocal
+
+cd /d %~dp0
+
+set installer_dir=%cd%
+set server_dir=..\servers\reason-language-server
+if exist %server_dir% rd /Q /S "%server_dir%"
+md "%server_dir%"
+cd /d "%server_dir%"
+
+curl -L -o rls-windows.zip "https://github.com/jaredly/reason-language-server/releases/download/1.7.4/rls-windows.zip"
+call %installer_dir%\run_unzip rls-windows.zip
+del rls-windows.zip
+
+move rls-windows\reason-language-server.exe reason-language-server.exe
+rmdir rls-windows


### PR DESCRIPTION
This downloads the language server and start properly but seems like the langserver it self is bad due to https://github.com/mattn/vim-lsp-settings/pull/30/files