### PR TITLE
Switch gopls url to golang.org/x/tools/gopls

### DIFF
--- a/installer/install-gopls.cmd
+++ b/installer/install-gopls.cmd
@@ -11,5 +11,5 @@ cd /d "%server_dir%"
 
 set GOPATH=%cd%
 set GOBIN=%cd%
-go get -v -u golang.org/x/tools/cmd/gopls
+go get -v -u golang.org/x/tools/gopls
 rd /S /Q "src"

--- a/installer/install-gopls.sh
+++ b/installer/install-gopls.sh
@@ -6,5 +6,5 @@ cd $(dirname $0)
 [ -d ../servers/gopls ] && rm -rf ../servers/gopls
 mkdir ../servers/gopls
 cd ../servers/gopls
-GOPATH=$(pwd) GOBIN=$(pwd) go get -v -u golang.org/x/tools/cmd/gopls
+GOPATH=$(pwd) GOBIN=$(pwd) go get -v -u golang.org/x/tools/gopls
 rm -rf src


### PR DESCRIPTION
Let's change the gopls url in favor of the deprecation. (I'm not sure they revert or not, keep using the _legacy_ is a risk)
```sh
 $ go get -v -u golang.org/x/tools/cmd/gopls
get "golang.org/x/tools/cmd/gopls": found meta tag get.metaImport{Prefix:"golang.org/x/tools", VCS:"git", Repo
Root:"https://go.googlesource.com/tools"} at //golang.org/x/tools/cmd/gopls?go-get=1
get "golang.org/x/tools/cmd/gopls": verifying non-authoritative meta tag
golang.org/x/tools (download)
package golang.org/x/tools/cmd/gopls: cannot find package "golang.org/x/tools/cmd/gopls" in any of:
...
```