### PR TITLE
Make g:lsp_settings higher priority than settings.json

### DIFF
--- a/plugin/lsp_settings.vim
+++ b/plugin/lsp_settings.vim
@@ -255,7 +255,7 @@ function! s:vim_lsp_load_or_suggest(ft) abort
   let l:found = 0
 
   for l:server in s:settings[a:ft]
-    if get(l:server, 'disabled', 0) || s:vim_lsp_settings_get(l:server.command, 'disabled', 0)
+    if s:vim_lsp_settings_get(l:server.command, 'disabled', get(l:server, 'disabled', 0))
       continue
     endif
     let l:default = get(g:, 'lsp_settings_' . a:ft, '')


### PR DESCRIPTION
Config from g:lsp_settings should have higher priority so that user can
enable efm-langserver without edit settings.json directly.