### PR TITLE
Bump metals version: 0.7.6 -> 0.8.0

### DIFF
--- a/installer/install-metals.cmd
+++ b/installer/install-metals.cmd
@@ -5,5 +5,5 @@ setlocal
 curl -Lo coursier https://git.io/coursier-cli
 curl -Lo coursier.bat https://git.io/coursier-bat
 
-set version="0.7.6"
+set version="0.8.0"
 java %JAVA_OPTS% -jar coursier bootstrap --ttl Inf "org.scalameta:metals_2.12:%version%" -r "bintray:scalacenter/releases" -r "sonatype:public" -r "sonatype:snapshots" -o metals

--- a/installer/install-metals.sh
+++ b/installer/install-metals.sh
@@ -5,5 +5,5 @@ set -e
 curl -Lo ./coursier https://git.io/coursier-cli
 chmod +x ./coursier
 
-version="0.7.6"
+version="0.8.0"
 java -jar ./coursier bootstrap --ttl Inf "org.scalameta:metals_2.12:$version" -r "bintray:scalacenter/releases" -r "sonatype:public" -r "sonatype:snapshots" -o ./metals


### PR DESCRIPTION
https://scalameta.org/metals/blog/2020/01/10/cobalt.html