### PR TITLE
update omnisharp-roslyn to v1.35.2

### DIFF
--- a/installer/install-omnisharp-lsp.cmd
+++ b/installer/install-omnisharp-lsp.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-curl -L -o omnisharp-win-x64.zip "https://github.com/OmniSharp/omnisharp-roslyn/releases/download/v1.35.3/omnisharp-win-x64.zip"
+curl -L -o omnisharp-win-x64.zip "https://github.com/OmniSharp/omnisharp-roslyn/releases/download/v1.35.2/omnisharp-win-x64.zip"
 call "%~dp0\run_unzip.cmd" omnisharp-win-x64.zip
 del omnisharp-win-x64.zip
 

--- a/installer/install-omnisharp-lsp.sh
+++ b/installer/install-omnisharp-lsp.sh
@@ -17,7 +17,7 @@ darwin)
   ;;
 esac
 
-version="v1.35.3"
+version="v1.35.2"
 url="https://github.com/OmniSharp/omnisharp-roslyn/releases/download/$version/omnisharp-$os$arch.tar.gz"
 curl -L "$url" | tar xz
 


### PR DESCRIPTION
Sorry, #244 was a mistake. v1.35.3 doesn't exists yet and v1.35.2 is the right latest version.