### PR TITLE
Add installer for clangd

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Currently, no way to uninstall/update server. Run this command again, newer vers
 
 | Language   | Language Server                                        | Local Install |
 |------------|--------------------------------------------------------|:-------------:|
-| C/C++      | clangd                                                 | No            |
+| C/C++      | clangd                                                 | Yes           |
 | C#         | omnisharp                                              | Yes           |
 | Clojure    | clojure-lsp                                            | Yes           |
 | TypeScript | typescript-language-server                             | Yes           |

--- a/installer/install-clangd.cmd
+++ b/installer/install-clangd.cmd
@@ -13,6 +13,11 @@ cd /d "%server_dir%"
 echo Downloading clang and LLVM...
 curl -L -o LLVM-9.0.0-win64.exe "http://releases.llvm.org/9.0.0/LLVM-9.0.0-win64.exe"
 echo Running setup...
-echo Make sure to add clangd to your PATH
-LLVM-9.0.0-win64.exe
+
+REM Run setup as regular user to avoid a UAC popup
+set __COMPAT_LAYER=RUNASINVOKER
+md tmp
+LLVM-9.0.0-win64.exe /S /D=%cd%\tmp
+copy tmp\bin\clangd.exe clangd.exe
 del LLVM-9.0.0-win64.exe
+rd /Q /S %cd%\tmp

--- a/installer/install-clangd.cmd
+++ b/installer/install-clangd.cmd
@@ -1,0 +1,18 @@
+@echo off
+
+setlocal
+
+cd /d %~dp0
+
+set installer_dir=%cd%
+set server_dir=..\servers\clangd
+if exist %server_dir% rd /Q /S "%server_dir%"
+md "%server_dir%"
+cd /d "%server_dir%"
+
+echo Downloading clang and LLVM...
+curl -L -o LLVM-9.0.0-win64.exe "http://releases.llvm.org/9.0.0/LLVM-9.0.0-win64.exe"
+echo Running setup...
+echo Make sure to add clangd to your PATH
+LLVM-9.0.0-win64.exe
+del LLVM-9.0.0-win64.exe

--- a/installer/install-clangd.cmd
+++ b/installer/install-clangd.cmd
@@ -21,3 +21,4 @@ LLVM-9.0.0-win64.exe /S /D=%cd%\tmp
 copy tmp\bin\clangd.exe clangd.exe
 del LLVM-9.0.0-win64.exe
 rd /Q /S %cd%\tmp
+.\clangd.exe --version

--- a/installer/install-clangd.sh
+++ b/installer/install-clangd.sh
@@ -33,6 +33,7 @@ url="http://releases.llvm.org/9.0.0/$filename.tar.xz"
 echo "Downloading clangd and LLVM..."
 curl -LO "$url"
 echo "Extracting archive..."
-tar xvf $filename.tar.xz --strip-components=2 $filename/bin/clangd
-rm -fr clang+llvm-9.0.0*
+tar xvf $filename.tar.xz --strip-components=1 $filename/
+rm $filename.tar.xz
+ln -sf bin/clangd
 ./clangd --version

--- a/installer/install-clangd.sh
+++ b/installer/install-clangd.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e
+
+cd $(dirname $0)
+
+server_dir="../servers/clangd"
+[ -d $server_dir ] && rm -rf $server_dir
+mkdir $server_dir && cd $server_dir
+
+os=$(uname -s | tr "[:upper:]" "[:lower:]")
+
+case $os in
+    linux)
+        platform="pc-linux-gnu"
+        ;;
+    darwin)
+        platform="darwin-apple"
+        ;;
+esac
+
+# Check Ubuntu version
+ubuntu_version=$(lsb_release -a 2>&1 | grep 'Release' | awk '{print $2}')
+
+case $ubuntu_version in
+    14.04|16.04|18.04)
+        platform="linux-gnu-ubuntu-$ubuntu_version"
+        ;;
+esac
+
+filename="clang+llvm-9.0.0-x86_64-$platform"
+url="http://releases.llvm.org/9.0.0/$filename.tar.xz"
+echo "Downloading clangd and LLVM..."
+curl -LO "$url"
+echo "Extracting archive..."
+tar xvf $filename.tar.xz --strip-components=2 $filename/bin/clangd
+rm -fr clang+llvm-9.0.0*
+./clangd --version

--- a/installer/install-clangd.sh
+++ b/installer/install-clangd.sh
@@ -33,7 +33,7 @@ url="http://releases.llvm.org/9.0.0/$filename.tar.xz"
 echo "Downloading clangd and LLVM..."
 curl -LO "$url"
 echo "Extracting archive..."
-tar xvf $filename.tar.xz --strip-components=1 $filename/
+tar xf $filename.tar.xz --strip-components=1 $filename/
 rm $filename.tar.xz
 ln -sf bin/clangd
 ./clangd --version


### PR DESCRIPTION
Initial support for clangd. It's not perfect yet, because it requires downloading a complete LLVM distribution. But as far as I can tell, LLVM doesn't distribute a binary dist of clangd only.

~~Windows support can also be improved, as at the moment it just download the LLVM installer and requires the user to manually run the setup.~~