### PR TITLE
Fix dls installer for Windows

### DIFF
--- a/installer/install-dls.cmd
+++ b/installer/install-dls.cmd
@@ -1,5 +1,5 @@
 @echo off
 
 curl -L -o dls-v0.26.0.windows.x86_64.zip https://github.com/d-language-server/dls/releases/download/v0.26.0/dls-v0.26.0.windows.x86_64.zip"
-call %installer_dir%\run_unzip dls-v0.26.0.windows.x86_64.zip
+call "%~dp0\run_unzip.cmd" dls-v0.26.0.windows.x86_64.zip
 del dls-v0.26.0.windows.x86_64.zip


### PR DESCRIPTION
Hello, thank you for the awesome plugin.
I noticed dls installer doesn't work on Windows.

It is because the installation file refer to undefined environment variable.