### PR TITLE
Fix default initialization_options of vue-language-server

### DIFF
--- a/settings/vls.vim
+++ b/settings/vls.vim
@@ -4,7 +4,7 @@ augroup vimlsp_settings_vls
       \ 'name': 'vls',
       \ 'cmd': {server_info->lsp_settings#get('vls', 'cmd', [lsp_settings#exec_path('vls'), '--stdio'])},
       \ 'root_uri':{server_info->lsp_settings#get('vls', 'root_uri', lsp_settings#root_uri(extend(['package.json'], g:lsp_settings_root_markers)))},
-      \ 'initialization_options': lsp_settings#get('vls', 'initialization_options', {'config': {'vetur': {'useWorkspaceDependencies': v:false, 'validation': {'template': v:true, 'style': v:true, 'script': v:true}, 'completion': {'autoImport': v:false, 'useScaffoldSnippets': v:false, 'tagCasing': 'kebab'}, 'format': {'defaultFormatter': {'js': v:none, 'ts': v:none}, 'defaultFormatterOptions': {}, 'scriptInitialIndent': v:false, 'styleInitialIndent': v:false}, 'dev': {'logLevel': 'DEBUG'}}, 'css': {}, 'html': {'suggest': {}}, 'javascript': {'format': {}}, 'typescript': {'format': {}}, 'emmet': {}, 'stylusSupremacy': {}}}),
+      \ 'initialization_options': lsp_settings#get('vls', 'initialization_options', {'config': {'vetur': {'useWorkspaceDependencies': v:false, 'validation': {'template': v:true, 'style': v:true, 'script': v:true}, 'completion': {'autoImport': v:false, 'useScaffoldSnippets': v:false, 'tagCasing': 'kebab'}, 'format': {'defaultFormatter': {'js': '', 'ts': ''}, 'defaultFormatterOptions': {}, 'scriptInitialIndent': v:false, 'styleInitialIndent': v:false}, 'dev': {'logLevel': 'DEBUG'}}, 'css': {}, 'html': {'suggest': {}}, 'javascript': {'format': {}}, 'typescript': {'format': {}}, 'emmet': {}, 'stylusSupremacy': {}}}),
       \ 'whitelist': lsp_settings#get('vls', 'whitelist', ['vue']),
       \ 'blacklist': lsp_settings#get('vls', 'blacklist', []),
       \ 'config': lsp_settings#get('vls', 'config', {}),


### PR DESCRIPTION
When use vue-language-server on Neovim, I encountered the following errors.

```
Error detected while processing User Autocommands for "lsp_setup":
E121: Undefined variable: v:none
E116: Invalid arguments for function lsp_settings#get
E116: Invalid arguments for function lsp#register_server
E121: Undefined variable: v:none
```

Probably Neovim has not `v:none`, and the configuration schema is different between vim-lsp-settings'one and defined by [vue-language-server's one](https://github.com/vuejs/vetur/blob/master/server/src/config.ts#L3).
This PR fixes the default configuration value to follows to the correct schema, as a result of that, the above errors on Neovim will be fixed.