### PR TITLE
Fix install-elm-language-server.sh

### DIFF
--- a/installer/install-elm-language-server.sh
+++ b/installer/install-elm-language-server.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-"$(dirname "$0")/npm_install.sh" elm-languageserver "@elm-tooling/elm-language-server"
+"$(dirname "$0")/npm_install.sh" elm-language-server "@elm-tooling/elm-language-server"

--- a/settings/elm-language-server.vim
+++ b/settings/elm-language-server.vim
@@ -2,7 +2,7 @@ augroup vim_lsp_settings_elm_language_server
   au!
   LspRegisterServer {
       \ 'name': 'elm-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('elm-language-server', 'cmd', [lsp_settings#exec_path('elm-language-server')])},
+      \ 'cmd': {server_info->lsp_settings#get('elm-language-server', 'cmd', [lsp_settings#exec_path('elm-language-server'), '--stdio'])},
       \ 'root_uri':{server_info->lsp_settings#get('elm-language-server', 'root_uri', lsp_settings#root_uri('elm-language-server'))},
       \ 'initialization_options': lsp_settings#get('elm-language-server', 'initialization_options', {'elmPath': 'elm', 'runtime': 'node', 'elmFormatPath': 'elm-format', 'elmTestPath': 'elm-test'}),
       \ 'allowlist': lsp_settings#get('elm-language-server', 'allowlist', ['elm', 'elm.tsx']),


### PR DESCRIPTION
This PR has two changes

1. `LspInstallServer` for Elm succeeds, but vim-lsp fails in starting LSP for Elm, because the name used in linking is different.
2. `elm-language-server` has to run with `--stdio` option in order to work with clients.