### PR TITLE
Update Metals versions and initializationOptions

### DIFF
--- a/installer/install-metals.cmd
+++ b/installer/install-metals.cmd
@@ -5,5 +5,5 @@ setlocal
 curl -Lo coursier https://git.io/coursier-cli
 curl -Lo coursier.bat https://git.io/coursier-bat
 
-set VERSION=0.8.4
+set VERSION=0.9.4
 java %JAVA_OPTS% -jar coursier bootstrap --ttl Inf "org.scalameta:metals_2.12:%VERSION%" -r "bintray:scalacenter/releases" -r "sonatype:public" -r "sonatype:snapshots" -o metals

--- a/installer/install-metals.sh
+++ b/installer/install-metals.sh
@@ -5,5 +5,5 @@ set -e
 curl -Lo ./coursier https://git.io/coursier-cli
 chmod +x ./coursier
 
-version="0.8.4"
+version="0.9.4"
 java -jar ./coursier bootstrap --ttl Inf "org.scalameta:metals_2.12:$version" -r "bintray:scalacenter/releases" -r "sonatype:public" -r "sonatype:snapshots" -o ./metals

--- a/settings/metals.vim
+++ b/settings/metals.vim
@@ -4,7 +4,7 @@ augroup vim_lsp_settings_metals
       \ 'name': 'metals',
       \ 'cmd': {server_info->lsp_settings#get('metals', 'cmd', [lsp_settings#exec_path('metals')])},
       \ 'root_uri':{server_info->lsp_settings#get('metals', 'root_uri', lsp_settings#root_uri('metals'))},
-      \ 'initialization_options': lsp_settings#get('metals', 'initialization_options', v:null),
+      \ 'initialization_options': lsp_settings#get('metals', 'initialization_options', {'isHttpEnabled': 'true'}),
       \ 'allowlist': lsp_settings#get('metals', 'allowlist', ['scala', 'sbt']),
       \ 'blocklist': lsp_settings#get('metals', 'blocklist', []),
       \ 'config': lsp_settings#get('metals', 'config', lsp_settings#server_config('metals')),


### PR DESCRIPTION
This pr just updates the default version of Metals to the latest. It also adds in the `isHttpEnabled` initializationOption and sets it to true. This allows the [Metals Doctor](https://scalameta.org/metals/docs/editors/new-editor.html#metals-http-client) to work in clients that don't have an embedded html viewer.