### PR TITLE
Add sumneko/lua-language-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Because there is no way to update a server, please run `:LspInstallServer` again
 | PHP              | intelephense                                           | Yes           |
 | Java             | eclipse-jdt-ls                                         | Yes           |
 | Lua              | emmylua-ls                                             | Yes           |
+| Lua              | sumneko-lua-language-server                            | Yes           |
 | Vim              | vim-language-server                                    | Yes           |
 | Bash             | bash-language-server                                   | Yes           |
 | Terraform        | terraform-lsp                                          | Yes           |

--- a/installer/install-sumneko-lua-language-server.sh
+++ b/installer/install-sumneko-lua-language-server.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -e
+
+os=$(uname -s | tr "[:upper:]" "[:lower:]")
+
+case $os in
+linux)
+	platform="Linux"
+	;;
+darwin)
+	platform="macOS"
+	;;
+esac
+
+version="0.20.2"
+
+publisher="sumneko"
+extensionname="lua"
+filename="sumneko-lua-language-server.zip"
+
+curl -Lo "$filename" "https://$publisher.gallery.vsassets.io/_apis/public/gallery/publisher/$publisher/extension/$extensionname/$version/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage"
+unzip "$filename"
+rm "$filename"
+
+chmod +x extension/server/bin/$platform/lua-language-server
+
+cat <<EOF >sumneko-lua-language-server
+#!/usr/bin/env bash
+
+DIR=\$(cd \$(dirname \$0); pwd)/extension/server
+\$DIR/bin/$platform/lua-language-server -E -e LANG=en \$DIR/main.lua \$*
+EOF
+
+chmod +x sumneko-lua-language-server

--- a/settings.json
+++ b/settings.json
@@ -436,6 +436,10 @@
       "requires": [
         "java"
       ]
+    },
+    {
+      "command": "sumneko-lua-language-server",
+      "requires": []
     }
   ],
   "nim": [

--- a/settings/sumneko-lua-language-server.vim
+++ b/settings/sumneko-lua-language-server.vim
@@ -1,42 +1,42 @@
 augroup vim_lsp_settings_sumneko_lua_language_server
   let g:vim_lsp_settings_sumneko_lua_language_server_workspace_config = {
-        \  "Lua": {
-        \    "color": {
-        \      "mode": "Semantic"
+        \  'Lua': {
+        \    'color': {
+        \      'mode': 'Semantic'
         \    },
-        \    "completion": {
-        \      "callSnippet": "Disable",
-        \      "enable": v:true,
-        \      "keywordSnippet": "Replace"
+        \    'completion': {
+        \      'callSnippet': 'Disable',
+        \      'enable': v:true,
+        \      'keywordSnippet': 'Replace'
         \    },
-        \    "develop": {
-        \      "debuggerPort": 11412,
-        \      "debuggerWait": v:false,
-        \      "enable": v:false
+        \    'develop': {
+        \      'debuggerPort': 11412,
+        \      'debuggerWait': v:false,
+        \      'enable': v:false
         \    },
-        \    "diagnostics": {
-        \      "enable": v:true,
-        \      "globals": "",
-        \      "severity": {}
+        \    'diagnostics': {
+        \      'enable': v:true,
+        \      'globals': '',
+        \      'severity': {}
         \    },
-        \    "hover": {
-        \      "enable": v:true,
-        \      "viewNumber": v:true,
-        \      "viewString": v:true,
-        \      "viewStringMax": 1000
+        \    'hover': {
+        \      'enable': v:true,
+        \      'viewNumber': v:true,
+        \      'viewString': v:true,
+        \      'viewStringMax': 1000
         \    },
-        \    "runtime": {
-        \      "path": ["?.lua", "?/init.lua", "?/?.lua"],
-        \      "version": "Lua 5.3"
+        \    'runtime': {
+        \      'path': ['?.lua', '?/init.lua', '?/?.lua'],
+        \      'version': 'Lua 5.3'
         \    },
-        \    "signatureHelp": {
-        \      "enable": v:true
+        \    'signatureHelp': {
+        \      'enable': v:true
         \    },
-        \    "workspace": {
-        \      "ignoreDir": [],
-        \      "maxPreload": 1000,
-        \      "preloadFileSize": 100,
-        \      "useGitIgnore": v:true
+        \    'workspace': {
+        \      'ignoreDir': [],
+        \      'maxPreload': 1000,
+        \      'preloadFileSize': 100,
+        \      'useGitIgnore': v:true
         \    }
         \  }
         \}

--- a/settings/sumneko-lua-language-server.vim
+++ b/settings/sumneko-lua-language-server.vim
@@ -1,0 +1,56 @@
+augroup vim_lsp_settings_sumneko_lua_language_server
+  let g:vim_lsp_settings_sumneko_lua_language_server_workspace_config = {
+        \  "Lua": {
+        \    "color": {
+        \      "mode": "Semantic"
+        \    },
+        \    "completion": {
+        \      "callSnippet": "Disable",
+        \      "enable": v:true,
+        \      "keywordSnippet": "Replace"
+        \    },
+        \    "develop": {
+        \      "debuggerPort": 11412,
+        \      "debuggerWait": v:false,
+        \      "enable": v:false
+        \    },
+        \    "diagnostics": {
+        \      "enable": v:true,
+        \      "globals": "",
+        \      "severity": {}
+        \    },
+        \    "hover": {
+        \      "enable": v:true,
+        \      "viewNumber": v:true,
+        \      "viewString": v:true,
+        \      "viewStringMax": 1000
+        \    },
+        \    "runtime": {
+        \      "path": ["?.lua", "?/init.lua", "?/?.lua"],
+        \      "version": "Lua 5.3"
+        \    },
+        \    "signatureHelp": {
+        \      "enable": v:true
+        \    },
+        \    "workspace": {
+        \      "ignoreDir": [],
+        \      "maxPreload": 1000,
+        \      "preloadFileSize": 100,
+        \      "useGitIgnore": v:true
+        \    }
+        \  }
+        \}
+
+  au!
+  LspRegisterServer {
+      \ 'name': 'sumneko-lua-language-server',
+      \ 'cmd': {server_info->lsp_settings#get('sumneko-lua-language-server', 'cmd', [lsp_settings#exec_path('sumneko-lua-language-server')])},
+      \ 'root_uri':{server_info->lsp_settings#get('sumneko-lua-language-server', 'root_uri', lsp_settings#root_uri('sumneko-lua-language-server'))},
+      \ 'initialization_options': lsp_settings#get('sumneko-lua-language-server', 'initialization_options', v:null),
+      \ 'allowlist': lsp_settings#get('sumneko-lua-language-server', 'allowlist', ['lua']),
+      \ 'blocklist': lsp_settings#get('sumneko-lua-language-server', 'blocklist', []),
+      \ 'config': lsp_settings#get('sumneko-lua-language-server', 'config', lsp_settings#server_config('sumneko-lua-language-server')),
+      \ 'workspace_config': lsp_settings#get('sumneko-lua-language-server', 'workspace_config', g:vim_lsp_settings_sumneko_lua_language_server_workspace_config),
+      \ 'semantic_highlight': lsp_settings#get('sumneko-lua-language-server', 'semantic_highlight', {}),
+      \ }
+augroup END


### PR DESCRIPTION
## Description

Added `sumneko/lua-language-server`. close https://github.com/mattn/vim-lsp-settings/issues/268

- GitHub
    - https://github.com/sumneko/lua-language-server
- GitHub Wiki - Build and Run (Standalone)
    - https://github.com/sumneko/lua-language-server/wiki/Build-and-Run-(Standalone)
- Visual Studio Marketplace - sumneko.lua
    - https://marketplace.visualstudio.com/items?itemName=sumneko.lua

To make it easier for users to install, we have made it available for download from a direct link in the Visual Studio Marketplace.

The format of the Visual Studio Marketplace direct link is as follows.

```
https://${publisher}.gallery.vsassets.io/_apis/public/gallery/publisher/${publisher}/extension/${extensionname}/${version}/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage
```

In the case of this sumneko/lua-language-server:

```
https://sumneko.gallery.vsassets.io/_apis/public/gallery/publisher/sumneko/extension/lua/0.20.2/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage
```

## Sorry

Installers for "Windows" are not included yet for this Pull Request, somebody's contributions are needed.

## Demo

![sumneko-lua-language-server_960](https://user-images.githubusercontent.com/188642/88317885-e029bc80-cd54-11ea-8ddf-d1f885cc8fa9.gif)
