### PR TITLE
Support prisma-language-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Because there is no way to update a server, please run `:LspInstallServer` again
 | Python           | pyls (pyls without dependencies)  | Yes       | Yes           |
 | Python           | pyls-ms (Microsoft Version)       | Yes       | Yes           |
 | Python           | jedi-language-server              | Yes       | Yes           |
+| Prisma           | prisma-language-server            | Yes       | Yes           |
 | R                | languageserver                    | Yes       | No            |
 | Reason           | reason-language-server            | Yes       | Yes           |
 | Ruby             | solargraph                        | Yes       | Yes           |

--- a/installer/install-prisma-language-server.cmd
+++ b/installer/install-prisma-language-server.cmd
@@ -1,0 +1,18 @@
+@echo off
+
+if not exist package.json (
+	call npm init -y
+
+	echo {"name":""}>package.json
+)
+
+
+call npm install "@prisma/engines"
+
+echo @echo off ^
+
+call %%~dp0\node_modules\@prisma\engines\prisma-fmt-windows.exe %%* ^
+
+> prisma-fmt.exe
+
+call "%~dp0\npm_install.cmd" prisma-langauge-server "@prisma/language-server"

--- a/installer/install-prisma-language-server.cmd
+++ b/installer/install-prisma-language-server.cmd
@@ -13,6 +13,6 @@ echo @echo off ^
 
 call %%~dp0\node_modules\@prisma\engines\prisma-fmt-windows.exe %%* ^
 
-> prisma-fmt.exe
+> prisma-fmt.cmd
 
 call "%~dp0\npm_install.cmd" prisma-langauge-server "@prisma/language-server"

--- a/installer/install-prisma-language-server.sh
+++ b/installer/install-prisma-language-server.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+
+if [ ! -f package.json ]; then
+  # Avoid the problem of not being able to install the same package as name in package.json.
+  # Create an empty package.json.
+  npm init -y
+  echo '{"name": ""}' >package.json
+fi
+
+npm install "@prisma/engines"
+pushd "node_modules/@prisma/engines"
+  PRISMA_FMT_BASENAME="$(find . -name "prisma-fmt*")"
+  test -x "$PRISMA_FMT_BASENAME"
+popd
+
+ln -s "./node_modules/@prisma/engines/${PRISMA_FMT_BASENAME}" ./prisma-fmt
+"$(dirname "$0")/npm_install.sh" prisma-language-server @prisma/language-server

--- a/settings.json
+++ b/settings.json
@@ -601,6 +601,20 @@
       ]
     }
   ],
+  "prisma": [
+    {
+      "command": "prisma-language-server",
+      "requires": [
+        "npm"
+      ],
+      "vim_plugin": {
+        "extensions": [
+          "prisma"
+        ],
+        "name": "pantharshit00/vim-prisma"
+      }
+    }
+  ],
   "prolog": [
     {
       "command": "prolog-lsp_server",

--- a/settings/prisma-language-server.vim
+++ b/settings/prisma-language-server.vim
@@ -1,0 +1,18 @@
+augroup vim_lsp_settings_typescript_language_server
+  au!
+  LspRegisterServer {
+      \ 'name': 'prisma-language-server',
+      \ 'cmd': {server_info->lsp_settings#get('prisma-language-server', 'cmd', [lsp_settings#exec_path('prisma-language-server'), '--stdio'])},
+      \ 'root_uri':{server_info->lsp_settings#get('prisma-language-server', 'root_uri', lsp_settings#root_uri('prisma-language-server'))},
+      \ 'initialization_options': lsp_settings#get('typescript-language-server', 'initialization_options', {'diagnostics': 'true'}),
+      \ 'allowlist': lsp_settings#get('prisma', 'allowlist', ['prisma']),
+      \ 'blocklist': lsp_settings#get('prisma-language-server', 'blocklist', []),
+      \ 'config': lsp_settings#get('prisma-language-server', 'config', lsp_settings#server_config('prisma-language-server')),
+      \ 'workspace_config': lsp_settings#get('prisma-language-server', 'workspace_config', {
+      \   'prismaLanguageServer': {
+      \     'prismaFmtBinPath': {c->!empty(c) ? c : lsp_settings#servers_dir() . '/prisma-language-server/prisma-fmt'}(lsp_settings#exec_path('prisma-fmt')),
+      \   }
+      \ }),
+      \ 'semantic_highlight': lsp_settings#get('prisma-language-server', 'semantic_highlight', {}),
+      \ }
+augroup END

--- a/settings/prisma-language-server.vim
+++ b/settings/prisma-language-server.vim
@@ -4,7 +4,7 @@ augroup vim_lsp_settings_prisma_language_server
       \ 'name': 'prisma-language-server',
       \ 'cmd': {server_info->lsp_settings#get('prisma-language-server', 'cmd', [lsp_settings#exec_path('prisma-language-server'), '--stdio'])},
       \ 'root_uri':{server_info->lsp_settings#get('prisma-language-server', 'root_uri', lsp_settings#root_uri('prisma-language-server'))},
-      \ 'initialization_options': lsp_settings#get('typescript-language-server', 'initialization_options', {'diagnostics': 'true'}),
+      \ 'initialization_options': lsp_settings#get('prisma-language-server', 'initialization_options', {'diagnostics': 'true'}),
       \ 'allowlist': lsp_settings#get('prisma', 'allowlist', ['prisma']),
       \ 'blocklist': lsp_settings#get('prisma-language-server', 'blocklist', []),
       \ 'config': lsp_settings#get('prisma-language-server', 'config', lsp_settings#server_config('prisma-language-server')),

--- a/settings/prisma-language-server.vim
+++ b/settings/prisma-language-server.vim
@@ -1,4 +1,4 @@
-augroup vim_lsp_settings_typescript_language_server
+augroup vim_lsp_settings_prisma_language_server
   au!
   LspRegisterServer {
       \ 'name': 'prisma-language-server',

--- a/settings/prisma-language-server.vim
+++ b/settings/prisma-language-server.vim
@@ -9,7 +9,7 @@ augroup vim_lsp_settings_prisma_language_server
       \ 'blocklist': lsp_settings#get('prisma-language-server', 'blocklist', []),
       \ 'config': lsp_settings#get('prisma-language-server', 'config', lsp_settings#server_config('prisma-language-server')),
       \ 'workspace_config': lsp_settings#get('prisma-language-server', 'workspace_config', {
-      \   'prismaLanguageServer': {
+      \   'prisma': {
       \     'prismaFmtBinPath': {c->!empty(c) ? c : lsp_settings#servers_dir() . '/prisma-language-server/prisma-fmt'}(lsp_settings#exec_path('prisma-fmt')),
       \   }
       \ }),


### PR DESCRIPTION
~WIP~

- [x] Installer for `prisma-lanaguage-server`
- [x] Installer for `prisma-fmt`
  - There're 3 ways,
    - from `npm i prisma` and use `node_modules/.bin/prisma fmt`,
    - from `npm i @prisma/engines` and use `node_modules/@prisma/engines/prisma-fmt-{PLATFORM_SPECIFIC}`,
    - and `git clone https://github.com/prisma/prisma-engines && cd prisma-engines && cargo build --release prisma-fmt`, and use `prisma-fmt`
  - Using `prisma fmt` looks smart (internally using second one) , but `prisma-language-server` does not support that. ( also `npx prisma fmt` ) . I'll issue for that...
  - MEMO: Binaries come from https://binaries.prisma.sh
- [x] Check installation and working with Linux
  - [x] With fully cleaned.
- [x] Check installation and working with Windows ( I will check soon. )
- [x] Check installation and working with Mac ( I can't! )

NOTE: `prisma-language-server` looks still buggy.

I welcome any suggestions. Thank you!

Filetype `prisma` is set by https://github.com/pantharshit00/vim-prisma .