### PR TITLE
go_install: typo fix

### DIFF
--- a/installer/go_install.sh
+++ b/installer/go_install.sh
@@ -5,5 +5,5 @@
 
 set -e
 
-GOPATH=$(pwd) GOBIN=$(pwd) GO111MODULE=on go get -v -up $1
+GOPATH=$(pwd) GOBIN=$(pwd) GO111MODULE=on go get -v -u $1
 rm -rf src


### PR DESCRIPTION
Sorry for typo

I modify go_install like as gopls install script, but typo this script.

#130 fix but remain typo.

## first fix
```patch
-GOPATH=$(pwd) GOBIN=$(pwd) GO111MODULE=on go get -v -up$1
+GOPATH=$(pwd) GOBIN=$(pwd) GO111MODULE=on go get -v -up $1
```

## second fix
```patch
-GOPATH=$(pwd) GOBIN=$(pwd) GO111MODULE=on go get -v -up $1
+GOPATH=$(pwd) GOBIN=$(pwd) GO111MODULE=on go get -v -u $1
```
