### PR TITLE
Fix golangci-lint-langserver installer

### DIFF
--- a/installer/install-golangci-lint-langserver.sh
+++ b/installer/install-golangci-lint-langserver.sh
@@ -3,4 +3,4 @@
 set -e
 
 "$(dirname "$0")/go_install.sh" github.com/nametake/golangci-lint-langserver@latest
-"$(dirname "$0")/go_install.sh" github.com/golangci/golangci-lint/cmd/golang-lint@latest
+"$(dirname "$0")/go_install.sh" github.com/golangci/golangci-lint/cmd/golangci-lint@latest


### PR DESCRIPTION
Hi, thanks for the nice plugin.
I noticed we can't install golangci-lint-langserver.

It is because the installation file have not permission and wrong path.