### PR TITLE
Add `ocaml-lsp`

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Because there is no way to update a server, please run `:LspInstallServer` again
 | Lua              | sumneko-lua-language-server                            | Yes           |
 | Nim              | nimls                                                  | No            |
 | PHP              | intelephense                                           | Yes           |
+| OCaml            | ocaml-lsp                                              | Yes           |
 | Python           | pyls-all (pyls with dependencies)                      | Yes           |
 | Python           | pyls (pyls without dependencies)                       | Yes           |
 | Python           | pyls-ms (Microsoft Version)                            | Yes           |

--- a/installer/install-ocaml-lsp.sh
+++ b/installer/install-ocaml-lsp.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -e
+
+DEFAULT_DIR="$(pwd)"
+INSTALL_DIR="$DEFAULT_DIR/bin"
+
+
+# We should not download GitHub's zip file here, because it doesn't include some submodules.
+git clone --recurse-submodules http://github.com/ocaml/ocaml-lsp.git --depth=1
+cd ocaml-lsp
+
+rm -r lsp/test
+export OPAMROOT="$(pwd)/.opam"
+opam init -a -n
+eval $(opam env)
+opam switch create . -y
+opam exec --switch=. dune build
+
+rm -rf .git
+
+cd "$DEFAULT_DIR"
+ln -snf "ocaml-lsp/_build/install/default/bin/ocamllsp" .
+chmod +x ocamllsp
+
+# output : ./ocamllsp
+

--- a/installer/install-ocaml-lsp.sh
+++ b/installer/install-ocaml-lsp.sh
@@ -9,9 +9,11 @@ git clone --recurse-submodules http://github.com/ocaml/ocaml-lsp.git ocaml-lsp-f
 cd ocaml-lsp-files
 
 rm -r lsp/test
-export OPAMROOT="$(pwd)/.opam"
+OPAMROOT="$(pwd)/.opam"
+export OPAMROOT
+
 opam init -a -n
-eval $(opam env)
+eval "$(opam env)"
 opam switch create . -y
 opam exec --switch=. dune build
 

--- a/installer/install-ocaml-lsp.sh
+++ b/installer/install-ocaml-lsp.sh
@@ -3,12 +3,10 @@
 set -e
 
 DEFAULT_DIR="$(pwd)"
-INSTALL_DIR="$DEFAULT_DIR/bin"
-
 
 # We should not download GitHub's zip file here, because it doesn't include some submodules.
-git clone --recurse-submodules http://github.com/ocaml/ocaml-lsp.git --depth=1
-cd ocaml-lsp
+git clone --recurse-submodules http://github.com/ocaml/ocaml-lsp.git ocaml-lsp-files  --depth=1
+cd ocaml-lsp-files
 
 rm -r lsp/test
 export OPAMROOT="$(pwd)/.opam"
@@ -20,8 +18,5 @@ opam exec --switch=. dune build
 rm -rf .git
 
 cd "$DEFAULT_DIR"
-ln -snf "ocaml-lsp/_build/install/default/bin/ocamllsp" .
-chmod +x ocamllsp
-
-# output : ./ocamllsp
-
+ln -snf "./ocaml-lsp-files/_build/default/ocaml-lsp-server/src/main.exe" ocaml-lsp
+chmod +x ocaml-lsp

--- a/settings.json
+++ b/settings.json
@@ -484,6 +484,12 @@
       "requires": []
     }
   ],
+  "ocaml": [
+    {
+      "command": "ocaml-lsp",
+      "requires": []
+    }
+  ],
   "perl": [
     {
       "command": "slp",

--- a/settings/ocaml-lsp.vim
+++ b/settings/ocaml-lsp.vim
@@ -1,0 +1,15 @@
+augroup vim_lsp_settings_ocaml_lsp
+  au!
+  LspRegisterServer {
+      \ 'name': 'ocaml-lsp',
+      \ 'cmd': {server_info->lsp_settings#get('ocaml-lsp', 'cmd', [lsp_settings#exec_path('ocaml-lsp'), '--log-file=log.txt'])},
+      \ 'root_uri':{server_info->lsp_settings#get('ocaml-lsp', 'root_uri', lsp_settings#root_uri('ocaml-lsp'))},
+      \ 'initialization_options': lsp_settings#get('ocaml-lsp', 'initialization_options', {}),
+      \ 'allowlist': lsp_settings#get('ocaml-lsp', 'allowlist', ['ocaml']),
+      \ 'blocklist': lsp_settings#get('ocaml-lsp', 'blocklist', []),
+      \ 'config': lsp_settings#get('ocaml-lsp', 'config', lsp_settings#server_config('ocaml-lsp')),
+      \ 'workspace_config': lsp_settings#get('ocaml-lsp', 'workspace_config', {}),
+      \ 'semantic_highlight': lsp_settings#get('ocaml-lsp', 'semantic_highlight', {}),
+      \ }
+augroup END
+


### PR DESCRIPTION
It adds [`ocaml-lsp`](https://github.com/ocaml/ocaml-lsp) (recommended cli name is `ocamllsp`), which is official and brand new language server implementation.

I'm sorry that the PR doesn't include installer for Windows, so future contributions are hoped. (But it works fine for POSIX sys.)

Because simple binary packages are not provided officially, it compiles binaries on local. It will not pollute user's local file system, but it requires `opam` command and `git` command.
(`curl | tar`, alternative to `git`, will not work here because GitHub's zip-download feature will drop some of `ocaml-lsp`'s submodules.)