### PR TITLE
Update pyls-ms: 0.5.45

### DIFF
--- a/installer/install-pyls-ms.cmd
+++ b/installer/install-pyls-ms.cmd
@@ -5,7 +5,7 @@ setlocal
 curl -L -o dotnet-runtime-3.1.1-win-x64.zip "https://download.visualstudio.microsoft.com/download/pr/d9768135-4646-4839-9eea-b404bb940452/8275e4320514bab636b1627c62906ef9/dotnet-runtime-3.1.1-win-x64.zip"
 call "%~dp0\run_unzip.cmd" dotnet-runtime-3.1.1-win-x64.zip
 
-set version=0.5.31
+set version=0.5.45
 set url=https://pvsc.blob.core.windows.net/python-language-server-stable/Python-Language-Server-win-x64.%version%.nupkg
 
 set nupkg=./pyls.nupkg

--- a/installer/install-pyls-ms.sh
+++ b/installer/install-pyls-ms.sh
@@ -17,7 +17,7 @@ darwin)
 *) ;;
 esac
 
-version="0.5.31"
+version="0.5.45"
 url="https://pvsc.azureedge.net/python-language-server-stable/Python-Language-Server-${system}-x64.${version}.nupkg"
 
 nupkg="./pyls.nupkg"


### PR DESCRIPTION
## Description

MPLS(Microsoft Python Language Server) released 0.5.45 on stable channel.

## Ref

### Download link

**osx**

https://pvsc.blob.core.windows.net/python-language-server-stable/Python-Language-Server-osx-x64.0.5.45.nupkg

**win**

https://pvsc.blob.core.windows.net/python-language-server-stable/Python-Language-Server-win-x64.0.5.45.nupkg

**linux**

https://pvsc.blob.core.windows.net/python-language-server-stable/Python-Language-Server-linux-x64.0.5.45.nupkg

### XML

**osx**

https://pvsc.blob.core.windows.net/python-language-server-stable?restype=container&comp=list&prefix=Python-Language-Server-osx-x64

**win**

https://pvsc.blob.core.windows.net/python-language-server-stable?restype=container&comp=list&prefix=Python-Language-Server-win-x64

**linux**

https://pvsc.blob.core.windows.net/python-language-server-stable?restype=container&comp=list&prefix=Python-Language-Server-linux-x64