### PR TITLE
Add Linux Mint support to clangd installer

### DIFF
--- a/installer/install-clangd.sh
+++ b/installer/install-clangd.sh
@@ -13,12 +13,28 @@ case $os in
         ;;
 esac
 
-# Check Ubuntu version
-ubuntu_version=$(lsb_release -a 2>&1 | grep 'Release' | awk '{print $2}')
-
-case $ubuntu_version in
-    14.04|16.04|18.04)
-        platform="linux-gnu-ubuntu-$ubuntu_version"
+distributor_id=$(lsb_release -a 2>&1 | grep 'Distributor ID' | awk '{print $3}')
+case $distributor_id in
+    # Check Ubuntu version
+    Ubuntu)
+        ubuntu_version=$(lsb_release -a 2>&1 | grep 'Release' | awk '{print $2}')
+        case $ubuntu_version in
+            14.04|16.04|18.04)
+                platform="linux-gnu-ubuntu-$ubuntu_version"
+                ;;
+        esac
+        ;;
+    # Check LinuxMint version
+    LinuxMint)
+        linuxmint_version=$(lsb_release -a 2>&1 | grep 'Release' | awk '{print $2}')
+        case $linuxmint_version in
+            19|19.1|19.2|19.3)
+                platform="linux-gnu-ubuntu-18.04"
+                ;;
+            18|18.1|18.2|18.3)
+                platform="linux-gnu-ubuntu-16.04"
+                ;;
+        esac
         ;;
 esac
 


### PR DESCRIPTION
Linux Mint is a Linux distribution based on Ubuntu LTS.
The clangd installer support only ubuntu in Linux, this pull request makes it support LinuxMint too. 