### PR TITLE
Add semantic_highlight to list of overridable keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Overridable keys are:
 * disabled (Boolean)
 * root_uri (String)
 * root_uri_patterns (List)
+* semantic_highlight (Dictionary)
 
 If you install ruby but not solargraph, you can install solargraph with following command.
 


### PR DESCRIPTION
Add 'semantic_highlight' to the list of keys which can be overriden with
settings for each server.