### PR TITLE
Setup server directory in Vim script

### DIFF
--- a/installer/install-bash-language-server.cmd
+++ b/installer/install-bash-language-server.cmd
@@ -1,5 +1,3 @@
 @echo off
 
-cd /d %~dp0
-
-call npm_install bash-language-server bash-language-server
+call "%~dp0\npm_install" bash-language-server bash-language-server

--- a/installer/install-bash-language-server.cmd
+++ b/installer/install-bash-language-server.cmd
@@ -1,3 +1,3 @@
 @echo off
 
-call "%~dp0\npm_install" bash-language-server bash-language-server
+call "%~dp0\npm_install.cmd" bash-language-server bash-language-server

--- a/installer/install-bash-language-server.sh
+++ b/installer/install-bash-language-server.sh
@@ -2,6 +2,4 @@
 
 set -e
 
-cd $(dirname $0)
-
-./npm_install.sh bash-language-server bash-language-server
+"$(dirname $0)/npm_install.sh" bash-language-server bash-language-server

--- a/installer/install-clojure-lsp.cmd
+++ b/installer/install-clojure-lsp.cmd
@@ -1,12 +1,3 @@
 @echo off
 
-setlocal
-
-cd /d %~dp0
-
-set server_dir=..\servers\clojure-lsp
-if exist %server_dir% rd /Q /S "%server_dir%"
-md "%server_dir%"
-cd /d "%server_dir%"
-
 curl -L -o clojure-lsp.cmd https://github.com/snoe/clojure-lsp/releases/download/release-20191202T142318/clojure-lsp

--- a/installer/install-clojure-lsp.sh
+++ b/installer/install-clojure-lsp.sh
@@ -2,9 +2,5 @@
 
 set -e
 
-cd $(dirname $0)
-[ -d ../servers/clojure-lsp ] && rm -rf ../servers/clojure-lsp
-mkdir ../servers/clojure-lsp
-cd ../servers/clojure-lsp
 curl -L -o clojure-lsp https://github.com/snoe/clojure-lsp/releases/download/release-20191202T142318/clojure-lsp
 chmod +x clojure-lsp

--- a/installer/install-cobol-language-support.cmd
+++ b/installer/install-cobol-language-support.cmd
@@ -2,18 +2,10 @@
 
 setlocal
 
-cd /d %~dp0
-
-set installer_dir=%cd%
-set server_dir=..\servers\cobol-language-support
-if exist %server_dir% rd /Q /S "%server_dir%"
-md "%server_dir%"
-cd /d "%server_dir%"
-
 set version=0.9.1
 set url=https://github.com/eclipse/che-che4z-lsp-for-cobol/releases/download/%version%/cobol-language-support-%version%.vsix
 curl -LO "%url%"
-call %installer_dir%\run_unzip "cobol-language-support-%version%.vsix"
+call "%~dp0\run_unzip" "cobol-language-support-%version%.vsix"
 
 echo @echo off ^
 

--- a/installer/install-cobol-language-support.cmd
+++ b/installer/install-cobol-language-support.cmd
@@ -5,7 +5,7 @@ setlocal
 set version=0.9.1
 set url=https://github.com/eclipse/che-che4z-lsp-for-cobol/releases/download/%version%/cobol-language-support-%version%.vsix
 curl -LO "%url%"
-call "%~dp0\run_unzip" "cobol-language-support-%version%.vsix"
+call "%~dp0\run_unzip.cmd" "cobol-language-support-%version%.vsix"
 
 echo @echo off ^
 

--- a/installer/install-cobol-language-support.sh
+++ b/installer/install-cobol-language-support.sh
@@ -2,12 +2,6 @@
 
 set -e
 
-cd $(dirname $0)
-
-server_dir="../servers/cobol-language-support"
-[ -d "$server_dir" ] && rm -rf "$server_dir"
-mkdir "$server_dir" && cd "$server_dir"
-
 version="0.9.1"
 url="https://github.com/eclipse/che-che4z-lsp-for-cobol/releases/download/$version/cobol-language-support-$version.vsix"
 curl -LO "$url"

--- a/installer/install-css-languageserver.cmd
+++ b/installer/install-css-languageserver.cmd
@@ -1,3 +1,3 @@
 @echo off
 
-call "%~dp0\npm_install" css-languageserver vscode-css-languageserver-bin
+call "%~dp0\npm_install.cmd" css-languageserver vscode-css-languageserver-bin

--- a/installer/install-css-languageserver.cmd
+++ b/installer/install-css-languageserver.cmd
@@ -1,5 +1,3 @@
 @echo off
 
-cd /d %~dp0
-
-call npm_install css-languageserver vscode-css-languageserver-bin
+call "%~dp0\npm_install" css-languageserver vscode-css-languageserver-bin

--- a/installer/install-css-languageserver.sh
+++ b/installer/install-css-languageserver.sh
@@ -2,6 +2,4 @@
 
 set -e
 
-cd $(dirname $0)
-
-./npm_install.sh css-languageserver vscode-css-languageserver-bin
+"$(dirname $0)/npm_install.sh" css-languageserver vscode-css-languageserver-bin

--- a/installer/install-dls.cmd
+++ b/installer/install-dls.cmd
@@ -1,15 +1,5 @@
 @echo off
 
-setlocal
-
-cd /d %~dp0
-
-set installer_dir=%cd%
-set server_dir=..\servers\dls
-if exist %server_dir% rd /Q /S "%server_dir%"
-md "%server_dir%"
-cd /d "%server_dir%"
-
 curl -L -o dls-v0.26.0.windows.x86_64.zip https://github.com/d-language-server/dls/releases/download/v0.26.0/dls-v0.26.0.windows.x86_64.zip"
 call %installer_dir%\run_unzip dls-v0.26.0.windows.x86_64.zip
 del dls-v0.26.0.windows.x86_64.zip

--- a/installer/install-dls.sh
+++ b/installer/install-dls.sh
@@ -2,12 +2,6 @@
 
 set -e
 
-cd $(dirname $0)
-
-server_dir="../servers/dls"
-[ -d $server_dir ] && rm -rf $server_dir
-mkdir $server_dir && cd $server_dir
-
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
 
 case $os in

--- a/installer/install-docker-langserver.cmd
+++ b/installer/install-docker-langserver.cmd
@@ -1,4 +1,4 @@
 @echo off
 
-call "%~dp0\npm_install" docker-langserver dockerfile-language-server-nodejs
+call "%~dp0\npm_install.cmd" docker-langserver dockerfile-language-server-nodejs
 

--- a/installer/install-docker-langserver.cmd
+++ b/installer/install-docker-langserver.cmd
@@ -1,6 +1,4 @@
 @echo off
 
-cd /d %~dp0
-
-call npm_install docker-langserver dockerfile-language-server-nodejs
+call "%~dp0\npm_install" docker-langserver dockerfile-language-server-nodejs
 

--- a/installer/install-docker-langserver.sh
+++ b/installer/install-docker-langserver.sh
@@ -2,6 +2,4 @@
 
 set -e
 
-cd $(dirname $0)
-
-./npm_install.sh docker-langserver dockerfile-language-server-nodejs
+"$(dirname $0)/npm_install.sh" docker-langserver dockerfile-language-server-nodejs

--- a/installer/install-eclipse-jdt-ls.cmd
+++ b/installer/install-eclipse-jdt-ls.cmd
@@ -1,14 +1,5 @@
 @echo off
 
-setlocal
-
-cd /d %~dp0
-
-set server_dir=..\servers\eclipse-jdt-ls
-if exist %server_dir% rd /Q /S "%server_dir%"
-md "%server_dir%"
-cd /d "%server_dir%"
-
 curl -o "jdt-language-server-latest.tar.gz" "http://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz"
 curl -o "lombok.jar" "https://projectlombok.org/downloads/lombok.jar"
 tar xvf jdt-language-server-latest.tar.gz

--- a/installer/install-eclipse-jdt-ls.sh
+++ b/installer/install-eclipse-jdt-ls.sh
@@ -2,10 +2,6 @@
 
 set -e
 
-cd $(dirname $0)
-[ -d ../servers/eclipse-jdt-ls ] && rm -rf ../servers/eclipse-jdt-ls
-mkdir ../servers/eclipse-jdt-ls
-cd ../servers/eclipse-jdt-ls
 curl -o jdt-language-server-latest.tar.gz 'http://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz'
 curl -o lombok.jar 'https://projectlombok.org/downloads/lombok.jar'
 tar xvf jdt-language-server-latest.tar.gz

--- a/installer/install-elixir-ls.cmd
+++ b/installer/install-elixir-ls.cmd
@@ -1,17 +1,7 @@
 @echo off
 
-setlocal
-
-cd /d %~dp0
-
-set installer_dir=%cd%
-set server_dir=..\servers\elixir-ls
-if exist %server_dir% rd /Q /S "%server_dir%"
-md "%server_dir%"
-cd /d "%server_dir%"
-
 curl -L -o elixir-ls.zip "https://github.com/JakeBecker/elixir-ls/releases/download/v0.2.25/elixir-ls.zip"
-call %installer_dir%\run_unzip elixir-ls.zip
+call "%~dp0\run_unzip" elixir-ls.zip
 del elixir-ls.zip
 
 echo @echo off ^

--- a/installer/install-elixir-ls.cmd
+++ b/installer/install-elixir-ls.cmd
@@ -1,7 +1,7 @@
 @echo off
 
 curl -L -o elixir-ls.zip "https://github.com/JakeBecker/elixir-ls/releases/download/v0.2.25/elixir-ls.zip"
-call "%~dp0\run_unzip" elixir-ls.zip
+call "%~dp0\run_unzip.cmd" elixir-ls.zip
 del elixir-ls.zip
 
 echo @echo off ^

--- a/installer/install-elixir-ls.sh
+++ b/installer/install-elixir-ls.sh
@@ -2,12 +2,6 @@
 
 set -e
 
-cd $(dirname $0)
-
-server_dir="../servers/elixir-ls"
-[ -d $server_dir ] && rm -rf $server_dir
-mkdir $server_dir && cd $server_dir
-
 version="v0.2.25"
 url="https://github.com/JakeBecker/elixir-ls/releases/download/$version/elixir-ls.zip"
 curl -LO "$url"

--- a/installer/install-elm-language-server.cmd
+++ b/installer/install-elm-language-server.cmd
@@ -1,5 +1,3 @@
 @echo off
 
-cd /d %~dp0
-
-call npm_install elm-language-server "@elm-tooling/elm-language-server"
+call "%~dp0\npm_install" elm-language-server "@elm-tooling/elm-language-server"

--- a/installer/install-elm-language-server.cmd
+++ b/installer/install-elm-language-server.cmd
@@ -1,3 +1,3 @@
 @echo off
 
-call "%~dp0\npm_install" elm-language-server "@elm-tooling/elm-language-server"
+call "%~dp0\npm_install.cmd" elm-language-server "@elm-tooling/elm-language-server"

--- a/installer/install-elm-language-server.sh
+++ b/installer/install-elm-language-server.sh
@@ -2,6 +2,4 @@
 
 set -e
 
-cd $(dirname $0)
-
-./npm_install.sh elm-languageserver "@elm-tooling/elm-language-server"
+"$(dirname $0)/npm_install.sh" elm-languageserver "@elm-tooling/elm-language-server"

--- a/installer/install-emmylua-ls.cmd
+++ b/installer/install-emmylua-ls.cmd
@@ -1,14 +1,5 @@
 @echo off
 
-setlocal
-
-cd /d %~dp0
-
-set server_dir=..\servers\emmylua-ls
-if exist %server_dir% rd /Q /S "%server_dir%"
-md "%server_dir%"
-cd /d "%server_dir%"
-
 curl -L -o EmmyLua-LS-all.jar "https://ci.appveyor.com/api/buildjobs/54yf9rjvj49494pd/artifacts/EmmyLua-LS%%2Fbuild%%2Flibs%%2FEmmyLua-LS-all.jar"
 
 echo @echo off ^

--- a/installer/install-emmylua-ls.sh
+++ b/installer/install-emmylua-ls.sh
@@ -2,10 +2,6 @@
 
 set -e
 
-cd $(dirname $0)
-[ -d ../servers/emmylua-ls ] && rm -rf ../servers/emmylua-ls
-mkdir ../servers/emmylua-ls
-cd ../servers/emmylua-ls
 curl -L -o EmmyLua-LS-all.jar 'https://ci.appveyor.com/api/buildjobs/54yf9rjvj49494pd/artifacts/EmmyLua-LS%2Fbuild%2Flibs%2FEmmyLua-LS-all.jar'
 
 cat <<EOF > emmylua-ls

--- a/installer/install-fortls.cmd
+++ b/installer/install-fortls.cmd
@@ -1,4 +1,4 @@
 @echo off
 
-call "%~dp0\pip_install" fortls fortran-language-server
+call "%~dp0\pip_install.cmd" fortls fortran-language-server
 

--- a/installer/install-fortls.cmd
+++ b/installer/install-fortls.cmd
@@ -1,6 +1,4 @@
 @echo off
 
-cd /d %~dp0
-
-call pip_install fortls fortran-language-server
+call "%~dp0\pip_install" fortls fortran-language-server
 

--- a/installer/install-fortls.sh
+++ b/installer/install-fortls.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-cd $(dirname $0)
-
-./pip_install.sh fortls fortran-language-server
+"$(dirname $0)/pip_install.sh" fortls fortran-language-server

--- a/installer/install-gopls.cmd
+++ b/installer/install-gopls.cmd
@@ -1,14 +1,5 @@
 @echo off
 
-setlocal
-
-cd /d %~dp0
-
-set server_dir=..\servers\gopls
-if exist %server_dir% rd /Q /S "%server_dir%"
-md "%server_dir%"
-cd /d "%server_dir%"
-
 set GOPATH=%cd%
 set GOBIN=%cd%
 go get -v -u golang.org/x/tools/gopls

--- a/installer/install-gopls.sh
+++ b/installer/install-gopls.sh
@@ -2,9 +2,5 @@
 
 set -e
 
-cd $(dirname $0)
-[ -d ../servers/gopls ] && rm -rf ../servers/gopls
-mkdir ../servers/gopls
-cd ../servers/gopls
 GOPATH=$(pwd) GOBIN=$(pwd) go get -v -u golang.org/x/tools/gopls
 rm -rf src

--- a/installer/install-groovy-language-server.sh
+++ b/installer/install-groovy-language-server.sh
@@ -2,12 +2,6 @@
 
 set -e
 
-cd $(dirname $0)
-
-server_dir="../servers/groovy-language-server"
-[ -d $server_dir ] && rm -rf $server_dir
-mkdir $server_dir && cd $server_dir
-
 git clone --depth=1 https://github.com/prominic/groovy-language-server .
 ./gradlew build
 

--- a/installer/install-html-languageserver.cmd
+++ b/installer/install-html-languageserver.cmd
@@ -1,3 +1,3 @@
 @echo off
 
-call "%~dp0\npm_install" html-languageserver vscode-json-languageserver-bin
+call "%~dp0\npm_install.cmd" html-languageserver vscode-json-languageserver-bin

--- a/installer/install-html-languageserver.cmd
+++ b/installer/install-html-languageserver.cmd
@@ -1,5 +1,3 @@
 @echo off
 
-cd /d %~dp0
-
-call npm_install html-languageserver vscode-json-languageserver-bin
+call "%~dp0\npm_install" html-languageserver vscode-json-languageserver-bin

--- a/installer/install-html-languageserver.sh
+++ b/installer/install-html-languageserver.sh
@@ -2,6 +2,4 @@
 
 set -e
 
-cd $(dirname $0)
-
-./npm_install.sh html-languageserver vscode-html-languageserver-bin
+"$(dirname $0)/npm_install.sh" html-languageserver vscode-html-languageserver-bin

--- a/installer/install-intelephense.cmd
+++ b/installer/install-intelephense.cmd
@@ -1,5 +1,3 @@
 @echo off
 
-cd /d %~dp0
-
-call npm_install intelephense intelephense
+call "%~dp0\npm_install" intelephense intelephense

--- a/installer/install-intelephense.cmd
+++ b/installer/install-intelephense.cmd
@@ -1,3 +1,3 @@
 @echo off
 
-call "%~dp0\npm_install" intelephense intelephense
+call "%~dp0\npm_install.cmd" intelephense intelephense

--- a/installer/install-intelephense.sh
+++ b/installer/install-intelephense.sh
@@ -2,6 +2,4 @@
 
 set -e
 
-cd $(dirname $0)
-
-./npm_install.sh intelephense intelephense
+"$(dirname $0)/npm_install.sh" intelephense intelephense

--- a/installer/install-javascript-typescript-stdio.cmd
+++ b/installer/install-javascript-typescript-stdio.cmd
@@ -1,3 +1,3 @@
 @echo off
 
-call "%~dp0\npm_install" javascript-typescript-stdio javascript-typescript-langserver
+call "%~dp0\npm_install.cmd" javascript-typescript-stdio javascript-typescript-langserver

--- a/installer/install-javascript-typescript-stdio.cmd
+++ b/installer/install-javascript-typescript-stdio.cmd
@@ -1,5 +1,3 @@
 @echo off
 
-cd /d %~dp0
-
-call npm_install javascript-typescript-stdio javascript-typescript-langserver
+call "%~dp0\npm_install" javascript-typescript-stdio javascript-typescript-langserver

--- a/installer/install-javascript-typescript-stdio.sh
+++ b/installer/install-javascript-typescript-stdio.sh
@@ -2,6 +2,4 @@
 
 set -e
 
-cd $(dirname $0)
-
-./npm_install.sh javascript-typescript-stdio javascript-typescript-langserver
+"$(dirname $0)/npm_install.sh" javascript-typescript-stdio javascript-typescript-langserver

--- a/installer/install-json-languageserver.cmd
+++ b/installer/install-json-languageserver.cmd
@@ -1,5 +1,3 @@
 @echo off
 
-cd /d %~dp0
-
-call npm_install json-languageserver vscode-json-languageserver-bin
+call "%~dp0\npm_install" json-languageserver vscode-json-languageserver-bin

--- a/installer/install-json-languageserver.cmd
+++ b/installer/install-json-languageserver.cmd
@@ -1,3 +1,3 @@
 @echo off
 
-call "%~dp0\npm_install" json-languageserver vscode-json-languageserver-bin
+call "%~dp0\npm_install.cmd" json-languageserver vscode-json-languageserver-bin

--- a/installer/install-json-languageserver.sh
+++ b/installer/install-json-languageserver.sh
@@ -2,6 +2,4 @@
 
 set -e
 
-cd $(dirname $0)
-
-./npm_install.sh json-languageserver vscode-json-languageserver-bin
+"$(dirname $0)/npm_install.sh" json-languageserver vscode-json-languageserver-bin

--- a/installer/install-kotlin-language-server.cmd
+++ b/installer/install-kotlin-language-server.cmd
@@ -1,17 +1,7 @@
 @echo off
 
-setlocal
-
-cd /d %~dp0
-
-set installer_dir=%cd%
-set server_dir=..\servers\kotlin-language-server
-if exist %server_dir% rd /Q /S "%server_dir%"
-md "%server_dir%"
-cd /d "%server_dir%"
-
 curl -L -o server.zip "https://github.com/fwcd/kotlin-language-server/releases/download/0.5.2/server.zip"
-call %installer_dir%\run_unzip server.zip
+call "%~dp0\run_unzip" server.zip
 del server.zip
 
 echo @echo off ^

--- a/installer/install-kotlin-language-server.cmd
+++ b/installer/install-kotlin-language-server.cmd
@@ -1,7 +1,7 @@
 @echo off
 
 curl -L -o server.zip "https://github.com/fwcd/kotlin-language-server/releases/download/0.5.2/server.zip"
-call "%~dp0\run_unzip" server.zip
+call "%~dp0\run_unzip.cmd" server.zip
 del server.zip
 
 echo @echo off ^

--- a/installer/install-kotlin-language-server.sh
+++ b/installer/install-kotlin-language-server.sh
@@ -2,10 +2,6 @@
 
 set -e
 
-cd $(dirname $0)
-[ -d ../servers/kotlin-language-server ] && rm -rf ../servers/kotlin-language-server
-mkdir ../servers/kotlin-language-server
-cd ../servers/kotlin-language-server
 curl -L -o server.zip 'https://github.com/fwcd/kotlin-language-server/releases/download/0.5.2/server.zip'
 unzip server.zip
 rm server.zip

--- a/installer/install-lsp4xml.cmd
+++ b/installer/install-lsp4xml.cmd
@@ -1,14 +1,5 @@
 @echo off
 
-setlocal
-
-cd /d %~dp0
-
-set server_dir=..\servers\lsp4xml
-if exist %server_dir% rd /Q /S "%server_dir%"
-md "%server_dir%"
-cd /d "%server_dir%"
-
 curl -LO "https://dl.bintray.com/lsp4xml/releases/org/lsp4xml/org.eclipse.lsp4xml/0.9.1/org.eclipse.lsp4xml-0.9.1-uber.jar"
 
 echo @echo off ^

--- a/installer/install-lsp4xml.sh
+++ b/installer/install-lsp4xml.sh
@@ -2,12 +2,6 @@
 
 set -e
 
-cd $(dirname $0)
-
-server_dir="../servers/lsp4xml"
-[ -d $server_dir ] && rm -rf $server_dir
-mkdir $server_dir && cd $server_dir
-
 version="0.9.1"
 url=https://dl.bintray.com/lsp4xml/releases/org/lsp4xml/org.eclipse.lsp4xml/${version}/org.eclipse.lsp4xml-${version}-uber.jar
 

--- a/installer/install-metals.cmd
+++ b/installer/install-metals.cmd
@@ -2,13 +2,6 @@
 
 setlocal
 
-cd /d %~dp0
-
-set server_dir=..\servers\metals
-if exist %server_dir% rd /Q /S "%server_dir%"
-md "%server_dir%"
-cd /d "%server_dir%"
-
 curl -Lo coursier https://git.io/coursier-cli
 curl -Lo coursier.bat https://git.io/coursier-bat
 

--- a/installer/install-metals.sh
+++ b/installer/install-metals.sh
@@ -2,13 +2,6 @@
 
 set -e
 
-cd $(dirname $0)
-
-server_dir="../servers/metals"
-
-[ -d $server_dir ] && rm -rf $server_dir
-mkdir $server_dir && cd $server_dir
-
 curl -Lo ./coursier https://git.io/coursier-cli
 chmod +x ./coursier
 

--- a/installer/install-omnisharp-lsp.cmd
+++ b/installer/install-omnisharp-lsp.cmd
@@ -1,17 +1,7 @@
 @echo off
 
-setlocal
-
-cd /d %~dp0
-
-set installer_dir=%cd%
-set server_dir=..\servers\omnisharp-lsp
-if exist %server_dir% rd /Q /S "%server_dir%"
-md "%server_dir%"
-cd /d "%server_dir%"
-
 curl -L -o omnisharp-win-x64.zip "https://github.com/OmniSharp/omnisharp-roslyn/releases/download/v1.34.9/omnisharp-win-x64.zip"
-call %installer_dir%\run_unzip omnisharp-win-x64.zip
+call "%~dp0\run_unzip" omnisharp-win-x64.zip
 del omnisharp-win-x64.zip
 
 echo @echo off ^

--- a/installer/install-omnisharp-lsp.cmd
+++ b/installer/install-omnisharp-lsp.cmd
@@ -1,7 +1,7 @@
 @echo off
 
 curl -L -o omnisharp-win-x64.zip "https://github.com/OmniSharp/omnisharp-roslyn/releases/download/v1.34.9/omnisharp-win-x64.zip"
-call "%~dp0\run_unzip" omnisharp-win-x64.zip
+call "%~dp0\run_unzip.cmd" omnisharp-win-x64.zip
 del omnisharp-win-x64.zip
 
 echo @echo off ^

--- a/installer/install-omnisharp-lsp.sh
+++ b/installer/install-omnisharp-lsp.sh
@@ -2,12 +2,6 @@
 
 set -e
 
-cd $(dirname $0)
-
-server_dir="../servers/omnisharp-lsp"
-[ -d $server_dir ] && rm -rf $server_dir
-mkdir $server_dir && cd $server_dir
-
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
 
 case $os in

--- a/installer/install-pyls.cmd
+++ b/installer/install-pyls.cmd
@@ -1,5 +1,3 @@
 @echo off
 
-cd /d %~dp0
-
-call pip_install pyls python-language-server
+call "%~dp0\pip_install" pyls python-language-server

--- a/installer/install-pyls.cmd
+++ b/installer/install-pyls.cmd
@@ -1,3 +1,3 @@
 @echo off
 
-call "%~dp0\pip_install" pyls python-language-server
+call "%~dp0\pip_install.cmd" pyls python-language-server

--- a/installer/install-pyls.sh
+++ b/installer/install-pyls.sh
@@ -2,6 +2,4 @@
 
 set -e
 
-cd $(dirname $0)
-
-./pip_install.sh pyls python-language-server
+"$(dirname $0)/pip_install.sh" pyls python-language-server

--- a/installer/install-reason-language-server.cmd
+++ b/installer/install-reason-language-server.cmd
@@ -1,17 +1,7 @@
 @echo off
 
-setlocal
-
-cd /d %~dp0
-
-set installer_dir=%cd%
-set server_dir=..\servers\reason-language-server
-if exist %server_dir% rd /Q /S "%server_dir%"
-md "%server_dir%"
-cd /d "%server_dir%"
-
 curl -L -o rls-windows.zip "https://github.com/jaredly/reason-language-server/releases/download/1.7.4/rls-windows.zip"
-call %installer_dir%\run_unzip rls-windows.zip
+call "%~dp0\run_unzip" rls-windows.zip
 del rls-windows.zip
 
 move rls-windows\reason-language-server.exe reason-language-server.exe

--- a/installer/install-reason-language-server.cmd
+++ b/installer/install-reason-language-server.cmd
@@ -1,7 +1,7 @@
 @echo off
 
 curl -L -o rls-windows.zip "https://github.com/jaredly/reason-language-server/releases/download/1.7.4/rls-windows.zip"
-call "%~dp0\run_unzip" rls-windows.zip
+call "%~dp0\run_unzip.cmd" rls-windows.zip
 del rls-windows.zip
 
 move rls-windows\reason-language-server.exe reason-language-server.exe

--- a/installer/install-reason-language-server.sh
+++ b/installer/install-reason-language-server.sh
@@ -2,12 +2,6 @@
 
 set -e
 
-cd $(dirname $0)
-
-server_dir="../servers/reason-language-server"
-[ -d $server_dir ] && rm -rf $server_dir
-mkdir $server_dir && cd $server_dir
-
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
 
 case $os in

--- a/installer/install-solargraph.cmd
+++ b/installer/install-solargraph.cmd
@@ -1,14 +1,5 @@
 @echo off
 
-setlocal
-
-cd /d %~dp0
-
-set server_dir=..\servers\solargraph
-if exist %server_dir% rd /Q /S "%server_dir%"
-md "%server_dir%"
-cd /d "%server_dir%"
-
 git clone "https://github.com/castwide/solargraph" .
 
 call bundle install --path vendor/bundle

--- a/installer/install-solargraph.sh
+++ b/installer/install-solargraph.sh
@@ -2,10 +2,6 @@
 
 set -e
 
-cd $(dirname $0)
-[ -d ../servers/solargraph ] && rm -rf ../servers/solargraph
-mkdir ../servers/solargraph
-cd ../servers/solargraph
 git clone "https://github.com/castwide/solargraph" .
 bundle install --path vendor/bundle
 

--- a/installer/install-terraform-lsp.cmd
+++ b/installer/install-terraform-lsp.cmd
@@ -1,12 +1,3 @@
 @echo off
 
-setlocal
-
-cd /d %~dp0
-
-set server_dir=..\servers\terraform-lsp
-if exist %server_dir% rd /Q /S "%server_dir%"
-md "%server_dir%"
-cd /d "%server_dir%"
-
 curl -L "https://github.com/juliosueiras/terraform-lsp/releases/download/v0.0.9/terraform-lsp_0.0.9_windows_amd64.tar.gz" | tar xz

--- a/installer/install-terraform-lsp.sh
+++ b/installer/install-terraform-lsp.sh
@@ -4,11 +4,6 @@ set -e
 
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
 version="0.0.9"
-server_dir="../servers/terraform-lsp"
-
-cd $(dirname $0)
-[ -d $server_dir ] && rm -rf $server_dir
-mkdir $server_dir && cd $server_dir
 
 case $os in
 darwin | linux)

--- a/installer/install-texlab.cmd
+++ b/installer/install-texlab.cmd
@@ -1,5 +1,5 @@
 @echo off
 
 curl -L -o texlab-x86_64-windows.zip "https://github.com/latex-lsp/texlab/releases/download/v1.8.0/texlab-x86_64-windows.zip"
-call "%~dp0\run_unzip" texlab-x86_64-windows.zip
+call "%~dp0\run_unzip.cmd" texlab-x86_64-windows.zip
 del texlab-x86_64-windows.zip

--- a/installer/install-texlab.cmd
+++ b/installer/install-texlab.cmd
@@ -1,15 +1,5 @@
 @echo off
 
-setlocal
-
-cd /d %~dp0
-
-set installer_dir=%cd%
-set server_dir=..\servers\texlab
-if exist %server_dir% rd /Q /S "%server_dir%"
-md "%server_dir%"
-cd /d "%server_dir%"
-
 curl -L -o texlab-x86_64-windows.zip "https://github.com/latex-lsp/texlab/releases/download/v1.8.0/texlab-x86_64-windows.zip"
-call %installer_dir%\run_unzip texlab-x86_64-windows.zip
+call "%~dp0\run_unzip" texlab-x86_64-windows.zip
 del texlab-x86_64-windows.zip

--- a/installer/install-texlab.sh
+++ b/installer/install-texlab.sh
@@ -2,12 +2,6 @@
 
 set -e
 
-cd $(dirname $0)
-
-server_dir="../servers/texlab"
-[ -d $server_dir ] && rm -rf $server_dir
-mkdir $server_dir && cd $server_dir
-
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
 
 case $os in

--- a/installer/install-typescript-language-server.cmd
+++ b/installer/install-typescript-language-server.cmd
@@ -1,4 +1,4 @@
 @echo off
 
-call "%~dp0\npm_install" tsserver typescript
-call "%~dp0\npm_install" typescript-language-server typescript-language-server
+call "%~dp0\npm_install.cmd" tsserver typescript
+call "%~dp0\npm_install.cmd" typescript-language-server typescript-language-server

--- a/installer/install-typescript-language-server.cmd
+++ b/installer/install-typescript-language-server.cmd
@@ -1,6 +1,4 @@
 @echo off
 
-cd /d %~dp0
-
-call npm_install tsserver typescript
-call npm_install typescript-language-server typescript-language-server
+call "%~dp0\npm_install" tsserver typescript
+call "%~dp0\npm_install" typescript-language-server typescript-language-server

--- a/installer/install-typescript-language-server.sh
+++ b/installer/install-typescript-language-server.sh
@@ -2,7 +2,5 @@
 
 set -e
 
-cd $(dirname $0)
-
-./npm_install.sh tsserver typescript
-./npm_install.sh typescript-language-server typescript-language-server
+"$(dirname $0)/npm_install.sh" tsserver typescript
+"$(dirname $0)/npm_install.sh" typescript-language-server typescript-language-server

--- a/installer/install-vim-language-server.cmd
+++ b/installer/install-vim-language-server.cmd
@@ -1,5 +1,3 @@
 @echo off
 
-cd /d %~dp0
-
-call npm_install vim-language-server vim-language-server
+call "%~dp0\npm_install" vim-language-server vim-language-server

--- a/installer/install-vim-language-server.cmd
+++ b/installer/install-vim-language-server.cmd
@@ -1,3 +1,3 @@
 @echo off
 
-call "%~dp0\npm_install" vim-language-server vim-language-server
+call "%~dp0\npm_install.cmd" vim-language-server vim-language-server

--- a/installer/install-vim-language-server.sh
+++ b/installer/install-vim-language-server.sh
@@ -2,6 +2,4 @@
 
 set -e
 
-cd $(dirname $0)
-
-./npm_install.sh vim-language-server vim-language-server
+"$(dirname $0)/npm_install.sh" vim-language-server vim-language-server

--- a/installer/install-yaml-language-server.cmd
+++ b/installer/install-yaml-language-server.cmd
@@ -1,5 +1,3 @@
 @echo off
 
-cd /d %~dp0
-
-call npm_install yaml-language-server yaml-language-server
+call "%~dp0\npm_install" yaml-language-server yaml-language-server

--- a/installer/install-yaml-language-server.cmd
+++ b/installer/install-yaml-language-server.cmd
@@ -1,3 +1,3 @@
 @echo off
 
-call "%~dp0\npm_install" yaml-language-server yaml-language-server
+call "%~dp0\npm_install.cmd" yaml-language-server yaml-language-server

--- a/installer/install-yaml-language-server.sh
+++ b/installer/install-yaml-language-server.sh
@@ -2,6 +2,4 @@
 
 set -e
 
-cd $(dirname $0)
-
-./npm_install.sh yaml-language-server yaml-language-server
+"$(dirname $0)/npm_install.sh" yaml-language-server yaml-language-server

--- a/installer/npm_install.cmd
+++ b/installer/npm_install.cmd
@@ -3,12 +3,6 @@
 if "x%1" equ "x" goto :EOF
 if "x%2" equ "x" goto :EOF
 
-set server_dir=..\servers\%1
-if exist "%server_dir%" rd /Q /S "%server_dir%"
-md "%server_dir%"
-pushd .
-cd /d "%server_dir%"
-
 call npm init -y
 
 echo {"name":""}>package.json
@@ -20,4 +14,3 @@ echo @echo off ^
 call %%~dp0\node_modules\.bin\%1.cmd %%* ^
 
 > %1.cmd
-popd

--- a/installer/npm_install.sh
+++ b/installer/npm_install.sh
@@ -5,11 +5,6 @@
 
 set -e
 
-server_dir="../servers/$1"
-[ -d "$server_dir" ] && rm -rf "$server_dir"
-mkdir "$server_dir"
-cd "$server_dir"
-
 npm init -y
 
 # Avoid the problem of not being able to install the same package as name in package.json.

--- a/installer/pip_install.cmd
+++ b/installer/pip_install.cmd
@@ -3,11 +3,6 @@
 if "x%1" equ "x" goto :EOF
 if "x%2" equ "x" goto :EOF
 
-set server_dir=..\servers\%1
-if exist "%server_dir%" rd /Q /S "%server_dir%"
-md "%server_dir%"
-cd /d "%server_dir%"
-
 REM python(ver 3.x) or python3 check
 where python  2>NUL && goto :python
 :python_fail

--- a/installer/pip_install.sh
+++ b/installer/pip_install.sh
@@ -5,10 +5,6 @@
 
 set -e
 
-server_dir="../servers/$1"
-[ -d "$server_dir" ] && rm -rf "$server_dir"
-mkdir "$server_dir" && cd "$server_dir"
-
 python3 -m venv ./venv
 ./venv/bin/pip3 install "$2"
 ln -s "./venv/bin/$1" .

--- a/plugin/lsp_settings.vim
+++ b/plugin/lsp_settings.vim
@@ -97,8 +97,13 @@ endfunction
 
 function! s:vimlsp_install_server() abort
   let l:entry = s:vimlsp_installer()
-  exe 'terminal' l:entry[1]
-  let l:job = term_getjob(bufnr('%'))
+  let l:server_install_dir = s:servers_dir . '/' . l:entry[0]
+  if isdirectory(l:server_install_dir)
+    call delete(l:server_install_dir, 'rf')
+  endif
+  call mkdir(l:server_install_dir, 'p')
+  let l:bufnr = term_start(l:entry[1], {'cwd': l:server_install_dir})
+  let l:job = term_getjob(l:bufnr)
   if l:job != v:null
     call job_setoptions(l:job, {'exit_cb': function('s:vimlsp_install_server_post', [l:entry[0]])})
   endif


### PR DESCRIPTION
All installer script do same things:  Remove the previous server and create a new directory.

This has 2 problems:
1. Reduced maintainability.
2. Changing install directory is too hard.

By this PR, all installer scripts assume invoked at the installing path.

I'll send an other PR to be configurable the installing server path if this PR is accepted.