### PR TITLE
fix julia language server for *nix

### DIFF
--- a/installer/install-julia-language-server.sh
+++ b/installer/install-julia-language-server.sh
@@ -7,7 +7,6 @@ julia -e 'using Pkg; Pkg.add("LanguageServer")'
 cat <<EOF >julia-language-server
 #!/usr/bin/env bash
 
-DIR=\$(cd \$(dirname \$0); pwd)
 julia -e "using LanguageServer, LanguageServer.SymbolServer; runserver()"
 EOF
 

--- a/installer/install-julia-language-server.sh
+++ b/installer/install-julia-language-server.sh
@@ -2,25 +2,13 @@
 
 set -e
 
-julia -e 'using Pkg; Pkg.add(PackageSpec(name="LanguageServer", rev="master"))'
-julia -e 'using Pkg; Pkg.add(PackageSpec(name="SymbolServer", rev="master"))'
-julia -e 'using Pkg; Pkg.add(PackageSpec(name="CSTParser", rev="master"))'
-
-cat <<EOF >languageserver.jl
-import LanguageServer
-import Pkg
-import SymbolServer
-envpath = dirname(Pkg.Types.Context().env.project_file)
-server = LanguageServer.LanguageServerInstance(stdin, stdout, false, envpath)
-server.runlinter = true
-run(server)
-EOF
+julia -e 'using Pkg; Pkg.add("LanguageServer")'
 
 cat <<EOF >julia-language-server
 #!/usr/bin/env bash
 
 DIR=\$(cd \$(dirname \$0); pwd)
-julia \$DIR/languageserver.jl \$*
+julia -e "using LanguageServer, LanguageServer.SymbolServer; runserver()"
 EOF
 
 chmod +x julia-language-server


### PR DESCRIPTION
This PR fix #280 only for *nix 

LanguageServer.jl changed API to launch language server:
https://github.com/julia-vscode/LanguageServer.jl

So, I fixed `install-julia-language-server.sh` based on its official doc.

I checked it works in Mac OS and Ubuntu.
I'm sorry I don't have windows, so I cannot fix `install-julia-language-server.cmd`. 

