### PR TITLE
update reason-language-server to v1.7.5

### DIFF
--- a/installer/install-reason-language-server.cmd
+++ b/installer/install-reason-language-server.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-curl -L -o rls-windows.zip "https://github.com/jaredly/reason-language-server/releases/download/1.7.4/rls-windows.zip"
+curl -L -o rls-windows.zip "https://github.com/jaredly/reason-language-server/releases/download/1.7.5/rls-windows.zip"
 call "%~dp0\run_unzip.cmd" rls-windows.zip
 del rls-windows.zip
 

--- a/installer/install-reason-language-server.sh
+++ b/installer/install-reason-language-server.sh
@@ -15,7 +15,7 @@ darwin)
   ;;
 esac
 
-version="1.7.4"
+version="1.7.5"
 url="https://github.com/jaredly/reason-language-server/releases/download/$version/rls-$os.zip"
 curl -LO "$url"
 unzip "rls-$os.zip"


### PR DESCRIPTION
this now at least starts the langserver but still seems like there is issue in the lang server.

working on it at https://github.com/prabirshrestha/vim-lsp/issues/598