### PR TITLE
Can specify the project root directry

### DIFF
--- a/autoload/lsp_settings/profile.vim
+++ b/autoload/lsp_settings/profile.vim
@@ -32,8 +32,14 @@ function! lsp_settings#profile#edit_global() abort
   endif
 endfunction
 
-function! lsp_settings#profile#edit_local() abort
-  let l:root = lsp_settings#root_path(['.vim-lsp-settings'])
+function! lsp_settings#profile#edit_local(...) abort
+  let l:root = ''
+  if a:0 >= 1
+    let l:root = a:1
+  endif
+  if l:root ==# ''
+    let l:root = lsp_settings#root_path(['.vim-lsp-settings'])
+  endif
   if !isdirectory(l:root)
     return
   endif

--- a/plugin/lsp_settings.vim
+++ b/plugin/lsp_settings.vim
@@ -12,7 +12,7 @@ let g:lsp_settings_root_markers = get(g:, 'lsp_settings_root_markers', [
       \ ])
 
 command! -nargs=0 LspSettingsStatus call lsp_settings#profile#status()
-command! -nargs=0 LspSettingsLocalEdit call lsp_settings#profile#edit_local()
+command! -nargs=? LspSettingsLocalEdit call lsp_settings#profile#edit_local(<f-args>)
 command! -nargs=0 LspSettingsGlobalEdit call lsp_settings#profile#edit_global()
 
 call lsp_settings#init()


### PR DESCRIPTION
`:LspSettingsLocalEdit` will automatically find the project root if the project is under the control of VCS. However, if my project is not under the control of VCS, I want to specify the project root manually.
For this purpose, I added an argument to `:LspSettingsLocalEdit` to specify the project root.