### PR TITLE
Support .svn root markers

### DIFF
--- a/plugin/lsp_settings.vim
+++ b/plugin/lsp_settings.vim
@@ -3,6 +3,13 @@ if exists('g:loaded_lsp_settings') || !exists('*json_encode') || !has('lambda')
 endif
 let g:loaded_lsp_settings= 1
 
+let g:lsp_settings_root_markers = get(g:, 'lsp_settings_root_markers', [
+      \ '.git/',
+      \ '.svn/',
+      \ '.hg/',
+      \ '.bzr/'
+      \ ])
+
 let s:settings_dir = expand('<sfile>:h:h').'/settings'
 let s:checkers_dir = expand('<sfile>:h:h').'/checkers'
 let s:installer_dir = expand('<sfile>:h:h').'/installer'

--- a/settings/analysis-server-dart-snapshot.vim
+++ b/settings/analysis-server-dart-snapshot.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_analysis_server_dart_snapshot
   LspRegisterServer {
       \ 'name': 'analysis-server-dart-snapshot',
       \ 'cmd': {server_info->lsp_settings#get('analysis-server-dart-snapshot', 'cmd', [lsp_settings#exec_path('analysis-server-dart-snapshot')])},
-      \ 'root_uri':{server_info->lsp_settings#get('analysis-server-dart-snapshot', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('analysis-server-dart-snapshot', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('analysis-server-dart-snapshot', 'initialization_options', v:null),
       \ 'whitelist': lsp_settings#get('analysis-server-dart-snapshot', 'whitelist', ['dart']),
       \ 'blacklist': lsp_settings#get('analysis-server-dart-snapshot', 'blacklist', []),

--- a/settings/bash-language-server.vim
+++ b/settings/bash-language-server.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_bash_language_server
   LspRegisterServer {
       \ 'name': 'bash-language-server',
       \ 'cmd': {server_info->lsp_settings#get('bash-language-server', 'cmd', [lsp_settings#exec_path('bash-language-server'), 'start'])},
-      \ 'root_uri':{server_info->lsp_settings#get('bash-language-server', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('bash-language-server', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('bash-language-server', 'initialization_options', v:null),
       \ 'whitelist': lsp_settings#get('bash-language-server', 'whitelist', ['sh']),
       \ 'blacklist': lsp_settings#get('bash-language-server', 'blacklist', []),

--- a/settings/cl-lsp.vim
+++ b/settings/cl-lsp.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_cl_lsp
   LspRegisterServer {
       \ 'name': 'cl-lsp',
       \ 'cmd': {server_info->lsp_settings#get('cl-lsp', 'cmd', {key, name-> ['ros', '-Q', '--', trim(filter(systemlist("ros version"), 'v:val=~"^homedir"')[0][8:], '"''') . '/bin/cl-lsp', 'stdio']})},
-      \ 'root_uri':{server_info->lsp_settings#get('cl-lsp', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('cl-lsp', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('cl-lsp', 'initialization_options', {}),
       \ 'whitelist': lsp_settings#get('cl-lsp', 'whitelist', ['lisp']),
       \ 'blacklist': lsp_settings#get('cl-lsp', 'blacklist', []),

--- a/settings/clangd.vim
+++ b/settings/clangd.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_clangd
   LspRegisterServer {
       \ 'name': 'clangd',
       \ 'cmd': {server_info->lsp_settings#get('clangd', 'cmd', [lsp_settings#exec_path('clangd')])},
-      \ 'root_uri':{server_info->lsp_settings#get('clangd', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('clangd', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('clangd', 'initialization_options', v:null),
       \ 'whitelist': lsp_settings#get('clangd', 'whitelist', ['c', 'cpp', 'objc', 'objcpp']),
       \ 'blacklist': lsp_settings#get('clangd', 'blacklist', []),

--- a/settings/clojure-lsp.vim
+++ b/settings/clojure-lsp.vim
@@ -3,8 +3,8 @@ augroup vimlsp_settings_clojure_lsp
   LspRegisterServer {
       \ 'name': 'clojure-lsp',
       \ 'cmd': {server_info->lsp_settings#get('clojure-lsp', 'cmd', [lsp_settings#exec_path('clojure-lsp')])},
-      \ 'root_uri':{server_info->lsp_settings#get('clojure-lsp', 'root_uri', lsp_settings#root_uri([
-      \     '.lein/', '.shadow-cljs/', '.git/', 'project.clj', 'deps.edn', 'shadow-cljs.edn']))},
+      \ 'root_uri':{server_info->lsp_settings#get('clojure-lsp', 'root_uri', lsp_settings#root_uri(extend([
+      \     '.lein/', '.shadow-cljs/', 'project.clj', 'deps.edn', 'shadow-cljs.edn'], g:lsp_settings_root_markers)))},
       \ 'initialization_options': lsp_settings#get('clojure-lsp', 'initialization_options', v:null),
       \ 'whitelist': lsp_settings#get('clojure-lsp', 'whitelist', ['clojure']),
       \ 'blacklist': lsp_settings#get('clojure-lsp', 'blacklist', []),

--- a/settings/cobol-language-support.vim
+++ b/settings/cobol-language-support.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_cobol_language_support
   LspRegisterServer {
       \ 'name': 'cobol-language-support',
       \ 'cmd': {server_info->lsp_settings#get('cobol-language-support', 'cmd', [lsp_settings#exec_path('cobol-language-support')])},
-      \ 'root_uri':{server_info->lsp_settings#get('cobol-language-server', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('cobol-language-server', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('cobol-language-support', 'initialization_options', {}),
       \ 'whitelist': lsp_settings#get('cobol-language-support', 'whitelist', ['cobol']),
       \ 'blacklist': lsp_settings#get('cobol-language-support', 'blacklist', []),

--- a/settings/css-languageserver.vim
+++ b/settings/css-languageserver.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_css_languageserver
   LspRegisterServer {
       \ 'name': 'css-languageserver',
       \ 'cmd': {server_info->lsp_settings#get('css-languageserver', 'cmd', [lsp_settings#exec_path('css-languageserver'), '--stdio'])},
-      \ 'root_uri':{server_info->lsp_settings#get('css-languageserver', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('css-languageserver', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('css-languageserver', 'initialization_options', v:null),
       \ 'whitelist': lsp_settings#get('css-languageserver', 'whitelist', ['css', 'less', 'sass']),
       \ 'blacklist': lsp_settings#get('css-languageserver', 'blacklist', []),

--- a/settings/digestif.vim
+++ b/settings/digestif.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_digestif
   LspRegisterServer {
       \ 'name': 'digestif',
       \ 'cmd': {server_info->lsp_settings#get('digestif', 'cmd', [lsp_settings#exec_path('digestif')])},
-      \ 'root_uri':{server_info->lsp_settings#get('digestif', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('digestif', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('digestif', 'initialization_options', {"diagnostics": "true"}),
       \ 'whitelist': lsp_settings#get('digestif', 'whitelist', ['plaintex', 'tex']),
       \ 'blacklist': lsp_settings#get('digestif', 'blacklist', []),

--- a/settings/dls.vim
+++ b/settings/dls.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_dls
   LspRegisterServer {
       \ 'name': 'dls',
       \ 'cmd': {server_info->lsp_settings#get('dls', 'cmd', [lsp_settings#exec_path('dls')])},
-      \ 'root_uri':{server_info->lsp_settings#get('dls', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('dls', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('dls', 'initialization_options', {"diagnostics": "true"}),
       \ 'whitelist': lsp_settings#get('dls', 'whitelist', ['d']),
       \ 'blacklist': lsp_settings#get('dls', 'blacklist', []),

--- a/settings/docker-langserver.vim
+++ b/settings/docker-langserver.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_dockerfile_language_server_nodejs
   LspRegisterServer {
       \ 'name': 'docker-langserver',
       \ 'cmd': {server_info->lsp_settings#get('docker-langserver', 'cmd', [lsp_settings#exec_path('docker-langserver'), '--stdio'])},
-      \ 'root_uri':{server_info->lsp_settings#get('docker-langserver', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('docker-langserver', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('docker-langserver', 'initialization_options', v:null),
       \ 'whitelist': lsp_settings#get('docker-langserver', 'whitelist', ['dockerfile']),
       \ 'blacklist': lsp_settings#get('docker-langserver', 'blacklist', []),

--- a/settings/eclipse-jdt-ls.vim
+++ b/settings/eclipse-jdt-ls.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_eclipse_jdt_ls
   LspRegisterServer {
       \ 'name': 'eclipse-jdt-ls',
       \ 'cmd': {server_info->lsp_settings#get('eclipse-jdt-ls', 'cmd', [lsp_settings#exec_path('eclipse-jdt-ls')])},
-      \ 'root_uri':{server_info->lsp_settings#get('eclipse-jdt-ls', 'root_uri', lsp_settings#root_uri(['.git/', 'pom.xml', 'build.gradle']))},
+      \ 'root_uri':{server_info->lsp_settings#get('eclipse-jdt-ls', 'root_uri', lsp_settings#root_uri(extend(['pom.xml', 'build.gradle'], g:lsp_settings_root_markers)))},
       \ 'initialization_options': lsp_settings#get('eclipse-jdt-ls', 'initialization_options', v:null),
       \ 'whitelist': lsp_settings#get('eclipse-jdt-ls', 'whitelist', ['java']),
       \ 'blacklist': lsp_settings#get('eclipse-jdt-ls', 'blacklist', []),

--- a/settings/elixir-ls.vim
+++ b/settings/elixir-ls.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_elixir_ls
   LspRegisterServer {
       \ 'name': 'elixir-ls',
       \ 'cmd': {server_info->lsp_settings#get('elixir-ls', 'cmd', [lsp_settings#exec_path('elixir-ls')])},
-      \ 'root_uri':{server_info->lsp_settings#get('elixir-ls', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('elixir-ls', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('elixir-ls', 'initialization_options', v:null),
       \ 'whitelist': lsp_settings#get('elixir-ls', 'whitelist', ['elixir']),
       \ 'blacklist': lsp_settings#get('elixir-ls', 'blacklist', []),

--- a/settings/elm-language-server.vim
+++ b/settings/elm-language-server.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_elm_language_server
   LspRegisterServer {
       \ 'name': 'elm-language-server',
       \ 'cmd': {server_info->lsp_settings#get('elm-language-server', 'cmd', [lsp_settings#exec_path('elm-language-server')])},
-      \ 'root_uri':{server_info->lsp_settings#get('elm-language-server', 'root_uri', lsp_settings#root_uri(['.git/', 'elm.json']))},
+      \ 'root_uri':{server_info->lsp_settings#get('elm-language-server', 'root_uri', lsp_settings#root_uri(extend(['elm.json'], g:lsp_settings_root_markers)))},
       \ 'initialization_options': lsp_settings#get('elm-language-server', 'initialization_options', {'elmPath': 'elm', 'runtime': 'node', 'elmFormatPath': 'elm-format', 'elmTestPath': 'elm-test'}),
       \ 'whitelist': lsp_settings#get('elm-language-server', 'whitelist', ['elm', 'elm.tsx']),
       \ 'blacklist': lsp_settings#get('elm-language-server', 'blacklist', []),

--- a/settings/emmylua-ls.vim
+++ b/settings/emmylua-ls.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_emmylua_ls
   LspRegisterServer {
       \ 'name': 'emmylua-ls',
       \ 'cmd': {server_info->lsp_settings#get('emmylua-ls', 'cmd', [lsp_settings#exec_path('emmylua-ls')])},
-      \ 'root_uri':{server_info->lsp_settings#get('emmylua-ls', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('emmylua-ls', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('emmylua-ls', 'initialization_options', v:null),
       \ 'whitelist': lsp_settings#get('emmylua-ls', 'whitelist', ['lua']),
       \ 'blacklist': lsp_settings#get('emmylua-ls', 'blacklist', []),

--- a/settings/erlang-ls.vim
+++ b/settings/erlang-ls.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_erlang_ls
   LspRegisterServer {
       \ 'name': 'erlang-ls',
       \ 'cmd': {server_info->lsp_settings#get('erlang-ls', 'cmd', [lsp_settings#exec_path('erlang-ls'), '--transport', 'stdio'])},
-      \ 'root_uri':{server_info->lsp_settings#get('erlang-ls', 'root_uri', lsp_settings#root_uri(['.git/', 'rebar.config']))},
+      \ 'root_uri':{server_info->lsp_settings#get('erlang-ls', 'root_uri', lsp_settings#root_uri(extend(['rebar.config'], g:lsp_settings_root_markers)))},
       \ 'initialization_options': lsp_settings#get('erlang-ls', 'initialization_options', {}),
       \ 'whitelist': lsp_settings#get('erlang-ls', 'whitelist', ['erlang']),
       \ 'blacklist': lsp_settings#get('erlang-ls', 'blacklist', []),

--- a/settings/fortls.vim
+++ b/settings/fortls.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_fortls
   LspRegisterServer {
       \ 'name': 'fortls',
       \ 'cmd': {server_info->lsp_settings#get('fortls', 'cmd', [lsp_settings#exec_path('fortls')])},
-      \ 'root_uri':{server_info->lsp_settings#get('fortls', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('fortls', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('fortls', 'initialization_options', v:null),
       \ 'whitelist': lsp_settings#get('fortls', 'whitelist', ['fortran']),
       \ 'blacklist': lsp_settings#get('fortls', 'blacklist', []),

--- a/settings/fsharp-language-server.vim
+++ b/settings/fsharp-language-server.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_fsharp_language_server
   LspRegisterServer {
       \ 'name': 'fsharp-language-server',
       \ 'cmd': {server_info->lsp_settings#get('fsharp-language-server', 'cmd', [lsp_settings#exec_path('fsharp-language-server'), '--stdio'])},
-      \ 'root_uri':{server_info->lsp_settings#get('fsharp-language-server', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('fsharp-language-server', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('fsharp-language-server', 'initialization_options', v:null),
       \ 'whitelist': lsp_settings#get('fsharp-language-server', 'whitelist', ['fsharp']),
       \ 'blacklist': lsp_settings#get('fsharp-language-server', 'blacklist', []),

--- a/settings/gopls.vim
+++ b/settings/gopls.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_gopls
   LspRegisterServer {
       \ 'name': 'gopls',
       \ 'cmd': {server_info->lsp_settings#get('gopls', 'cmd', [lsp_settings#exec_path('gopls')])},
-      \ 'root_uri':{server_info->lsp_settings#get('gopls', 'root_uri', lsp_settings#root_uri(['.git/', 'go.mod']))},
+      \ 'root_uri':{server_info->lsp_settings#get('gopls', 'root_uri', lsp_settings#root_uri(extend(['go.mod'], g:lsp_settings_root_markers)))},
       \ 'initialization_options': lsp_settings#get('gopls', 'initialization_options', {"diagnostics": v:true, 'completeUnimported': v:true}),
       \ 'whitelist': lsp_settings#get('gopls', 'whitelist', ['go']),
       \ 'blacklist': lsp_settings#get('gopls', 'blacklist', []),

--- a/settings/gql-language-server.vim
+++ b/settings/gql-language-server.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_gql_language_server
   LspRegisterServer {
       \ 'name': 'gql-language-server',
       \ 'cmd': {server_info->lsp_settings#get('gql-language-server', 'cmd', [lsp_settings#exec_path('gql-language-server'), '--stdio'])},
-      \ 'root_uri':{server_info->lsp_settings#get('gql-language-server', 'root_uri', lsp_settings#root_uri(['.git/', 'package.json', 'tsconfig.json', '.gqlconfig']))},
+      \ 'root_uri':{server_info->lsp_settings#get('gql-language-server', 'root_uri', lsp_settings#root_uri(extend(['package.json', 'tsconfig.json', '.gqlconfig'], g:lsp_settings_root_markers)))},
       \ 'initialization_options': lsp_settings#get('gql-language-server', 'initialization_options', {"diagnostics": "true"}),
       \ 'whitelist': lsp_settings#get('gql-language-server', 'whitelist', ['graphql']),
       \ 'blacklist': lsp_settings#get('gql-language-server', 'blacklist', []),

--- a/settings/groovy-language-server.vim
+++ b/settings/groovy-language-server.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_groovy_language_server
   LspRegisterServer {
       \ 'name': 'groovy-language-server',
       \ 'cmd': {server_info->lsp_settings#get('groovy-language-server', 'cmd', [lsp_settings#exec_path('groovy-language-server')])},
-      \ 'root_uri':{server_info->lsp_settings#get('groovy-language-server', 'root_uri', lsp_settings#root_uri(['.git/', 'build.gradle']))},
+      \ 'root_uri':{server_info->lsp_settings#get('groovy-language-server', 'root_uri', lsp_settings#root_uri(extend(['build.gradle'], g:lsp_settings_root_markers)))},
       \ 'initialization_options': lsp_settings#get('groovy-language-server', 'initialization_options', {}),
       \ 'whitelist': lsp_settings#get('groovy-language-server', 'whitelist', ['groovy']),
       \ 'blacklist': lsp_settings#get('groovy-language-server', 'blacklist', []),

--- a/settings/html-languageserver.vim
+++ b/settings/html-languageserver.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_html_languageserver
   LspRegisterServer {
       \ 'name': 'html-languageserver',
       \ 'cmd': {server_info->lsp_settings#get('html-languageserver', 'cmd', [lsp_settings#exec_path('html-languageserver'), '--stdio'])},
-      \ 'root_uri':{server_info->lsp_settings#get('html-langserver', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('html-langserver', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('html-languageserver', 'initialization_options', {'embeddedLanguages': {'css': v:true, 'html': v:true}}),
       \ 'whitelist': lsp_settings#get('html-languageserver', 'whitelist', ['html']),
       \ 'blacklist': lsp_settings#get('html-languageserver', 'blacklist', []),

--- a/settings/intelephense.vim
+++ b/settings/intelephense.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_intelephense_server
   LspRegisterServer {
       \ 'name': 'intelephense',
       \ 'cmd': {server_info->lsp_settings#get('intelephense', 'cmd', [lsp_settings#exec_path('intelephense'), '--stdio'])},
-      \ 'root_uri':{server_info->lsp_settings#get('intelephense', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('intelephense', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('intelephense', 'initialization_options', {}),
       \ 'whitelist': lsp_settings#get('intelephense', 'whitelist', ['php']),
       \ 'blacklist': lsp_settings#get('intelephense', 'blacklist', []),

--- a/settings/javascript-typescript-stdio.vim
+++ b/settings/javascript-typescript-stdio.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_javascript_typescript_stdio
   LspRegisterServer {
       \ 'name': 'javascript-typescript-stdio',
       \ 'cmd': {server_info->lsp_settings#get('javascript-typescript-stdio', 'cmd', [lsp_settings#exec_path('javascript-typescript-stdio')])},
-      \ 'root_uri':{server_info->lsp_settings#get('javascript-typescript-stdio', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('javascript-typescript-stdio', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('javascript-typescript-stdio', 'initialization_options', {"diagnostics": "true"}),
       \ 'whitelist': lsp_settings#get('javascript-typescript-stdio', 'whitelist', ['javascript', 'javascriptreact']),
       \ 'blacklist': lsp_settings#get('javascript-typescript-stdio', 'blacklist', []),

--- a/settings/json-languageserver.vim
+++ b/settings/json-languageserver.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_json_languageserver
   LspRegisterServer {
       \ 'name': 'json-languageserver',
       \ 'cmd': {server_info->lsp_settings#get('json-languageserver', 'cmd', [lsp_settings#exec_path('json-languageserver'), '--stdio'])},
-      \ 'root_uri':{server_info->lsp_settings#get('json-languageserver', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('json-languageserver', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('json-languageserver', 'initialization_options', v:null),
       \ 'whitelist': lsp_settings#get('json-languageserver', 'whitelist', ['json']),
       \ 'blacklist': lsp_settings#get('json-languageserver', 'blacklist', []),

--- a/settings/kotlin-language-server.vim
+++ b/settings/kotlin-language-server.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_kotlin_language_server
   LspRegisterServer {
       \ 'name': 'kotlin-language-server',
       \ 'cmd': {server_info->lsp_settings#get('kotlin-language-server', 'cmd', [lsp_settings#exec_path('kotlin-language-server')])},
-      \ 'root_uri':{server_info->lsp_settings#get('kotlin-language-server', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('kotlin-language-server', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('kotlin-language-server', 'initialization_options', v:null),
       \ 'whitelist': lsp_settings#get('kotlin-language-server', 'whitelist', ['kotlin']),
       \ 'blacklist': lsp_settings#get('kotlin-language-server', 'blacklist', []),

--- a/settings/lsp4xml.vim
+++ b/settings/lsp4xml.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_lsp4xml
   LspRegisterServer {
       \ 'name': 'lsp4xml',
       \ 'cmd': {server_info->lsp_settings#get('lsp4xml', 'cmd', [lsp_settings#exec_path('lsp4xml')])},
-      \ 'root_uri':{server_info->lsp_settings#get('lsp4xml', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('lsp4xml', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('lsp4xml', 'initialization_options', v:null),
       \ 'whitelist': lsp_settings#get('lsp4xml', 'whitelist', ['xml']),
       \ 'blacklist': lsp_settings#get('lsp4xml', 'blacklist', []),

--- a/settings/metals.vim
+++ b/settings/metals.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_metals
   LspRegisterServer {
       \ 'name': 'metals',
       \ 'cmd': {server_info->lsp_settings#get('metals', 'cmd', [lsp_settings#exec_path('metals')])},
-      \ 'root_uri':{server_info->lsp_settings#get('metals', 'root_uri', lsp_settings#root_uri(['.git/', 'build.sbt']))},
+      \ 'root_uri':{server_info->lsp_settings#get('metals', 'root_uri', lsp_settings#root_uri(extend(['build.sbt'], g:lsp_settings_root_markers)))},
       \ 'initialization_options': lsp_settings#get('metals', 'initialization_options', v:null),
       \ 'whitelist': lsp_settings#get('metals', 'whitelist', ['scala', 'sbt']),
       \ 'blacklist': lsp_settings#get('metals', 'blacklist', []),

--- a/settings/nimlsp.vim
+++ b/settings/nimlsp.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_nimlsp
   LspRegisterServer {
       \ 'name': 'nimlsp',
       \ 'cmd': {server_info->lsp_settings#get('nimlsp', 'cmd', [lsp_settings#exec_path('nimlsp')])},
-      \ 'root_uri':{server_info->lsp_settings#get('nimlsp', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('nimlsp', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('nimlsp', 'initialization_options', {"diagnostics": "true"}),
       \ 'whitelist': lsp_settings#get('nimlsp', 'whitelist', ['nim']),
       \ 'blacklist': lsp_settings#get('nimlsp', 'blacklist', []),

--- a/settings/omnisharp-lsp.vim
+++ b/settings/omnisharp-lsp.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_omnisharp_lsp
   LspRegisterServer {
       \ 'name': 'omnisharp-lsp',
       \ 'cmd': {server_info->lsp_settings#get('omnisharp-lsp', 'cmd', [lsp_settings#exec_path('omnisharp-lsp'), '-lsp'])},
-      \ 'root_uri':{server_info->lsp_settings#get('omnisharp-lsp', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('omnisharp-lsp', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('omnisharp-lsp', 'initialization_options', v:null),
       \ 'whitelist': lsp_settings#get('omnisharp-lsp', 'whitelist', ['cs']),
       \ 'blacklist': lsp_settings#get('omnisharp-lsp', 'blacklist', []),

--- a/settings/pyls.vim
+++ b/settings/pyls.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_pyls
   LspRegisterServer {
       \ 'name': 'pyls',
       \ 'cmd': {server_info->lsp_settings#get('pyls', 'cmd', [lsp_settings#exec_path('pyls')])},
-      \ 'root_uri':{server_info->lsp_settings#get('pyls', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('pyls', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('pyls', 'initialization_options', v:null),
       \ 'whitelist': lsp_settings#get('pyls', 'whitelist', ['python']),
       \ 'blacklist': lsp_settings#get('pyls', 'blacklist', []),

--- a/settings/reason-language-server.vim
+++ b/settings/reason-language-server.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_reason_language_server
   LspRegisterServer {
       \ 'name': 'reason-language-server',
       \ 'cmd': {server_info->lsp_settings#get('reason-language-server', 'cmd', [lsp_settings#exec_path('reason-language-server')])},
-      \ 'root_uri':{server_info->lsp_settings#get('reason-language-server', 'root_uri', lsp_settings#root_uri(['.git/', 'package.json']))},
+      \ 'root_uri':{server_info->lsp_settings#get('reason-language-server', 'root_uri', lsp_settings#root_uri(extend(['package.json'], g:lsp_settings_root_markers)))},
       \ 'initialization_options': lsp_settings#get('reason-language-server', 'initialization_options', {}),
       \ 'whitelist': lsp_settings#get('reason-language-server', 'whitelist', ['reason']),
       \ 'blacklist': lsp_settings#get('reason-language-server', 'blacklist', []),

--- a/settings/reason-language-server.vim
+++ b/settings/reason-language-server.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_reason_language_server
   LspRegisterServer {
       \ 'name': 'reason-language-server',
       \ 'cmd': {server_info->lsp_settings#get('reason-language-server', 'cmd', [lsp_settings#exec_path('reason-language-server')])},
-      \ 'root_uri':{server_info->lsp_settings#get('reason-language-server', 'root_uri', lsp_settings#root_uri(['.git/', 'pacakge.json']))},
+      \ 'root_uri':{server_info->lsp_settings#get('reason-language-server', 'root_uri', lsp_settings#root_uri(['.git/', 'package.json']))},
       \ 'initialization_options': lsp_settings#get('reason-language-server', 'initialization_options', {}),
       \ 'whitelist': lsp_settings#get('reason-language-server', 'whitelist', ['reason']),
       \ 'blacklist': lsp_settings#get('reason-language-server', 'blacklist', []),

--- a/settings/rls.vim
+++ b/settings/rls.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_rls
   LspRegisterServer {
       \ 'name': 'rls',
       \ 'cmd': {server_info->lsp_settings#get('rls', 'cmd', [lsp_settings#exec_path('rls')])},
-      \ 'root_uri':{server_info->lsp_settings#get('rls', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('rls', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('rls', 'initialization_options', v:null),
       \ 'whitelist': lsp_settings#get('rls', 'whitelist', ['rust']),
       \ 'blacklist': lsp_settings#get('rls', 'blacklist', []),

--- a/settings/solargraph.vim
+++ b/settings/solargraph.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_solargraph
   LspRegisterServer {
       \ 'name': 'solargraph',
       \ 'cmd': {server_info->lsp_settings#get('solargraph', 'cmd', [lsp_settings#exec_path('solargraph'), 'stdio'])},
-      \ 'root_uri':{server_info->lsp_settings#get('solargraph', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('solargraph', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('solargraph', 'initialization_options', {"diagnostics": "true"}),
       \ 'whitelist': lsp_settings#get('solargraph', 'whitelist', ['ruby']),
       \ 'blacklist': lsp_settings#get('solargraph', 'blacklist', []),

--- a/settings/sourcekit-lsp.vim
+++ b/settings/sourcekit-lsp.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_sourcekit_lsp
   LspRegisterServer {
       \ 'name': 'sourcekit-lsp',
       \ 'cmd': {server_info->lsp_settings#get('sourcekit-lsp', 'cmd', [lsp_settings#exec_path('sourcekit-lsp')])},
-      \ 'root_uri':{server_info->lsp_settings#get('sourcekit-lsp', 'root_uri', lsp_settings#root_uri(['.git/', 'Package.swift', '.xcodeproj', '.xcworkspace', 'Cartfile', 'Podfile']))},
+      \ 'root_uri':{server_info->lsp_settings#get('sourcekit-lsp', 'root_uri', lsp_settings#root_uri(extend(['Package.swift', '.xcodeproj', '.xcworkspace', 'Cartfile', 'Podfile'], g:lsp_settings_root_markers)))},
       \ 'initialization_options': lsp_settings#get('sourcekit-lsp', 'initialization_options', {}),
       \ 'whitelist': lsp_settings#get('sourcekit-lsp', 'whitelist', ['swift']),
       \ 'blacklist': lsp_settings#get('sourcekit-lsp', 'blacklist', []),

--- a/settings/terraform-lsp.vim
+++ b/settings/terraform-lsp.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_terraform_lsp
   LspRegisterServer {
       \ 'name': 'terraform-lsp',
       \ 'cmd': {server_info->lsp_settings#get('terraform-lsp', 'cmd', [lsp_settings#exec_path('terraform-lsp')])},
-      \ 'root_uri':{server_info->lsp_settings#get('terraform-lsp', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('terraform-lsp', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('terraform-lsp', 'initialization_options', v:null),
       \ 'whitelist': lsp_settings#get('terraform-lsp', 'whitelist', ['terraform']),
       \ 'blacklist': lsp_settings#get('terraform-lsp', 'blacklist', []),

--- a/settings/texlab.vim
+++ b/settings/texlab.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_texlab
   LspRegisterServer {
       \ 'name': 'texlab',
       \ 'cmd': {server_info->lsp_settings#get('texlab', 'cmd', [lsp_settings#exec_path('texlab')])},
-      \ 'root_uri':{server_info->lsp_settings#get('texlab', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('texlab', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('texlab', 'initialization_options', {"diagnostics": "true"}),
       \ 'whitelist': lsp_settings#get('texlab', 'whitelist', ['plaintex', 'tex']),
       \ 'blacklist': lsp_settings#get('texlab', 'blacklist', []),

--- a/settings/typescript-language-server.vim
+++ b/settings/typescript-language-server.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_typescript_language_server
   LspRegisterServer {
       \ 'name': 'typescript-language-server',
       \ 'cmd': {server_info->lsp_settings#get('typescript-language-server', 'cmd', [lsp_settings#exec_path('typescript-language-server'), '--stdio'])},
-      \ 'root_uri':{server_info->lsp_settings#get('typescript-language-server', 'root_uri', lsp_settings#root_uri(['.git/', 'package.json', 'tsconfig.json']))},
+      \ 'root_uri':{server_info->lsp_settings#get('typescript-language-server', 'root_uri', lsp_settings#root_uri(extend(['package.json', 'tsconfig.json'], g:lsp_settings_root_markers)))},
       \ 'initialization_options': lsp_settings#get('typescript-language-server', 'initialization_options', {"diagnostics": "true"}),
       \ 'whitelist': lsp_settings#get('typescript-language-server', 'whitelist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact']),
       \ 'blacklist': lsp_settings#get('typescript-language-server', 'blacklist', []),

--- a/settings/vim-language-server.vim
+++ b/settings/vim-language-server.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_vim_language_server
   LspRegisterServer {
       \ 'name': 'vim-language-server',
       \ 'cmd': {server_info->lsp_settings#get('vim-language-server', 'cmd', [lsp_settings#exec_path('vim-language-server'), '--stdio'])},
-      \ 'root_uri':{server_info->lsp_settings#get('vim-language-server', 'root_uri', lsp_settings#root_uri(['.git/', '.vim/', 'vimfiles/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('vim-language-server', 'root_uri', lsp_settings#root_uri(extend(['.vim/', 'vimfiles/'], g:lsp_settings_root_markers)))},
       \ 'initialization_options': { 'vimruntime': $VIMRUNTIME, 'runtimepath': &rtp },
       \ 'whitelist': lsp_settings#get('vim-language-server', 'whitelist', ['vim']), 
       \ 'blacklist': lsp_settings#get('vimbash-language-server', 'blacklist', []),

--- a/settings/vls.vim
+++ b/settings/vls.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_vls
   LspRegisterServer {
       \ 'name': 'vls',
       \ 'cmd': {server_info->lsp_settings#get('vls', 'cmd', [lsp_settings#exec_path('vls'), '--stdio'])},
-      \ 'root_uri':{server_info->lsp_settings#get('vls', 'root_uri', lsp_settings#root_uri(['.git/', 'package.json']))},
+      \ 'root_uri':{server_info->lsp_settings#get('vls', 'root_uri', lsp_settings#root_uri(extend(['package.json'], g:lsp_settings_root_markers)))},
       \ 'initialization_options': lsp_settings#get('vls', 'initialization_options', {'config': {'vetur': {'useWorkspaceDependencies': v:false, 'validation': {'template': v:true, 'style': v:true, 'script': v:true}, 'completion': {'autoImport': v:false, 'useScaffoldSnippets': v:false, 'tagCasing': 'kebab'}, 'format': {'defaultFormatter': {'js': v:none, 'ts': v:none}, 'defaultFormatterOptions': {}, 'scriptInitialIndent': v:false, 'styleInitialIndent': v:false}, 'dev': {'logLevel': 'DEBUG'}}, 'css': {}, 'html': {'suggest': {}}, 'javascript': {'format': {}}, 'typescript': {'format': {}}, 'emmet': {}, 'stylusSupremacy': {}}}),
       \ 'whitelist': lsp_settings#get('vls', 'whitelist', ['vue']),
       \ 'blacklist': lsp_settings#get('vls', 'blacklist', []),

--- a/settings/yaml-language-server.vim
+++ b/settings/yaml-language-server.vim
@@ -3,7 +3,7 @@ augroup vimlsp_settings_yaml_language_server
   LspRegisterServer {
       \ 'name': 'yaml-language-server',
       \ 'cmd': {server_info->lsp_settings#get('yaml-language-server', 'cmd', [lsp_settings#exec_path('yaml-language-server'), '--stdio'])},
-      \ 'root_uri':{server_info->lsp_settings#get('yaml-language-server', 'root_uri', lsp_settings#root_uri(['.git/']))},
+      \ 'root_uri':{server_info->lsp_settings#get('yaml-language-server', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('yaml-language-server', 'initialization_options', v:null),
       \ 'whitelist': lsp_settings#get('yaml-language-server', 'whitelist', ['yaml']),
       \ 'blacklist': lsp_settings#get('yaml-language-server', 'blacklist', []),


### PR DESCRIPTION
Make it easier to add new root markers and support .svn directories as root markers.

I found a typo in the reason root marker, so I threw that in here too.