### PR TITLE
fix globpath so it removes trailing slash if it exists on windows

### DIFF
--- a/autoload/lsp_settings.vim
+++ b/autoload/lsp_settings.vim
@@ -28,8 +28,19 @@ function! lsp_settings#exec_path(cmd) abort
   let l:dir = len(l:s) >= 1 ? l:s[0] : ''
   let l:cmd = len(l:s) >= 2 ? l:s[1] : l:s[0]
 
-  let l:paths = split($PATH, has('win32') ? ';' : ':')
-  let l:paths = join(l:paths, ',')
+  let l:paths = []
+  if has('win32')
+    for l:path in split($PATH, ';')
+      if l:path[len(l:path) - 1:] == "\\"
+        call add(l:paths, l:path[:len(l:path)-2])
+      elseif !empty(l:path)
+        call add(l:paths, l:path)
+      endif
+    endfor
+  else
+    let l:path = split($PATH, ':')
+  endif
+  let l:paths = join(l:paths, ",")
   let l:path = globpath(l:paths, l:cmd)
   if !has('win32')
     if !empty(l:path)


### PR DESCRIPTION
rls for rust in windows wasn't starting for me even though it was in the path.

From `:h globpath()`

```
		Note that on MS-Windows a directory may have a
		trailing backslash, remove it if you put a comma after it.
		If the expansion fails for one of the directories, there is no
		error message.
```

While debugging I also noticed that sometimes there are empty path so I also have a check for it. Empty path doesn't seems to cause issues so I can change it to just `else` if needed. Seems like sometime some people manually add `;` in the path.

I explicitly only added this check for windows since the note only mentions windows. 