### PR TITLE
Handle dependency error in a better way

### DIFF
--- a/autoload/lsp_settings.vim
+++ b/autoload/lsp_settings.vim
@@ -105,6 +105,7 @@ function! s:vim_lsp_installer(ft, ...) abort
     let l:missing = 0
     for l:require in l:conf.requires
       if !lsp_settings#executable(l:require)
+        call lsp_settings#utils#warning(l:conf.command . ' requires ' . l:require)
         let l:missing = 1
         break
       endif
@@ -116,7 +117,7 @@ function! s:vim_lsp_installer(ft, ...) abort
       return [l:conf.command, l:command]
     endif
   endfor
-  return []
+  return [v:false] " placeholder, so that empty() returns false, but len() < 2 returns true
 endfunction
 
 function! lsp_settings#server_config(name) abort
@@ -334,6 +335,10 @@ function! s:vim_lsp_install_server(ft, command, bang) abort
   let l:entry = s:vim_lsp_installer(a:ft, a:command)
   if empty(l:entry)
     call lsp_settings#utils#error('Server not found')
+    return
+  endif
+  if len(l:entry) < 2
+    call lsp_settings#utils#error('Server could not be installed. See :messages for details.')
     return
   endif
   if empty(a:bang) && confirm(printf('Install %s ?', l:entry[0]), "&Yes\n&Cancel") !=# 1

--- a/autoload/lsp_settings/utils.vim
+++ b/autoload/lsp_settings/utils.vim
@@ -5,6 +5,13 @@ function! lsp_settings#utils#msg(msg) abort
   echohl None
 endfunction
 
+function! lsp_settings#utils#warning(msg) abort
+  redraw
+  echohl WarningMsg
+  echomsg a:msg
+  echohl None
+endfunction
+
 function! lsp_settings#utils#error(msg) abort
   redraw
   echohl Error


### PR DESCRIPTION
If server is found, but dependencies are not found, then currently
"Server not found" is shown, making user clueless. This commit tries to
inform the user that server was found, but dependencies were not
satisfied.