### PR TITLE
Add clojure-lsp root-uri settings(for leiningen, shadow-cljs, deps.edn)

### DIFF
--- a/settings/clojure-lsp.vim
+++ b/settings/clojure-lsp.vim
@@ -3,7 +3,8 @@ augroup vimlsp_settings_clojure_lsp
   LspRegisterServer {
       \ 'name': 'clojure-lsp',
       \ 'cmd': {server_info->lsp_settings#get('clojure-lsp', 'cmd', [lsp_settings#exec_path('clojure-lsp')])},
-      \ 'root_uri':{server_info->lsp_settings#get('clojure-lsp', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('clojure-lsp', 'root_uri', lsp_settings#root_uri([
+      \     '.lein/', '.shadow-cljs/', '.git/', 'project.clj', 'deps.edn', 'shadow-cljs.edn']))},
       \ 'initialization_options': lsp_settings#get('clojure-lsp', 'initialization_options', v:null),
       \ 'whitelist': lsp_settings#get('clojure-lsp', 'whitelist', ['clojure']),
       \ 'blacklist': lsp_settings#get('clojure-lsp', 'blacklist', []),


### PR DESCRIPTION
In some projects, are not always exist `.git/`.
And Clojure/script projects commonly put package-manager config file(leiningen/shadow-cljs/deps.edn) on root path.
So, I added them to `settings/clojure-lsp.vim`.