### PR TITLE
Check FileType in little later

### DIFF
--- a/autoload/lsp_settings.vim
+++ b/autoload/lsp_settings.vim
@@ -333,8 +333,12 @@ function! s:vim_lsp_suggest_plugin() abort
   endfor
 endfunction
 
+function! s:vim_lsp_load_or_suggest_delay(ft) abort
+  call timer_start(0, {timer -> s:vim_lsp_load_or_suggest(a:ft)})
+endfunction
+
 function! s:vim_lsp_load_or_suggest(ft) abort
-  if !has_key(s:settings, a:ft)
+  if &filetype !=# a:ft || !has_key(s:settings, a:ft)
     return
   endif
 
@@ -431,7 +435,7 @@ function! lsp_settings#init() abort
     endif
     exe 'augroup' lsp_settings#utils#group_name(l:ft)
       autocmd!
-      exe 'autocmd FileType' l:ft printf("call s:vim_lsp_load_or_suggest('%s')", l:ft)
+      exe 'autocmd FileType' l:ft 'call' printf("s:vim_lsp_load_or_suggest_delay('%s')", l:ft)
     augroup END
   endfor
   augroup vim_lsp_suggest

--- a/autoload/lsp_settings.vim
+++ b/autoload/lsp_settings.vim
@@ -341,7 +341,7 @@ function! s:vim_lsp_load_or_suggest_delay(ft) abort
 endfunction
 
 function! s:vim_lsp_load_or_suggest(ft) abort
-  if (a:ft != '_' && &filetype !=# a:ft) || !has_key(s:settings, a:ft)
+  if (a:ft !=# '_' && &filetype !=# a:ft) || !has_key(s:settings, a:ft)
     return
   endif
 

--- a/autoload/lsp_settings.vim
+++ b/autoload/lsp_settings.vim
@@ -334,11 +334,14 @@ function! s:vim_lsp_suggest_plugin() abort
 endfunction
 
 function! s:vim_lsp_load_or_suggest_delay(ft) abort
+  if get(g:, 'vim_lsp_settings_filetype_no_delays', 0)
+    return s:vim_lsp_load_or_suggest(a:ft)
+  endif
   call timer_start(0, {timer -> s:vim_lsp_load_or_suggest(a:ft)})
 endfunction
 
 function! s:vim_lsp_load_or_suggest(ft) abort
-  if &filetype !=# a:ft || !has_key(s:settings, a:ft)
+  if (a:ft != '_' && &filetype !=# a:ft) || !has_key(s:settings, a:ft)
     return
   endif
 

--- a/test/lsp_settings.vimspec
+++ b/test/lsp_settings.vimspec
@@ -88,6 +88,7 @@ Describe lsp_settings
         It should setup commands and autocmds.
             call lsp_settings#clear()
             call lsp_settings#init()
+            let g:vim_lsp_settings_filetype_no_delays = 1
             autocmd vim_lsp_suggest_python
             Assert exists(':LspInstallServer')
             delcommand LspInstallServer
@@ -99,6 +100,7 @@ Describe lsp_settings
                 exe 'augroup! ' . v
             endfor
             bw!
+            unlet g:vim_lsp_settings_filetype_no_delays
         End
 
         It should setup commands and autocmds with python.
@@ -106,6 +108,7 @@ Describe lsp_settings
             call lsp_settings#init()
             new
             let g:lsp_settings = {'pyls': {'cmd': ['foo', 'bar']}}
+            let g:vim_lsp_settings_filetype_no_delays = 1
             Throw /E117/ :setfiletype python
             bw!
             for v in filter(split(execute('augroup'), '\s\+'), 'v:val=~"^vim_lsp_suggest"')
@@ -115,6 +118,7 @@ Describe lsp_settings
                 exe 'augroup! ' . v
             endfor
             unlet g:lsp_settings
+            unlet g:vim_lsp_settings_filetype_no_delays
         End
     End
 End


### PR DESCRIPTION
When open `foo.jl`, vim detect it as be lisp. Eventhough we add julia-syntax plugins, it is too late. Already cl-lsp is  started. This change add chance to modify filetype by syntax plugins.