### PR TITLE
fix installer for eslint-language-server

### DIFF
--- a/installer/install-eslint-language-server.cmd
+++ b/installer/install-eslint-language-server.cmd
@@ -1,14 +1,12 @@
 @echo off
 
-git clone "https://github.com/microsoft/vscode-eslint" .
-git checkout release/2.0.15
-call npm install
-call npm --prefix ./server install ./server
-call npm run compile:server
+curl -L -o "vscode-eslint.vsix" "https://github.com/microsoft/vscode-eslint/releases/download/release%2F2.1.0-next.1/vscode-eslint-2.1.0.vsix"
+call "%~dp0\run_unzip.cmd" vscode-eslint.vsix
+del vscode-eslint.vsix
 
 echo @echo off ^
 
-node %%~dp0\server\out\eslintServer.js --stdio %%* ^
+node %%~dp0\extension\server\out\eslintServer.js --stdio %%* ^
 
 > eslint-language-server.cmd
 

--- a/installer/install-eslint-language-server.sh
+++ b/installer/install-eslint-language-server.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
-git clone "https://github.com/microsoft/vscode-eslint" .
-git checkout release/2.0.15
-npm install
-npm --prefix ./server install ./server
-npm run compile:server
+url="https://github.com/microsoft/vscode-eslint/releases/download/release%2F2.1.0-next.1/vscode-eslint-2.1.0.vsix"
+asset="vscode-eslint.vsix"
+curl -L "$url" -o "$asset"
+unzip "$asset"
+rm "$asset"
 
 cat <<EOF >eslint-language-server
 #!/usr/bin/env bash
 
 DIR=\$(cd \$(dirname \$0); pwd)
-node \$DIR/server/out/eslintServer.js --stdio \$*
+node \$DIR/extension/server/out/eslintServer.js --stdio \$*
 EOF
 
 chmod +x eslint-language-server

--- a/settings.json
+++ b/settings.json
@@ -277,12 +277,10 @@
     {
       "command": "eslint-language-server",
       "requires": [
-        "git",
-        "npm"
+        "node"
       ],
       "root_uri_patterns": [
-        "package.json",
-        "tsconfig.json"
+        "package.json"
       ]
     }
   ],
@@ -293,8 +291,16 @@
         "npm"
       ],
       "root_uri_patterns": [
-        "package.json",
-        "tsconfig.json"
+        "package.json"
+      ]
+    },
+    {
+      "command": "eslint-language-server",
+      "requires": [
+        "node"
+      ],
+      "root_uri_patterns": [
+        "package.json"
       ]
     },
     {
@@ -638,8 +644,7 @@
     {
       "command": "eslint-language-server",
       "requires": [
-        "git",
-        "npm"
+        "node"
       ],
       "root_uri_patterns": [
         "package.json",
@@ -652,6 +657,16 @@
       "command": "typescript-language-server",
       "requires": [
         "npm"
+      ],
+      "root_uri_patterns": [
+        "package.json",
+        "tsconfig.json"
+      ]
+    },
+    {
+      "command": "eslint-language-server",
+      "requires": [
+        "node"
       ],
       "root_uri_patterns": [
         "package.json",

--- a/settings/eslint-language-server.vim
+++ b/settings/eslint-language-server.vim
@@ -5,7 +5,7 @@ augroup vimlsp_settings_eslint_language_server
       \ 'cmd': {server_info->lsp_settings#get('eslint-language-server', 'cmd', [lsp_settings#exec_path('eslint-language-server'), '--stdio'])},
       \ 'root_uri':{server_info->lsp_settings#get('eslint-language-server', 'root_uri', lsp_settings#root_uri('eslint-language-server'))},
       \ 'initialization_options': lsp_settings#get('eslint-language-server', 'initialization_options', {'diagnostics': 'true'}),
-      \ 'whitelist': lsp_settings#get('eslint-language-server', 'whitelist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact', 'typescript.tsx']),
+      \ 'whitelist': lsp_settings#get('eslint-language-server', 'whitelist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact']),
       \ 'blacklist': lsp_settings#get('eslint-language-server', 'blacklist', []),
       \ 'config': lsp_settings#get('eslint-language-server', 'config', lsp_settings#server_config('eslint-language-server')),
       \ 'workspace_config': lsp_settings#get('eslint-language-server', 'workspace_config', {


### PR DESCRIPTION
## Description
- Use pre-built language server (pre-release) https://github.com/microsoft/vscode-eslint/releases/tag/release%2F2.1.0-next.1
- Supports `typescriptreact` and `javascriptreact`.

## Note
- Drop support `typescript.tsx`.
- Remove unnecessary `tsconfig.json` from `root_uri_patterns` for `javascript` and `javascriptreact`.