### PR TITLE
Fix exists(':Excmd') check

### DIFF
--- a/plugin/lsp_settings.vim
+++ b/plugin/lsp_settings.vim
@@ -115,7 +115,7 @@ function! s:vimlsp_settings_suggest() abort
   if empty(s:vimlsp_installer())
     return
   endif
-  if !exists(':LspInstallServer')
+  if exists(':LspInstallServer') !=# 2
     redraw
     echohl Directory
     echomsg 'If you want to enable Language Server, please do :LspInstallServer'
@@ -186,12 +186,12 @@ function! s:vimlsp_load_or_suggest(ft) abort
     call s:vimlsp_settings_suggest()
   else
     doautocmd User lsp_setup
-    if !exists(':LspInstallServer')
+    if exists(':LspInstallServer') !=# 2
       command! -buffer LspInstallServer call s:vimlsp_install_server()
     endif
   endif
 
-  if !exists(':LspRegisterServer')
+  if exists(':LspRegisterServer') !=# 2
     delcommand LspRegisterServer
   endif
 endfunction


### PR DESCRIPTION
From :h exists()

```
			:cmdname	Ex command: built-in command, user
					command or command modifier |:command|.
					Returns:
					1  for match with start of a command
					2  full match with a command
					3  matches several user commands
					To check for a supported command
					always check the return value to be 2.
```