### PR TITLE
fix css-languageserver setting for scss filetype

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -556,6 +556,14 @@
       ]
     }
   ],
+  "scss": [
+    {
+      "command": "css-languageserver",
+      "requires": [
+        "npm"
+      ]
+    }
+  ],
   "scala": [
     {
       "command": "metals",

--- a/settings/css-languageserver.vim
+++ b/settings/css-languageserver.vim
@@ -5,13 +5,14 @@ augroup vim_lsp_settings_css_languageserver
       \ 'cmd': {server_info->lsp_settings#get('css-languageserver', 'cmd', [lsp_settings#exec_path('css-languageserver'), '--stdio'])},
       \ 'root_uri':{server_info->lsp_settings#get('css-languageserver', 'root_uri', lsp_settings#root_uri('css-languageserver'))},
       \ 'initialization_options': lsp_settings#get('css-languageserver', 'initialization_options', v:null),
-      \ 'whitelist': lsp_settings#get('css-languageserver', 'whitelist', ['css', 'less', 'sass']),
+      \ 'whitelist': lsp_settings#get('css-languageserver', 'whitelist', ['css', 'less', 'sass', 'scss']),
       \ 'blacklist': lsp_settings#get('css-languageserver', 'blacklist', []),
       \ 'config': lsp_settings#get('css-languageserver', 'config', lsp_settings#server_config('css-languageserver')),
       \ 'workspace_config': lsp_settings#get('css-languageserver', 'workspace_config', {
       \   'css': {'lint': {'validProperties': []}},
       \   'less': {'lint': {'validProperties': []}},
       \   'sass': {'lint': {'validProperties': []}},
+      \   'scss': {'lint': {'validProperties': []}},
       \ }),
       \ 'semantic_highlight': lsp_settings#get('css-languageserver', 'semantic_highlight', {}),
       \ }


### PR DESCRIPTION
Hello, thank you for the awesome plugin.
I noticed css-langserver doesn't work when we edit *.scss files.
If set filetype to "sass" in *.scss, the file is treated as the different syntax from the scss syntax.

This pull request just adds scss filetype to some setting files.