### PR TITLE
enable autoimport of go modules

### DIFF
--- a/settings/gopls.vim
+++ b/settings/gopls.vim
@@ -4,7 +4,7 @@ augroup vimlsp_settings_gopls
       \ 'name': 'gopls',
       \ 'cmd': {server_info->lsp_settings#get('gopls', 'cmd', [lsp_settings#exec_path('gopls')])},
       \ 'root_uri':{server_info->lsp_settings#get('gopls', 'root_uri', lsp_settings#root_uri(['.git/', 'go.mod']))},
-      \ 'initialization_options': lsp_settings#get('gopls', 'initialization_options', {"diagnostics": "true"}),
+      \ 'initialization_options': lsp_settings#get('gopls', 'initialization_options', {"diagnostics": v:true, 'completeUnimported': v:true}),
       \ 'whitelist': lsp_settings#get('gopls', 'whitelist', ['go']),
       \ 'blacklist': lsp_settings#get('gopls', 'blacklist', []),
       \ 'config': lsp_settings#get('gopls', 'config', {}),


### PR DESCRIPTION
This enables autocomplete to show unimported modules and by complete/resolve it will auto import the module.

Seems like it is a bit slow sometimes to resolve. For example I had to type `http.Client(` to resolve `net/http` while for `fmt` and `encoding` as soon as I added `.` it autoimported.

![autoimport](https://user-images.githubusercontent.com/287744/71797489-37f41680-3003-11ea-88a2-042f68db9593.gif)

I don't code much in go so won't be able to decide if this is better than existing tools so feel free to close this PR if the experience is bad or merge if this is better.