### PR TITLE
Install solargraph without development gems

### DIFF
--- a/installer/install-solargraph.cmd
+++ b/installer/install-solargraph.cmd
@@ -2,7 +2,7 @@
 
 git clone --depth=1 https://github.com/castwide/solargraph .
 
-call bundle install --path vendor/bundle
+call bundle install --without development --path vendor/bundle
 
 echo @echo off ^
 

--- a/installer/install-solargraph.sh
+++ b/installer/install-solargraph.sh
@@ -3,7 +3,7 @@
 set -e
 
 git clone --depth=1 https://github.com/castwide/solargraph .
-bundle install --path vendor/bundle
+bundle install --without development --path vendor/bundle
 
 cat <<EOF >solargraph
 #!/usr/bin/env bash


### PR DESCRIPTION
```
$ cd ~/.local/share/vim-lsp-settings/servers/solargraph

# before
$ bundle list --name-only |wc
      39      39     397

# after
$ bundle list --name-only |wc
      22      22     219
 ```
  
