### PR TITLE
Fix powershell-languageserver error on windows

### DIFF
--- a/installer/install-powershell-languageserver.cmd
+++ b/installer/install-powershell-languageserver.cmd
@@ -7,14 +7,14 @@ call "%~dp0\run_unzip.cmd" PowerShellEditorServices.zip
 del PowerShellEditorServices.zip
 mkdir %~dp0session
 
-echo @echo off ^
+echo @echo off^
 
-setlocal ^
+setlocal^
 
-set PSES_BUNDLE_PATH=%%~dp0PowerShellEditorServices ^
+set PSES_BUNDLE_PATH=%%~dp0PowerShellEditorServices^
 
-set SESSION_TEMP_PATH=%%~dp0session ^
+set SESSION_TEMP_PATH=%%~dp0session^
 
-powershell -NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command "%%PSES_BUNDLE_PATH:\=/%%/PowerShellEditorServices/Start-EditorServices.ps1 -BundledModulesPath %%PSES_BUNDLE_PATH:\=/%% -LogPath %%SESSION_TEMP_PATH:\=/%%/logs.log -SessionDetailsPath %%SESSION_TEMP_PATH:\=/%%/session.json -FeatureFlags @() -AdditionalModules @() -HostName 'My Client' -HostProfileId 'myclient' -HostVersion 1.0.0 -Stdio -LogLevel Normal" ^
+powershell -NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command "%%PSES_BUNDLE_PATH:\=/%%/PowerShellEditorServices/Start-EditorServices.ps1 -BundledModulesPath %%PSES_BUNDLE_PATH:\=/%% -LogPath %%SESSION_TEMP_PATH:\=/%%/logs.log -SessionDetailsPath %%SESSION_TEMP_PATH:\=/%%/session.json -FeatureFlags @() -AdditionalModules @() -HostName 'My Client' -HostProfileId 'myclient' -HostVersion 1.0.0 -Stdio -LogLevel Normal"^
 
 > powershell-languageserver.cmd


### PR DESCRIPTION
Currently, powershell-languageserver failed to launch with messages below:

```
%LocalAppData%/vim-lsp-settings/servers/powershell-languageserver/PowerShellEditorServices : 用語 '%LocalAppData%/vim-lsp-settings/servers/powershell-languageserver/PowerShellEditorServices' は、コマンド
レット、関数、スクリプト ファイル、または操作可能なプログラムの名前として認識されません。名前が正しく記述されていること
を確認し、パスが含まれている場合はそのパスが正しいことを確認してから、再試行してください。
発生場所 行:1 文字:1
+ C:/Users/<user>/AppData/Local/vim-lsp-settings/servers/powershell-l ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:/Users/<user>...lEditorServices:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
```

This is caused by the trailing whitespaces in the launcher batch file:
``` dosbatch
set PSES_BUNDLE_PATH=%~dp0PowerShellEditorServices 
set SESSION_TEMP_PATH=%~dp0session 
```
Because both of the environmental variables include whitespace at the end of the value, the environmental value expansion includes whitespaces in the command line arguments.

This PR fixes it.