### PR TITLE
Load extra schemas

### DIFF
--- a/autoload/lsp_settings/utils.vim
+++ b/autoload/lsp_settings/utils.vim
@@ -54,3 +54,11 @@ function! lsp_settings#utils#dotmerge(d) abort
   endfor
   return l:ret
 endfunction
+
+let s:catalog_path = expand('<sfile>:h:h:h') . '/data/catalog.json'
+
+function! lsp_settings#utils#load_schemas(name) abort
+  let l:schemas = json_decode(join(readfile(s:catalog_path), "\n"))['schemas']
+  let g:hoge = l:schemas
+  return extend(l:schemas, lsp_settings#get(a:name, 'schemas', []))
+endfunction

--- a/doc/vim-lsp-settings.txt
+++ b/doc/vim-lsp-settings.txt
@@ -102,11 +102,11 @@ and put schemas property like below:
      "schemas": [
        {
          "fileMatch":["my-config.yaml"],
-         "url": "https://example.com/my-config-schema.json'
+         "url": "https://example.com/my-config-schema.json"
        },
        {
          "fileMatch":["your-config.yaml"],
-         "url": "https://example.com/your-config-schema.json'
+         "url": "https://example.com/your-config-schema.json"
        }
      ]
    }

--- a/doc/vim-lsp-settings.txt
+++ b/doc/vim-lsp-settings.txt
@@ -90,6 +90,28 @@ script. You can modify configuration like below:
  \    }
  \  },
  \}
+
 <
+If you want to add extra schemas for yaml-language-server or
+json-language-server, do |:LspSettingsLocalEdit| or |:LspSettingsGlobalEdit|
+and put schemas property like below:
+
+>
+ {
+   "yaml-language-server": {
+     "schemas": [
+       {
+         "fileMatch":["my-config.yaml"],
+         "url": "https://example.com/my-config-schema.json'
+       },
+       {
+         "fileMatch":["your-config.yaml"],
+         "url": "https://example.com/your-config-schema.json'
+       }
+     ]
+   }
+ }
+<
+
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:noet:fen:fdl=0:

--- a/settings/json-languageserver.vim
+++ b/settings/json-languageserver.vim
@@ -8,7 +8,7 @@ augroup vim_lsp_settings_json_languageserver
       \ 'whitelist': lsp_settings#get('json-languageserver', 'whitelist', ['json', 'jsonc']),
       \ 'blacklist': lsp_settings#get('json-languageserver', 'blacklist', []),
       \ 'config': lsp_settings#get('json-languageserver', 'config', lsp_settings#server_config('json-languageserver')),
-      \ 'workspace_config': lsp_settings#get('json-languageserver', 'workspace_config', {name, key->{'json': {'format': {'enable': v:true}, 'schemas': json_decode(join(readfile(expand('<sfile>:h:h') . '/data/catalog.json'), "\n"))['schemas'] + [{'fileMatch':['/.vim-lsp-settings/settings.json'], 'url': 'https://mattn.github.io/vim-lsp-settings/local-schema.json'}]}}}),
+      \ 'workspace_config': lsp_settings#get('json-languageserver', 'workspace_config', {name, key->{'json': {'format': {'enable': v:true}, 'schemas': lsp_settings#utils#load_schemas('json-language-server') + [{'fileMatch':['/.vim-lsp-settings/settings.json'], 'url': 'https://mattn.github.io/vim-lsp-settings/local-schema.json'}]}}}),
       \ 'semantic_highlight': lsp_settings#get('json-languageserver', 'semantic_highlight', {}),
       \ }
 augroup END

--- a/settings/yaml-language-server.vim
+++ b/settings/yaml-language-server.vim
@@ -8,7 +8,7 @@ augroup vim_lsp_settings_yaml_language_server
       \ 'whitelist': lsp_settings#get('yaml-language-server', 'whitelist', ['yaml']),
       \ 'blacklist': lsp_settings#get('yaml-language-server', 'blacklist', []),
       \ 'config': lsp_settings#get('yaml-language-server', 'config', lsp_settings#server_config('yaml-language-server')),
-      \ 'workspace_config': lsp_settings#get('yaml-language-server', 'workspace_config', {name, key->{'json': {'format': {'enable': v:true}, 'schemas': json_decode(join(readfile(expand('<sfile>:h:h') . '/data/catalog.json'), "\n"))['schemas']}}}),
+      \ 'workspace_config': lsp_settings#get('yaml-language-server', 'workspace_config', {name, key->{'json': {'format': {'enable': v:true}, 'schemas': lsp_settings#utils#load_schemas('yaml-language-server')}}}),
       \ 'semantic_highlight': lsp_settings#get('yaml-language-server', 'semantic_highlight', {}),
       \ }
 augroup END


### PR DESCRIPTION
If you want to add extra schemas for `yaml-language-server` or
`json-language-server`, do `:LspSettingsLocalEdit` or `:LspSettingsGlobalEdit`
and put schemas property like below:

```json
 {
   "yaml-language-server": {
     "schemas": [
       {
         "fileMatch":["my-config.yaml"],
         "url": "https://example.com/my-config-schema.json"
       },
       {
         "fileMatch": ["your-config.yaml"],
         "url": "https://example.com/your-config-schema.json"
       }
     ]
   }
 }
```