### PR TITLE
fix: prevent broken go get

### DIFF
--- a/installer/install-gopls.sh
+++ b/installer/install-gopls.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-GOPATH=$(pwd) GOBIN=$(pwd) go get -v -u golang.org/x/tools/gopls
+GOPATH=$(pwd) GOBIN=$(pwd) go get -v golang.org/x/tools/gopls
 rm -rf src


### PR DESCRIPTION
```bash
$ go get -u golang.org/x/tools/gopls
go: finding golang.org/x/tools latest
go: finding golang.org/x/sync latest
go: finding golang.org/x/xerrors latest
# golang.org/x/tools/gopls/internal/hooks
../../go/pkg/mod/golang.org/x/tools/gopls@v0.2.2/internal/hooks/analysis.go:17:30: first argument to append must be slice; have map[string]*analysis.Analyzer
../../go/pkg/mod/golang.org/x/tools/gopls@v0.2.2/internal/hooks/analysis.go:20:30: first argument to append must be slice; have map[string]*analysis.Analyzer
../../go/pkg/mod/golang.org/x/tools/gopls@v0.2.2/internal/hooks/analysis.go:23:30: first argument to append must be slice; have map[string]*analysis.Analyzer
```