### PR TITLE
Update clangd to 11

### DIFF
--- a/installer/install-clangd.sh
+++ b/installer/install-clangd.sh
@@ -38,7 +38,7 @@ case $distributor_id in
 Ubuntu)
   ubuntu_version=$(lsb_release -a 2>&1 | grep 'Release' | awk '{print $2}')
   case $ubuntu_version in
-  14.04 | 16.04 | 18.04)
+  14.04 | 16.04 | 18.04 | 20.04)
     platform="linux-gnu-ubuntu-$ubuntu_version"
     ;;
   esac
@@ -65,15 +65,24 @@ filename_v9="clang+llvm-9.0.0-x86_64-$platform"
 url_v9="http://releases.llvm.org/9.0.0/$filename_v9.tar.xz"
 filename_v10="clang+llvm-10.0.0-x86_64-$platform"
 url_v10="https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/$filename_v10.tar.xz"
+filename_v11="clang+llvm-11.0.0-x86_64-$platform"
+url_v11="https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/$filename_v11.tar.xz"
 
-response_code=$(curl -sIL ${url_v10} -o /dev/null -w "%{response_code}")
+response_code=$(curl -sIL ${url_v11} -o /dev/null -w "%{response_code}")
 
 if [ "${response_code}" == "404" ]; then
-  url="${url_v9}"
-  filename="${filename_v9}"
+  response_code=$(curl -sIL ${url_v10} -o /dev/null -w "%{response_code}")
+
+  if [ "${response_code}" == "404" ]; then
+    url="${url_v9}"
+    filename="${filename_v9}"
+  else
+    url="${url_v10}"
+    filename="${filename_v10}"
+  fi
 else
-  url="${url_v10}"
-  filename="${filename_v10}"
+  url="${url_v11}"
+  filename="${filename_v11}"
 fi
 
 echo "Downloading clangd and LLVM..."


### PR DESCRIPTION
I use Ubuntu 20.04 on WSL2.

With `LspInstallServer clangd`, I received the following error message.

> ./clangd: error while loading shared libraries: libz3.so.4.8: cannot open shared object file: No such file or directory

According to llvm-project repo, they release binary for Ubuntu 20.04 from 11.0.0.
https://github.com/llvm/llvm-project/releases

I added some lines for Ubuntu 20.04 and LLVM 11.0.0.
Now, `LspInstallServer clangd` and clangd are working well on my side.

If any additional check or info is needed, please kindly let me know.

Many thanks.