### PR TITLE
Add serve-d language server. Closes #305

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Because there is no way to update a server, please run `:LspInstallServer` again
 | Clojure          | clj-kondo-lsp                     | Yes           | Yes           |
 | Cmake            | cmake-language-server             | Yes           | Yes           |
 | D                | dls                               | Yes           | No            |
+| D                | serve-d                           | Yes           | No            |
 | Dart             | analysis-server-dart-snapshot     | Yes           | Yes           |
 | Dockerfile       | dockerfile-language-server-nodejs | Yes           | Yes           |
 | Elixir           | elixir-ls                         | Yes           | Yes           |

--- a/installer/install-serve-d.cmd
+++ b/installer/install-serve-d.cmd
@@ -1,0 +1,8 @@
+@echo off
+
+setlocal
+set VERSION=0.6.0
+set FILE="serve-d_%VERSION%-windows.zip"
+curl -L -o %FILE% https://github.com/Pure-D/serve-d/releases/download/v%VERSION%/%FILE%
+call "%~dp0\run_unzip.cmd" %FILE%
+del %FILE%

--- a/installer/install-serve-d.sh
+++ b/installer/install-serve-d.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+os=$(uname -s | tr "[:upper:]" "[:lower:]")
+
+case $os in
+linux) ;;
+darwin)
+  os="osx"
+  ;;
+*)
+  echo "$os is not supported by installer"
+  exit 1
+  ;;
+esac
+
+version="0.6.0"
+filename="serve-d_$version-$os-x86_64.tar.xz"
+url="https://github.com/Pure-D/serve-d/releases/download/v$version/$filename"
+curl -L "$url" | unxz | tar x

--- a/settings.json
+++ b/settings.json
@@ -117,6 +117,10 @@
   ],
   "d": [
     {
+      "command": "serve-d",
+      "requires": []
+    },
+    {
       "command": "dls",
       "requires": [
         "npm"

--- a/settings/serve-d.vim
+++ b/settings/serve-d.vim
@@ -1,0 +1,14 @@
+augroup vim_lsp_settings_serve_d
+  au!
+  LspRegisterServer {
+      \ 'name': 'serve-d',
+      \ 'cmd': {server_info->lsp_settings#get('serve-d', 'cmd', [lsp_settings#exec_path('serve-d')])},
+      \ 'root_uri':{server_info->lsp_settings#get('serve-d', 'root_uri', lsp_settings#root_uri('serve-d'))},
+      \ 'initialization_options': lsp_settings#get('serve-d', 'initialization_options', {'diagnostics': 'true'}),
+      \ 'allowlist': lsp_settings#get('serve-d', 'allowlist', ['d']),
+      \ 'blocklist': lsp_settings#get('serve-d', 'blocklist', []),
+      \ 'config': lsp_settings#get('serve-d', 'config', lsp_settings#server_config('serve-d')),
+      \ 'workspace_config': lsp_settings#get('serve-d', 'workspace_config', {}),
+      \ 'semantic_highlight': lsp_settings#get('serve-d', 'semantic_highlight', {}),
+      \ }
+augroup END


### PR DESCRIPTION
dls has been deprecated, this commit adds support for is a well maintained language server.