### PR TITLE
[Fix] clangd installer does not respect g:lsp_settings_servers_dir

### DIFF
--- a/installer/install-clangd.cmd
+++ b/installer/install-clangd.cmd
@@ -2,14 +2,6 @@
 
 setlocal
 
-cd /d %~dp0
-
-set installer_dir=%cd%
-set server_dir=..\servers\clangd
-if exist %server_dir% rd /Q /S "%server_dir%"
-md "%server_dir%"
-cd /d "%server_dir%"
-
 echo Downloading clang and LLVM...
 curl -L -o LLVM-9.0.0-win64.exe "http://releases.llvm.org/9.0.0/LLVM-9.0.0-win64.exe"
 echo Running setup...

--- a/installer/install-clangd.sh
+++ b/installer/install-clangd.sh
@@ -2,12 +2,6 @@
 
 set -e
 
-cd $(dirname $0)
-
-server_dir="../servers/clangd"
-[ -d $server_dir ] && rm -rf $server_dir
-mkdir $server_dir && cd $server_dir
-
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
 
 case $os in


### PR DESCRIPTION
Fix #77 
Fix #78 


I confirmed that `clangd` (and misc. files) are installed under the directory.
Sorry, I didn't confirm on Windows.