### PR TITLE
fix: not found tsserver for typescript-language-server

### DIFF
--- a/autoload/lsp_settings.vim
+++ b/autoload/lsp_settings.vim
@@ -24,7 +24,7 @@ function! s:first_one(cmd) abort
 endfunction
 
 function! lsp_settings#exec_path(cmd) abort
-  let l:s= split(a:cmd, '/')
+  let l:s = split(a:cmd, ':')
   let l:dir = len(l:s) >= 1 ? l:s[0] : ''
   let l:cmd = len(l:s) >= 2 ? l:s[1] : l:s[0]
 

--- a/autoload/lsp_settings.vim
+++ b/autoload/lsp_settings.vim
@@ -24,23 +24,27 @@ function! s:first_one(cmd) abort
 endfunction
 
 function! lsp_settings#exec_path(cmd) abort
+  let l:s= split(a:cmd, '/')
+  let l:dir = len(l:s) >= 1 ? l:s[0] : ''
+  let l:cmd = len(l:s) >= 2 ? l:s[1] : l:s[0]
+
   let l:paths = split($PATH, has('win32') ? ';' : ':')
   let l:paths = join(l:paths, ',')
-  let l:path = globpath(l:paths, a:cmd)
+  let l:path = globpath(l:paths, l:cmd)
   if !has('win32')
     if !empty(l:path)
       return s:first_one(l:path)
     endif
   else
-    let l:path = globpath(l:paths, a:cmd . '.exe')
+    let l:path = globpath(l:paths, l:cmd . '.exe')
     if !empty(l:path)
       return s:first_one(l:path)
     endif
-    let l:path = globpath(l:paths, a:cmd . '.cmd')
+    let l:path = globpath(l:paths, l:cmd . '.cmd')
     if !empty(l:path)
       return s:first_one(l:path)
     endif
-    let l:path = globpath(l:paths, a:cmd . '.bat')
+    let l:path = globpath(l:paths, l:cmd . '.bat')
     if !empty(l:path)
       return s:first_one(l:path)
     endif
@@ -51,19 +55,19 @@ function! lsp_settings#exec_path(cmd) abort
     let l:paths = join(l:paths, ',') . ','
   endif
   let l:servers_dir = get(g:, 'lsp_settings_servers_dir', s:servers_dir)
-  let l:paths .= l:servers_dir . '/' . a:cmd
+  let l:paths .= l:servers_dir . '/' . l:dir
   if !has('win32')
-    return s:first_one(globpath(l:paths, a:cmd))
+    return s:first_one(globpath(l:paths, l:cmd))
   endif
-  let l:path = globpath(l:paths, a:cmd . '.exe')
+  let l:path = globpath(l:paths, l:cmd . '.exe')
   if !empty(l:path)
     return s:first_one(l:path)
   endif
-  let l:path = globpath(l:paths, a:cmd . '.cmd')
+  let l:path = globpath(l:paths, l:cmd . '.cmd')
   if !empty(l:path)
     return s:first_one(l:path)
   endif
-  let l:path = globpath(l:paths, a:cmd . '.bat')
+  let l:path = globpath(l:paths, l:cmd . '.bat')
   if !empty(l:path)
     return s:first_one(l:path)
   endif

--- a/installer/npm_install.cmd
+++ b/installer/npm_install.cmd
@@ -3,9 +3,13 @@
 if "x%1" equ "x" goto :EOF
 if "x%2" equ "x" goto :EOF
 
-call npm init -y
+if not exist package.json (
 
-echo {"name":""}>package.json
+	call npm init -y
+
+	echo {"name":""}>package.json
+)
+
 
 call npm install "%2"
 

--- a/installer/npm_install.cmd
+++ b/installer/npm_install.cmd
@@ -4,7 +4,6 @@ if "x%1" equ "x" goto :EOF
 if "x%2" equ "x" goto :EOF
 
 if not exist package.json (
-
 	call npm init -y
 
 	echo {"name":""}>package.json

--- a/settings/typescript-language-server.vim
+++ b/settings/typescript-language-server.vim
@@ -2,7 +2,7 @@ augroup vimlsp_settings_typescript_language_server
   au!
   LspRegisterServer {
       \ 'name': 'typescript-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('typescript-language-server', 'cmd', [lsp_settings#exec_path('typescript-language-server'), '--stdio', '--tsserver-path', lsp_settings#exec_path('tsserver')])},
+      \ 'cmd': {server_info->lsp_settings#get('typescript-language-server', 'cmd', [lsp_settings#exec_path('typescript-language-server'), '--stdio', '--tsserver-path', lsp_settings#exec_path('typescript-language-server/tsserver')])},
       \ 'root_uri':{server_info->lsp_settings#get('typescript-language-server', 'root_uri', lsp_settings#root_uri(['.git/', 'package.json']))},
       \ 'initialization_options': lsp_settings#get('typescript-language-server', 'initialization_options', {"diagnostics": "true"}),
       \ 'whitelist': lsp_settings#get('typescript-language-server', 'whitelist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact']),

--- a/settings/typescript-language-server.vim
+++ b/settings/typescript-language-server.vim
@@ -2,7 +2,7 @@ augroup vimlsp_settings_typescript_language_server
   au!
   LspRegisterServer {
       \ 'name': 'typescript-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('typescript-language-server', 'cmd', [lsp_settings#exec_path('typescript-language-server'), '--stdio', '--tsserver-path', lsp_settings#exec_path('typescript-language-server/tsserver')])},
+      \ 'cmd': {server_info->lsp_settings#get('typescript-language-server', 'cmd', [lsp_settings#exec_path('typescript-language-server'), '--stdio', '--tsserver-path', lsp_settings#exec_path('typescript-language-server:tsserver')])},
       \ 'root_uri':{server_info->lsp_settings#get('typescript-language-server', 'root_uri', lsp_settings#root_uri(['.git/', 'package.json']))},
       \ 'initialization_options': lsp_settings#get('typescript-language-server', 'initialization_options', {"diagnostics": "true"}),
       \ 'whitelist': lsp_settings#get('typescript-language-server', 'whitelist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact']),


### PR DESCRIPTION
PR(#59) additional fixes
- Support windows
- extension `lsp_settings#exec_path` for fixes not found tsserver
  - a:cmd support string `'dir/cmd'`