### PR TITLE
Add g:lsp_settings_servers_dir option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ You need to install both [vim-lsp](https://github.com/prabirshrestha/vim-lsp) an
 
 ### Notice
 
-If you use plugin manager that is merging  plugins (ex. dein), Please setting stop merging work(ex. dein / merged = 0).
+If you use plugin manager that is merging  plugins (ex. dein), Please setting stop merging work(ex. dein / merged = 0) or set `g:lsp_settings_servers_dir` option to a different directory from the vim-lsp's default.
 
 _reason_:
 
-Servers are installed in ./servers directory at the caching area.
-But when rebuild the cache, any merging plugin manager erases old cached files(include ./servers and server execute files) before install.
+Servers are installed in `./servers` directory at the caching area in default.
+But when rebuild the cache, any merging plugin manager erases old cached files(include `./servers` and server execute files) before install.
+You can change the directory to install servers by set `g:lsp_settings_servers_dir` option in full path.
 
 ## Usage
 

--- a/autoload/lsp_settings.vim
+++ b/autoload/lsp_settings.vim
@@ -50,7 +50,8 @@ function! lsp_settings#exec_path(cmd) abort
   if type(l:paths) == type([])
     let l:paths = join(l:paths, ',') . ','
   endif
-  let l:paths .= s:servers_dir . '/' . a:cmd
+  let l:servers_dir = get(g:, 'lsp_settings_servers_dir', s:servers_dir)
+  let l:paths .= l:servers_dir . '/' . a:cmd
   if !has('win32')
     return s:first_one(globpath(l:paths, a:cmd))
   endif

--- a/plugin/lsp_settings.vim
+++ b/plugin/lsp_settings.vim
@@ -16,7 +16,8 @@ function! s:executable(cmd) abort
   if type(l:paths) == type([])
     let l:paths = join(l:paths, ',')
   endif
-  let l:paths .= ',' . s:servers_dir . '/' . a:cmd
+  let l:servers_dir = get(g:, 'lsp_settings_servers_dir', s:servers_dir)
+  let l:paths .= ',' . l:servers_dir . '/' . a:cmd
   if !has('win32')
     return !empty(globpath(l:paths, a:cmd))
   endif
@@ -97,7 +98,8 @@ endfunction
 
 function! s:vimlsp_install_server() abort
   let l:entry = s:vimlsp_installer()
-  let l:server_install_dir = s:servers_dir . '/' . l:entry[0]
+  let l:servers_dir = get(g:, 'lsp_settings_servers_dir', s:servers_dir)
+  let l:server_install_dir = l:servers_dir . '/' . l:entry[0]
   if isdirectory(l:server_install_dir)
     call delete(l:server_install_dir, 'rf')
   endif


### PR DESCRIPTION
This option allows you to change the server installation location.

The default value is the same as the existing value.
However, we may reconsider the default value to reduce traps for dein.vim users.
What do you think?