### PR TITLE
Fix an unneeded sentence in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,8 +254,6 @@ Overridable keys are:
 * root_uri_patterns (List)
 * semantic_highlight (Dictionary)
 
-If you installed ruby but not solargraph, you can install solargraph with the following command.
-
 If you have some Language Servers and want to use specified the server:
 
 ```vim


### PR DESCRIPTION
Hi.

I think you forgot to erase unnecessary sentences.

https://github.com/mattn/vim-lsp-settings/commit/20a2b3d7dcd0e92ec48d39aba78eb12414013efc#diff-04c6e90faac2675aa89e2176d2eec7d8L52
https://github.com/mattn/vim-lsp-settings/commit/20a2b3d7dcd0e92ec48d39aba78eb12414013efc#diff-04c6e90faac2675aa89e2176d2eec7d8R131

---

多分、該当箇所は 20a2b3d7dcd0e92ec48d39aba78eb12414013efc で消し忘れた文章かと思われます。
（solargraphの設定が上手くいかず、情報を探していた際に本文章を見て気づきました。）

---

もし間違ってたら適当にcloseしていただいて構いません。