### PR TITLE
feat: add haskell ide engine(hie) for haskell

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Because there is no way to update a server, please run `:LspInstallServer` again
 | SystemVerilog    | svls                                                   | Yes           |
 | Apex/VisualForce | apex-jorje-lsp                                         | Yes           |
 | *                | efm-langserver                                         | Yes           |
+| Haskell          | haskell-ide-engine                                     | No            |
 
 ## Notes
 
@@ -172,6 +173,11 @@ $ npm install @playlyfe/gql --save-dev
 If you have a separate existing installation of the dart analysis server and
 want it to be used, it must either exist in your path, or you must specify its
 location. See 'Configurations' below.
+
+### [haskell ide engine](https://github.com/haskell/haskell-ide-engine) (Haskell)
+
+If you installed hie with stack, you can use hie without configurations.
+But if you have not installed hie yet, you can install it by following [these steps](https://github.com/haskell/haskell-ide-engine#installation).
 
 ## Configurations
 

--- a/settings.json
+++ b/settings.json
@@ -134,7 +134,7 @@
       "requires": [
         "elixir"
       ],
-      "root_uri_patterns":[
+      "root_uri_patterns": [
         "mix.exs"
       ],
       "vim_plugin": {
@@ -270,6 +270,18 @@
       ],
       "root_uri_patterns": [
         "build.gradle"
+      ]
+    }
+  ],
+  "haskell": [
+    {
+      "command": "hie",
+      "requires": [
+        "stack"
+      ],
+      "root_uri_patterns": [
+        "stack.yaml",
+        "package.yaml"
       ]
     }
   ],

--- a/settings/hie.vim
+++ b/settings/hie.vim
@@ -1,0 +1,14 @@
+augroup vim_lsp_settings_hie
+  au!
+  LspRegisterServer {
+      \ 'name': 'hie',
+      \ 'cmd': {server_info->lsp_settings#get('hie', 'cmd', [lsp_settings#exec_path('hie-wrapper'), "--lsp"])},
+      \ 'root_uri':{server_info->lsp_settings#get('hie', 'root_uri', lsp_settings#root_uri('hie'))},
+      \ 'initialization_options': lsp_settings#get('hie', 'initialization_options', v:null),
+      \ 'allowlist': lsp_settings#get('hie', 'allowlist', ['haskell']),
+      \ 'blocklist': lsp_settings#get('hie', 'blocklist', []),
+      \ 'config': lsp_settings#get('hie', 'config', lsp_settings#server_config('hie')),
+      \ 'workspace_config': lsp_settings#get('hie', 'workspace_config', {}),
+      \ 'semantic_highlight': lsp_settings#get('hie', 'semantic_highlight', {}),
+      \ }
+augroup END


### PR DESCRIPTION
did not provide a installation script since it should be installed from source on most OS which is
quite complicated and takes a lot of time