### PR TITLE
fix: Fix bash throws bad interpreter error by fix commit about #126

### DIFF
--- a/autoload/lsp_settings.vim
+++ b/autoload/lsp_settings.vim
@@ -277,8 +277,7 @@ function! s:vim_lsp_install_server(ft, command) abort
     split new
     call termopen(l:entry[1], {'cwd': l:server_install_dir, 'on_exit': function('s:vim_lsp_install_server_post', [l:entry[0]])}) | startinsert
   else
-    let l:args = has('win32') ? ['cmd', '/c', l:entry[1]] : ['bash', '-c', l:entry[1]]
-    let l:bufnr = term_start(l:args, {'cwd': l:server_install_dir})
+    let l:bufnr = term_start(l:entry[1], {'cwd': l:server_install_dir})
     let l:job = term_getjob(l:bufnr)
     if l:job != v:null
       call job_setoptions(l:job, {'exit_cb': function('s:vim_lsp_install_server_post', [l:entry[0]])})

--- a/installer/go_install.sh
+++ b/installer/go_install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Usage
 # $ go_install [GO_GET_URLPATH]

--- a/installer/install-analysis-server-dart-snapshot.sh
+++ b/installer/install-analysis-server-dart-snapshot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
@@ -7,7 +7,7 @@ unzip "dartsdk-linux-x64-release.zip"
 rm "dartsdk-linux-x64-release.zip"
 
 cat <<EOF > analysis-server-dart-snapshot
-#!/bin/sh
+#!/usr/bin/env bash
 
 DIR=\$(cd \$(dirname \$0); pwd)
 \$DIR/bin/dart \$DIR/bin/snapshots/analysis_server.dart.snapshot --lsp \$*

--- a/installer/install-bash-language-server.sh
+++ b/installer/install-bash-language-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-cl-lsp.sh
+++ b/installer/install-cl-lsp.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 ros install cxxxr/cl-lsp

--- a/installer/install-clangd.sh
+++ b/installer/install-clangd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-clojure-lsp.sh
+++ b/installer/install-clojure-lsp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-cobol-language-support.sh
+++ b/installer/install-cobol-language-support.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
@@ -8,7 +8,7 @@ curl -LO "$url"
 unzip "cobol-language-support-$version.vsix"
 
 cat <<EOF >./cobol-language-support
-#!/bin/sh
+#!/usr/bin/env bash
 DIR=\$(cd \$(dirname \$0); pwd)
 java "-Dline.speparator=\r\n" -jar "\$DIR/extension/server/lsp-service-cobol-$version.jar" pipeEnabled
 EOF

--- a/installer/install-css-languageserver.sh
+++ b/installer/install-css-languageserver.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-dls.sh
+++ b/installer/install-dls.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-docker-langserver.sh
+++ b/installer/install-docker-langserver.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-eclipse-jdt-ls.sh
+++ b/installer/install-eclipse-jdt-ls.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
@@ -8,7 +8,7 @@ tar xvf jdt-language-server-latest.tar.gz
 rm jdt-language-server-latest.tar.gz
 
 cat <<EOF > eclipse-jdt-ls
-#!/bin/sh
+#!/usr/bin/env bash
 
 DIR=\$(cd \$(dirname \$0); pwd)
 LAUNCHER=\$(ls \$DIR/plugins/org.eclipse.equinox.launcher_*.jar)

--- a/installer/install-efm-langserver.sh
+++ b/installer/install-efm-langserver.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-elixir-ls.sh
+++ b/installer/install-elixir-ls.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
@@ -9,7 +9,7 @@ unzip elixir-ls.zip
 rm elixir-ls.zip
 
 cat <<EOF > elixir-ls
-#!/bin/sh
+#!/usr/bin/env bash
 
 DIR=\$(cd \$(dirname \$0); pwd)
 \$DIR/language_server.sh \$*

--- a/installer/install-elm-language-server.sh
+++ b/installer/install-elm-language-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-emmylua-ls.sh
+++ b/installer/install-emmylua-ls.sh
@@ -1,11 +1,11 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 
 curl -L -o EmmyLua-LS-all.jar 'https://ci.appveyor.com/api/buildjobs/54yf9rjvj49494pd/artifacts/EmmyLua-LS%2Fbuild%2Flibs%2FEmmyLua-LS-all.jar'
 
 cat <<EOF > emmylua-ls
-#!/bin/sh
+#!/usr/bin/env bash
 
 DIR=\$(cd \$(dirname \$0); pwd)
 java -cp \$DIR/EmmyLua-LS-all.jar com.tang.vscode.MainKt

--- a/installer/install-erlang-ls.sh
+++ b/installer/install-erlang-ls.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-fortls.sh
+++ b/installer/install-fortls.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 "$(dirname $0)/pip_install.sh" fortls fortran-language-server

--- a/installer/install-fsharp-language-server.sh
+++ b/installer/install-fsharp-language-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
@@ -7,7 +7,7 @@ npm install
 dotnet build -c Release
 
 cat <<EOF > fsharp-language-server
-#!/bin/sh
+#!/usr/bin/env bash
 
 DIR=\$(cd \$(dirname \$0); pwd)
 \$DIR/src/FSharpLanguageServer/bin/Release/netcoreapp2.0/FSharpLanguageServer.dll \$*

--- a/installer/install-gopls.sh
+++ b/installer/install-gopls.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-gql-language-server.sh
+++ b/installer/install-gql-language-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-groovy-language-server.sh
+++ b/installer/install-groovy-language-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
@@ -6,7 +6,7 @@ git clone --depth=1 https://github.com/prominic/groovy-language-server .
 ./gradlew build
 
 cat <<EOF >groovy-language-server
-#!/bin/sh
+#!/usr/bin/env bash
 
 DIR=\$(cd \$(dirname \$0); pwd)
 java -jar \$DIR/build/libs/groovy-language-server-all.jar

--- a/installer/install-html-languageserver.sh
+++ b/installer/install-html-languageserver.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-intelephense.sh
+++ b/installer/install-intelephense.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-javascript-typescript-stdio.sh
+++ b/installer/install-javascript-typescript-stdio.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-json-languageserver.sh
+++ b/installer/install-json-languageserver.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-kotlin-language-server.sh
+++ b/installer/install-kotlin-language-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-lsp4xml.sh
+++ b/installer/install-lsp4xml.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
@@ -8,7 +8,7 @@ url=https://dl.bintray.com/lsp4xml/releases/org/lsp4xml/org.eclipse.lsp4xml/${ve
 curl -LO "$url"
 
 cat <<EOF >lsp4xml
-#!/bin/sh
+#!/usr/bin/env bash
 
 DIR=\$(cd \$(dirname \$0); pwd)
 java -jar \$DIR/org.eclipse.lsp4xml-${version}-uber.jar

--- a/installer/install-metals.sh
+++ b/installer/install-metals.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-omnisharp-lsp.sh
+++ b/installer/install-omnisharp-lsp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
@@ -26,7 +26,7 @@ rm omnisharp-$os$arch.tar.gz
 chmod +x run
 
 cat <<EOF > omnisharp-lsp
-#!/bin/sh
+#!/usr/bin/env bash
 
 DIR=\$(cd \$(dirname \$0); pwd)
 \$DIR/run \$*

--- a/installer/install-pyls-ms.sh
+++ b/installer/install-pyls-ms.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
@@ -25,7 +25,7 @@ curl -L "$url" -o "$nupkg"
 unzip "$nupkg"
 
 cat <<EOF >pyls-ms
-#!/bin/sh
+#!/usr/bin/env bash
 
 DIR=\$(cd \$(dirname \$0); pwd)
 \$DIR/.dotnet/dotnet \$DIR/Microsoft.Python.LanguageServer.dll

--- a/installer/install-pyls.sh
+++ b/installer/install-pyls.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-ra_lsp_server.sh
+++ b/installer/install-ra_lsp_server.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-reason-language-server.sh
+++ b/installer/install-reason-language-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-solargraph.sh
+++ b/installer/install-solargraph.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 
@@ -6,7 +6,7 @@ git clone "https://github.com/castwide/solargraph" .
 bundle install --path vendor/bundle
 
 cat <<EOF > solargraph
-#!/bin/sh
+#!/usr/bin/env bash
 
 DIR=\$(cd \$(dirname \$0); pwd)
 cd \$DIR && bundle exec ruby \$DIR/bin/solargraph stdio

--- a/installer/install-sql-language-server.sh
+++ b/installer/install-sql-language-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-terraform-lsp.sh
+++ b/installer/install-terraform-lsp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-texlab.sh
+++ b/installer/install-texlab.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-typescript-language-server.sh
+++ b/installer/install-typescript-language-server.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-vim-language-server.sh
+++ b/installer/install-vim-language-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-vls.sh
+++ b/installer/install-vls.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/install-yaml-language-server.sh
+++ b/installer/install-yaml-language-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/installer/npm_install.sh
+++ b/installer/npm_install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Usage
 # $ npm_install [EXECUTABLE_NAME] [NPM_NAME]

--- a/installer/pip_install.sh
+++ b/installer/pip_install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Usage
 # $ pip_install [EXECUTABLE_NAME] [PYPI_NAME]


### PR DESCRIPTION
[This commit](https://github.com/mattn/vim-lsp-settings/pull/127/commits/a95b48fd4c275b64a153adf8455714228f733151) is using bash as execute shell for installer scripts, but this fix make new probrem about installer scripts throws `Bad Interpreter` error if `/bin/bash` does not exists.

My pull request is changed shebang to `#!/usr/bin/env bash`, and this code is fixed about `Bad Interpreter` error.

BTW, I think that my pull request does not care of bash is not installed.
So I suggest adding notes about runtime dependences to README?