### PR TITLE
fix: package path

### DIFF
--- a/installer/install-omnisharp-lsp.sh
+++ b/installer/install-omnisharp-lsp.sh
@@ -3,11 +3,13 @@
 set -e
 
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
+arch="-x64"
 
 case $os in
 linux) ;;
 darwin)
   os="osx"
+  arch=""
   ;;
 *)
   printf "%s doesn't supported by bash installer" "$os"
@@ -16,10 +18,10 @@ darwin)
 esac
 
 version="v1.34.9"
-url="https://github.com/OmniSharp/omnisharp-roslyn/releases/download/$version/omnisharp-$os-x64.tar.gz"
+url="https://github.com/OmniSharp/omnisharp-roslyn/releases/download/$version/omnisharp-$os$arch.tar.gz"
 curl -LO "$url"
-tar xzvf omnisharp-$os-x64.tar.gz
-rm omnisharp-$os-x64.tar.gz
+tar xzvf omnisharp-$os$arch.tar.gz
+rm omnisharp-$os$arch.tar.gz
 
 chmod +x run
 


### PR DESCRIPTION
https://github.com/OmniSharp/omnisharp-roslyn/releases

OmniSharp package path for OSX is incorrect.
It does not need `-x64`.

Thanks.
