### PR TITLE
Don't output errors (skip load) on older vim

### DIFF
--- a/plugin/lsp_settings.vim
+++ b/plugin/lsp_settings.vim
@@ -1,4 +1,4 @@
-if exists('g:loaded_lsp_settings')
+if exists('g:loaded_lsp_settings') || !exists('*json_encode') || !has('lambda')
   finish
 endif
 let g:loaded_lsp_settings= 1


### PR DESCRIPTION
vim-lsp requires json_encode and so do we. Skip loading if it's not
available.

I did [a similar PR for vim-lsp](https://github.com/prabirshrestha/vim-lsp/pull/271). It looks like timers is not used for vim-lsp-settings so I omitted it.


Tested on:
VIM - Vi IMproved 7.4 (2013 Aug 10, compiled Nov 24 2016 16:43:18)
Included patches: 1-52
Extra patches: 8.0.0056
Modified by pkg-vim-maintainers@lists.alioth.debian.org