### PR TITLE
Add root_uri_patterns for elixir-ls setting

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -107,6 +107,9 @@
       "requires": [
         "elixir"
       ],
+      "root_uri_patterns":[
+        "mix.exs"
+      ],
       "vim_plugin": {
         "extensions": [
           "ex",


### PR DESCRIPTION
This changes add mix.exs to elixir-ls root_uri_patterns setting to
detect elixir project for who's working with multi elixir projects
within a single repository.