### PR TITLE
Update clojure lsp version to latest

### DIFF
--- a/installer/install-clojure-lsp.cmd
+++ b/installer/install-clojure-lsp.cmd
@@ -1,5 +1,5 @@
 @echo off
 
 setlocal
-set VERSION=20191202T142318
+set VERSION=20200706T152722
 curl -L -o clojure-lsp.cmd https://github.com/snoe/clojure-lsp/releases/download/release-%VERSION%/clojure-lsp

--- a/installer/install-clojure-lsp.sh
+++ b/installer/install-clojure-lsp.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-version="20191202T142318"
+version="20200706T152722"
 curl -L -o clojure-lsp https://github.com/snoe/clojure-lsp/releases/download/release-$version/clojure-lsp
 chmod +x clojure-lsp


### PR DESCRIPTION
Maybe we could also use the [`LATEST` alias](https://github.com/snoe/clojure-lsp/releases/latest) but that would require a little bit more of investigation on how to do it since just replacing `release-$version` with it does not work 😞 