### PR TITLE
Upgrade elixir-ls

### DIFF
--- a/installer/install-elixir-ls.cmd
+++ b/installer/install-elixir-ls.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-curl -L -o elixir-ls.zip "https://github.com/JakeBecker/elixir-ls/releases/download/v0.2.25/elixir-ls.zip"
+curl -L -o elixir-ls.zip "https://github.com/elixir-lsp/elixir-ls/releases/download/v0.3.3/elixir-ls.zip"
 call "%~dp0\run_unzip.cmd" elixir-ls.zip
 del elixir-ls.zip
 

--- a/installer/install-elixir-ls.sh
+++ b/installer/install-elixir-ls.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-version="v0.2.25"
-url="https://github.com/JakeBecker/elixir-ls/releases/download/$version/elixir-ls.zip"
+version="v0.3.3"
+url="https://github.com/elixir-lsp/elixir-ls/releases/download/$version/elixir-ls.zip"
 curl -LO "$url"
 unzip elixir-ls.zip
 rm elixir-ls.zip


### PR DESCRIPTION
Now elixir-ls move to new repository [1]. So this changes change the
download path and bump to a new version (v0.3.3).

[1] https://github.com/elixir-lsp/elixir-ls

Close #215