### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,10 +268,11 @@ When the servers are specified in a list, these will all be started.
 
 If you want to configure Language Server to use flake8 rather than pycodestyle,
 the following can be added to your `~/.vimrc` file.
+Note that `pyls-all` was the automatically registered server name. Check with `:LspStatus`.
 
 ```vim
 let g:lsp_settings = {
-\   'pyls': {
+\   'pyls-all': {
 \     'workspace_config': {
 \       'pyls': {
 \         'configurationSources': ['flake8']


### PR DESCRIPTION
`pyls-all` is the default server name after installation, so configurations should refer to it instead of `pyls`.