### PR TITLE
Introduce g:lsp_settings_disable_suggestions

### DIFF
--- a/autoload/lsp_settings.vim
+++ b/autoload/lsp_settings.vim
@@ -477,7 +477,7 @@ function! s:vim_lsp_load_or_suggest(ft) abort
   delcommand LspRegisterServer
 
   if l:disabled == 0 && l:found ==# 0
-    if a:ft !=# '_' && get(g:, 'lsp_settings_enable_suggestions') == 1
+    if a:ft !=# '_' && get(g:, 'lsp_settings_enable_suggestions', 1) == 1
       call s:vim_lsp_settings_suggest(a:ft)
     endif
   else

--- a/autoload/lsp_settings.vim
+++ b/autoload/lsp_settings.vim
@@ -477,7 +477,7 @@ function! s:vim_lsp_load_or_suggest(ft) abort
   delcommand LspRegisterServer
 
   if l:disabled == 0 && l:found ==# 0
-    if a:ft !=# '_'
+    if a:ft !=# '_' && get(g:, 'lsp_settings_disable_suggestions') != 1
       call s:vim_lsp_settings_suggest(a:ft)
     endif
   else

--- a/autoload/lsp_settings.vim
+++ b/autoload/lsp_settings.vim
@@ -477,7 +477,7 @@ function! s:vim_lsp_load_or_suggest(ft) abort
   delcommand LspRegisterServer
 
   if l:disabled == 0 && l:found ==# 0
-    if a:ft !=# '_' && get(g:, 'lsp_settings_disable_suggestions') != 1
+    if a:ft !=# '_' && get(g:, 'lsp_settings_enable_suggestions') == 1
       call s:vim_lsp_settings_suggest(a:ft)
     endif
   else

--- a/doc/vim-lsp-settings.txt
+++ b/doc/vim-lsp-settings.txt
@@ -124,10 +124,9 @@ and put schemas property like below:
 
 					  *g:lsp_settings_enable_suggestions*
 g:lsp_settings_enable_suggestions
-  Default: 0
-  Set 1 if you'd like to get "Please do :LspInstallServer to enable Language
-  Server" suggestion messages when you open a file with its filetype not being
-  supposed by installed items.
+  Default: 1
+  Set 0 only if you'd like to opt-out "Please do :LspInstallServer to enable
+  Language Server" suggestion messages.
 
 :LspSettingsLocalEdit [root]                           *:LspSettingsLocalEdit*
   Edit local settings. Accepts an optional explicit [root] directory that

--- a/doc/vim-lsp-settings.txt
+++ b/doc/vim-lsp-settings.txt
@@ -122,10 +122,12 @@ and put schemas property like below:
  }
 <
 
-					  *g:lsp_settings_disable_suggestions*
-g:lsp_settings_disable_suggestions
-  Set 1 only if you'd like to opt-out "Please do :LspInstallServer to enable
-  Language Server" suggestion messages.
+					  *g:lsp_settings_enable_suggestions*
+g:lsp_settings_enable_suggestions
+  Default: 0
+  Set 1 if you'd like to get "Please do :LspInstallServer to enable Language
+  Server" suggestion messages when you open a file with its filetype not being
+  supposed by installed items.
 
 :LspSettingsLocalEdit [root]                           *:LspSettingsLocalEdit*
   Edit local settings. Accepts an optional explicit [root] directory that

--- a/doc/vim-lsp-settings.txt
+++ b/doc/vim-lsp-settings.txt
@@ -122,6 +122,11 @@ and put schemas property like below:
  }
 <
 
+					  *g:lsp_settings_disable_suggestions*
+g:lsp_settings_disable_suggestions
+  Set 1 only if you'd like to opt-out "Please do :LspInstallServer to enable
+  Language Server" suggestion messages.
+
 :LspSettingsLocalEdit [root]                           *:LspSettingsLocalEdit*
   Edit local settings. Accepts an optional explicit [root] directory that
   contains the .vim-lsp-settings config directory.


### PR DESCRIPTION
* Problem: When you use lsp for certain filetypes, you see
  "Please do :LspInstallServer to enable Language Server" message
  every time when you open a file that you don't need lsp supports.
  It's hard to disable all the possible filetypes but the one
  you use.
* Solution: Provide a way to opt-out the messages.