### PR TITLE
Fix installer for Powershell-languageserver

### DIFF
--- a/installer/install-powershell-languageserver.cmd
+++ b/installer/install-powershell-languageserver.cmd
@@ -5,7 +5,7 @@ set VERSION=2.1.0
 curl -L -o PowerShellEditorServices.zip "https://github.com/PowerShell/PowerShellEditorServices/releases/download/v%VERSION%/PowerShellEditorServices.zip"
 call "%~dp0\run_unzip.cmd" PowerShellEditorServices.zip
 del PowerShellEditorServices.zip
-mkdir %~dp0session
+if not exist "%~dp0session" mkdir "%~dp0session"
 
 echo @echo off^
 
@@ -15,6 +15,6 @@ set PSES_BUNDLE_PATH=%%~dp0PowerShellEditorServices^
 
 set SESSION_TEMP_PATH=%%~dp0session^
 
-powershell -NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command "%%PSES_BUNDLE_PATH:\=/%%/PowerShellEditorServices/Start-EditorServices.ps1 -BundledModulesPath %%PSES_BUNDLE_PATH:\=/%% -LogPath %%SESSION_TEMP_PATH:\=/%%/logs.log -SessionDetailsPath %%SESSION_TEMP_PATH:\=/%%/session.json -FeatureFlags @() -AdditionalModules @() -HostName 'My Client' -HostProfileId 'myclient' -HostVersion 1.0.0 -Stdio -LogLevel Normal"^
+powershell -NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command ^"%%PSES_BUNDLE_PATH: =` %%\PowerShellEditorServices\Start-EditorServices.ps1^" -BundledModulesPath '%%PSES_BUNDLE_PATH%%' -LogPath '%%SESSION_TEMP_PATH%%\logs.log' -SessionDetailsPath '%%SESSION_TEMP_PATH%%\session.json' -FeatureFlags @() -AdditionalModules @() -HostName 'My Client' -HostProfileId 'myclient' -HostVersion 1.0.0 -Stdio -LogLevel Normal^
 
 > powershell-languageserver.cmd


### PR DESCRIPTION
When trying to install this LSP server, I get an error during `LspInstallServer`:
```
...
C:\Users\Dominic Della Valle\AppData\Local\vim-lsp-settings\servers\powershell-languageserver>curl -L -o PowerShellEdit
orServices.zip "https://github.com/PowerShell/PowerShellEditorServices/releases/download/v2.1.0/PowerShellEditorService
s.zip"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   652  100   652    0     0    652      0  0:00:01 --:--:--  0:00:01  3468
100 18.5M  100 18.5M    0     0  18.5M      0  0:00:01 --:--:--  0:00:01 18.5M

C:\Users\Dominic Della Valle\AppData\Local\vim-lsp-settings\servers\powershell-languageserver>call "C:\Users\Dominic De
lla Valle\.vim\plugged\vim-lsp-settings\installer\\run_unzip.cmd" PowerShellEditorServices.zip
C:\msys64\usr\bin\unzip.exe
Archive:  PowerShellEditorServices.zip
   creating: PowerShellEditorServices/
...
  inflating: PowerShellEditorServices/PSScriptAnalyzer/1.19.0/Settings/ScriptSecurity.psd1
Access is denied.
Error occurred while processing: C:\Users\Dominic.
```

Short version:
I seem to have fixed it.  Works on my machine. :^)

Long version:
(Sorry this is so complicated to express; the legacy+mixing of CMD and Powershell makes it so)

I looked into this and there were a few issues.
The argument for `mkdir` was not quoted which is causing the `Access is denied` error with the wrong target.
I also made a change so that the cmd only tries to create the "session" directory if it does not exist. Otherwise it emits a different error: "A subdirectory or file session already exists."

After this, the LSP server would install, but not launch. This is because the invocation for the Powershell command was quoted in the CMD context, but not in the Powershell context.
(Treated as 1 large string for CMD, but the actual Powershell parameter array it's expressing, had unquoted arguments)
So I quoted the `Command`'s path argument and substituted whitespace within it using the CMD escape format.
e.g. `-Command C:\Users\Dominic Della Valle\...\x.ps1` -> `-Command "C:\Users\Dominic` Della` Valle\...\x.ps1"`
The remainder of the invocation string uses the Powershell convention for quoted strings (just wrapped in `'`), as this is how they will be interpreted past that point. The surrounding quotes are not included because the entire block is inherently treated as a string by CMD.
>In cmd.exe, there is no such thing as a script block (or ScriptBlock type), so the value passed to Command will always be a string.
...
If the value of Command is a string, Command must be the last parameter for pwsh, because all arguments following it are interpreted as part of the command to execute.

[cite](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_powershell_exe?view=powershell-5.1#-command)

I also noticed the paths were being converted from `\` to `/` delimited paths.  This doesn't seem necessary so I removed it.
The paths are being returned from a `.cmd` and being sent to a `.cmd` which is being used to invoke the system native `powershell.exe` so it seems to make more sense to just pass them using the traditional/system-native convention rather than do basic string substitutions on path strings if we don't have to.

I think that's all in order 😵
