### PR TITLE
fix lemminx installer

### DIFF
--- a/installer/install-lemminx.sh
+++ b/installer/install-lemminx.sh
@@ -2,17 +2,26 @@
 
 set -e
 
-# See https://repo.eclipse.org/content/repositories/lemminx-snapshots/org/eclipse/org.eclipse.lemminx/
-version="0.11.0"
-url="https://repo.eclipse.org/content/repositories/lemminx-snapshots/org/eclipse/org.eclipse.lemminx/0.11.0-SNAPSHOT/org.eclipse.lemminx-0.11.0-20200309.180941-1-uber.jar"
+# Latest version is available on https://repo.eclipse.org/content/repositories/lemminx-snapshots/org/eclipse/org.eclipse.lemminx/.
+# But the lemminx snapshot jar on repo.eclipse.org seems to be obsolete when a new version is released.
+# To avoid confusion, this script refers to lemminx bundled with vscode-xml.
 
-curl -L "$url" -o "org.eclipse.lemminx-${version}-uber.jar"
+vscode_xml_version="0.11.0"
+lemminx_version="0.11.1"
+url="https://github.com/redhat-developer/vscode-xml/releases/download/${vscode_xml_version}/redhat.vscode-xml-${vscode_xml_version}.vsix"
+extention="redhat.vscode-xml-${vscode_xml_version}.vsix"
+lemminx_jar="org.eclipse.lemminx-${lemminx_version}-uber.jar"
+
+curl -L "$url" -o "$extention"
+unzip -d vscode-xml "$extention"
+rm "$extention"
+ln -s "vscode-xml/extension/server/${lemminx_jar}" .
 
 cat <<EOF >lemminx
 #!/usr/bin/env bash
 
 DIR=\$(cd \$(dirname \$0); pwd)
-java -jar \$DIR/org.eclipse.lemminx-${version}-uber.jar
+java -jar \$DIR/${lemminx_jar}
 EOF
 
 chmod +x lemminx


### PR DESCRIPTION
Latest lemminx jar is available on https://repo.eclipse.org/content/repositories/lemminx-snapshots/org/eclipse/org.eclipse.lemminx/.
But the lemminx snapshot jar on repo.eclipse.org seems to be obsolete when a new version is released.

To avoid confusion, installer refers to lemminx bundled with vscode-xml.
https://github.com/redhat-developer/vscode-xml/releases

The installer for windows is also probably broken, but I'm sorry I don't have a windows environment to debug.