### PR TITLE
Add pyls-all language server (installs pyls with its dependencies)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ Because there is no way to update a server, please run `:LspInstallServer` again
 | JavaScript       | typescript-language-server                             | Yes           |
 | JavaScript       | javascript-typescript-stdio                            | Yes           |
 | JavaScript       | eslint-language-server                                 | Yes           |
-| Python           | pyls                                                   | Yes           |
+| Python           | pyls-all (pyls with dependencies)                      | Yes           |
+| Python           | pyls (pyls without dependencies)                       | Yes           |
 | Python           | pyls-ms (Microsoft Version)                            | Yes           |
 | Python           | jedi-language-server                                   | Yes           |
 | Rust             | rls                                                    | No            |

--- a/installer/install-pyls-all.cmd
+++ b/installer/install-pyls-all.cmd
@@ -1,0 +1,4 @@
+@echo off
+
+call "%~dp0\pip_install.cmd" pyls "python-language-server[all]"
+move pyls pyls-all

--- a/installer/install-pyls-all.sh
+++ b/installer/install-pyls-all.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+
+"$(dirname "$0")/pip_install.sh" pyls 'python-language-server[all]'
+mv pyls pyls-all

--- a/installer/install-pyls.sh
+++ b/installer/install-pyls.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-"$(dirname "$0")/pip_install.sh" pyls python-language-server
+"$(dirname "$0")/pip_install.sh" pyls 'python-language-server[all]'

--- a/installer/install-pyls.sh
+++ b/installer/install-pyls.sh
@@ -3,4 +3,3 @@
 set -e
 
 "$(dirname "$0")/pip_install.sh" pyls 'python-language-server[all]'
-"$(dirname "$0")/pip_install.sh" pyls-isort pyls-isort

--- a/installer/install-pyls.sh
+++ b/installer/install-pyls.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-"$(dirname "$0")/pip_install.sh" pyls 'python-language-server[all]'
+"$(dirname "$0")/pip_install.sh" pyls python-language-server

--- a/installer/install-pyls.sh
+++ b/installer/install-pyls.sh
@@ -3,3 +3,4 @@
 set -e
 
 "$(dirname "$0")/pip_install.sh" pyls 'python-language-server[all]'
+"$(dirname "$0")/pip_install.sh" pyls-isort pyls-isort

--- a/settings.json
+++ b/settings.json
@@ -524,6 +524,18 @@
   ],
   "python": [
     {
+      "command": "pyls-all",
+      "requires": [
+        "py"
+      ]
+    },
+    {
+      "command": "pyls-all",
+      "requires": [
+        "python3"
+      ]
+    },
+    {
       "command": "pyls",
       "requires": [
         "py"

--- a/settings/pyls-all.vim
+++ b/settings/pyls-all.vim
@@ -1,0 +1,14 @@
+augroup vim_lsp_settings_pyls_all
+  au!
+  LspRegisterServer {
+      \ 'name': 'pyls-all',
+      \ 'cmd': {server_info->lsp_settings#get('pyls-all', 'cmd', [lsp_settings#exec_path('pyls-all')])},
+      \ 'root_uri':{server_info->lsp_settings#get('pyls-all', 'root_uri', lsp_settings#root_uri('pyls-all'))},
+      \ 'initialization_options': lsp_settings#get('pyls-all', 'initialization_options', v:null),
+      \ 'allowlist': lsp_settings#get('pyls-all', 'allowlist', ['python']),
+      \ 'blocklist': lsp_settings#get('pyls-all', 'blocklist', []),
+      \ 'config': lsp_settings#get('pyls-all', 'config', lsp_settings#server_config('pyls-all')),
+      \ 'workspace_config': lsp_settings#get('pyls-all', 'workspace_config', {}),
+      \ 'semantic_highlight': lsp_settings#get('pyls-all', 'semantic_highlight', {}),
+      \ }
+augroup END


### PR DESCRIPTION
In the current settings, vim-lsp-settings only installs pyls.
The function of pyls is limited unless its dependencies: Rope, Pyflakes, McCabe, pycodestyle, pydocstyle, autopep8, YAPF. (See [Installation](https://github.com/palantir/python-language-server#installation))

pyls searches those dependencies in its `sys.path`. When pyls is installed into a venv (as vim-lsp-settings does), its dependencies must be installed to the same venv if you want to use their functions.
vim-lsp-settings only installs pyls to a venv, not with its dependencies. In this situation, you can jump to the definition and hover the hint, but you can neither lint nor format the code.

This PR enables users to use the functions just after introducing vim-lsp-settings, without locating venv and performing installing pyls dependencies into it.