### PR TITLE
rust-analyzer: add rust-analyzer

### DIFF
--- a/installer/install-rust-analyzer.cmd
+++ b/installer/install-rust-analyzer.cmd
@@ -1,0 +1,5 @@
+@echo off
+
+curl -L -o rust-analyzer-windows.exe "https://github.com/rust-analyzer/rust-analyzer/releases/download/2020-02-18/rust-analyzer-windows.exe"
+
+move rust-analyzer-windows.exe rust-analyzer.exe

--- a/installer/install-rust-analyzer.sh
+++ b/installer/install-rust-analyzer.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+os=$(uname -s | tr "[:upper:]" "[:lower:]")
+
+case $os in
+linux)
+  platform="linux"
+  ;;
+darwin)
+  platform="mac"
+  ;;
+esac
+
+version="2020-02-18"
+curl -L -o ra_lsp_server-$platform "https://github.com/rust-analyzer/rust-analyzer/releases/download/$version/rust-analyzer-$platform"
+
+mv rust-analyzer-$platform rust-analyzer
+chmod +x rust-analyzer

--- a/settings.json
+++ b/settings.json
@@ -467,6 +467,10 @@
       "requires": []
     },
     {
+      "command": "rust-analyzer",
+      "requires": []
+    },
+    {
       "command": "ra_lsp_server",
       "requires": []
     }

--- a/settings/rust-analyzer.vim
+++ b/settings/rust-analyzer.vim
@@ -1,0 +1,13 @@
+augroup vimlsp_settings_rust-analyzer
+  au!
+  LspRegisterServer {
+      \ 'name': 'rust-analyzer',
+      \ 'cmd': {server_info->lsp_settings#get('rust-analyzer', 'cmd', [lsp_settings#exec_path('rust-analyzer')])},
+      \ 'root_uri':{server_info->lsp_settings#get('rust-analyzer', 'root_uri', lsp_settings#root_uri(['Cargo.toml']))},
+      \ 'initialization_options': lsp_settings#get('rust-analyzer', 'initialization_options', v:null),
+      \ 'whitelist': lsp_settings#get('rust-analyzer', 'whitelist', ['rust']),
+      \ 'blacklist': lsp_settings#get('rust-analyzer', 'blacklist', []),
+      \ 'config': lsp_settings#get('rust-analyzer', 'config', lsp_settings#server_config('rust-analyzer')),
+      \ 'workspace_config': lsp_settings#get('rust-analyzer', 'workspace_config', {}),
+      \ }
+augroup END


### PR DESCRIPTION
ref: https://github.com/rust-analyzer/rust-analyzer/pull/3216

I think it's better to keep ra_lsp_server for a while as a user transition period,
so I add rust-analyzer instead of rename.