### PR TITLE
default to rust-analyzer for rust

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -537,14 +537,14 @@
   ],
   "rust": [
     {
-      "command": "rls",
+      "command": "rust-analyzer",
       "requires": [],
       "root_uri_patterns": [
         "Cargo.toml"
       ]
     },
     {
-      "command": "rust-analyzer",
+      "command": "rls",
       "requires": [],
       "root_uri_patterns": [
         "Cargo.toml"


### PR DESCRIPTION
Based on this blog we should make it the default. https://rust-analyzer.github.io/blog/2020/04/20/first-release.html

Merge this first. https://github.com/mattn/vim-lsp-settings/pull/226

I have been using rust-analyzer over rls for months and prefer it.

https://github.com/rust-lang/rfcs/pull/2912 will also replace rust-analyzer as official LSP implementation of rust.