### PR TITLE
Add .tsx and .jsx extentions to LspRegisterServer

### DIFF
--- a/settings/javascript-typescript-stdio.vim
+++ b/settings/javascript-typescript-stdio.vim
@@ -5,7 +5,7 @@ augroup vimlsp_settings_javascript_typescript_stdio
       \ 'cmd': {server_info->lsp_settings#get('javascript-typescript-stdio', 'cmd', [lsp_settings#exec_path('javascript-typescript-stdio')])},
       \ 'root_uri':{server_info->lsp_settings#get('javascript-typescript-stdio', 'root_uri', lsp_settings#root_uri(g:lsp_settings_root_markers))},
       \ 'initialization_options': lsp_settings#get('javascript-typescript-stdio', 'initialization_options', {"diagnostics": "true"}),
-      \ 'whitelist': lsp_settings#get('javascript-typescript-stdio', 'whitelist', ['javascript', 'javascriptreact']),
+      \ 'whitelist': lsp_settings#get('javascript-typescript-stdio', 'whitelist', ['javascript', 'javascriptreact', 'javascript.jsx']),
       \ 'blacklist': lsp_settings#get('javascript-typescript-stdio', 'blacklist', []),
       \ 'config': lsp_settings#get('javascript-typescript-stdio', 'config', {}),
       \ 'workspace_config': lsp_settings#get('javascript-typescript-stdio', 'workspace_config', {}),

--- a/settings/typescript-language-server.vim
+++ b/settings/typescript-language-server.vim
@@ -5,7 +5,7 @@ augroup vimlsp_settings_typescript_language_server
       \ 'cmd': {server_info->lsp_settings#get('typescript-language-server', 'cmd', [lsp_settings#exec_path('typescript-language-server'), '--stdio'])},
       \ 'root_uri':{server_info->lsp_settings#get('typescript-language-server', 'root_uri', lsp_settings#root_uri(extend(['package.json', 'tsconfig.json'], g:lsp_settings_root_markers)))},
       \ 'initialization_options': lsp_settings#get('typescript-language-server', 'initialization_options', {"diagnostics": "true"}),
-      \ 'whitelist': lsp_settings#get('typescript-language-server', 'whitelist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact']),
+      \ 'whitelist': lsp_settings#get('typescript-language-server', 'whitelist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact', 'typescript.tsx']),
       \ 'blacklist': lsp_settings#get('typescript-language-server', 'blacklist', []),
       \ 'config': lsp_settings#get('typescript-language-server', 'config', {}),
       \ 'workspace_config': lsp_settings#get('typescript-language-server', 'workspace_config', {}),


### PR DESCRIPTION
These filetypes are in use by a few plugins I maintain, and it would be nice for these configs to just work for them.