### PR TITLE
Fix lsp_settings#root_path is not using arguments

### DIFF
--- a/autoload/lsp_settings.vim
+++ b/autoload/lsp_settings.vim
@@ -177,9 +177,9 @@ function! lsp_settings#exec_path(cmd) abort
   return ''
 endfunction
 
-function! lsp_settings#root_path(name) abort
-  let l:patterns = get(a:000, 0, [])
-  return lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), extend(l:patterns, g:lsp_settings_root_markers))
+function! lsp_settings#root_path(patterns) abort
+  let l:patterns = extend(copy(a:patterns), g:lsp_settings_root_markers)
+  return lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), l:patterns)
 endfunction
 
 function! lsp_settings#root_uri(name) abort

--- a/test/lsp_settings.vimspec
+++ b/test/lsp_settings.vimspec
@@ -121,4 +121,38 @@ Describe lsp_settings
             unlet g:vim_lsp_settings_filetype_no_delays
         End
     End
+
+    Describe lsp_settings#root_path
+        It should return full-path to the directory that contains one of args
+            if empty(globpath(&rtp, 'autoload/lsp/utils.vim'))
+                Skip vim-lsp plugin required, use --runtimepath {path-to-plugin-dir}
+            endif
+            let s:_saved_lsp_settings_root_markers = g:lsp_settings_root_markers
+            let g:lsp_settings_root_markers = []
+            try
+                new autoload/testbuffer
+                Assert Equal(lsp_settings#root_path(['lsp_settings/']), expand('%:p:h'))
+                Assert Equal(lsp_settings#root_path(['README.md']), expand('%:p:h:h'))
+                Assert Equal(lsp_settings#root_path(['not exist file name', 'README.md']), expand('%:p:h:h'))
+            finally
+                bwipe! autoload/testbuffer
+                let g:lsp_settings_root_markers = s:_saved_lsp_settings_root_markers
+            endtry
+        End
+
+        It should return '' when directory not found
+            if empty(globpath(&rtp, 'autoload/lsp/utils.vim'))
+                Skip vim-lsp plugin required, use --runtimepath {path-to-plugin-dir}
+            endif
+            let s:_saved_lsp_settings_root_markers = g:lsp_settings_root_markers
+            let g:lsp_settings_root_markers = []
+            try
+                new autoload/testbuffer
+                Assert Empty(lsp_settings#root_path(['not exist file name']))
+            finally
+                bwipe! autoload/testbuffer
+                let g:lsp_settings_root_markers = s:_saved_lsp_settings_root_markers
+            endtry
+        End
+    End
 End


### PR DESCRIPTION
The arguments of `lsp_settings#root_path` is not used. Fix it.

The function is used in: https://github.com/mattn/vim-lsp-settings/blob/f361e8e88cc6c130885c3ae24991415cfcc649d1/autoload/lsp_settings/profile.vim#L36
However, it always returned project root directory by `g:lsp_settings_root_markers` because this bug.