### PR TITLE
Add vscode-css-languageserver-bin to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Because no way to update server, please run `:LspInstallServer` again, newer ver
 | C/C++            | clangd                                                 | Yes           |
 | C#               | omnisharp                                              | Yes           |
 | Clojure          | clojure-lsp                                            | Yes           |
+| CSS              | vscode-css-languageserver-bin                          | Yes           |
 | TypeScript       | typescript-language-server                             | Yes           |
 | TypeScript       | eslint-language-server                                 | Yes           |
 | JavaScript       | typescript-language-server                             | Yes           |


### PR DESCRIPTION
vim-lsp-settings supports vscode-css-languageserver-bin out of the box! Let's document this in README.