### PR TITLE
Add haskell-language-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Because there is no way to update a server, please run `:LspInstallServer` again
 | GraphQL          | gql-language-server               | Yes       | Yes           |
 | Groovy           | groovy-language-server            | Yes       | Yes           |
 | Haskell          | haskell-ide-engine                | No        | No            |
+| Haskell          | haskell-language-server           | No        | No            |
 | HTML             | html-languageserver               | Yes       | Yes           |
 | HTML             | angular-language-server           | Yes       | Yes           |
 | HTML             | tailwindcss-intellisense          | Yes       | Yes           |

--- a/settings.json
+++ b/settings.json
@@ -306,6 +306,14 @@
         "stack.yaml",
         "package.yaml"
       ]
+    },
+    {
+      "command": "haskell-language-server",
+      "requires": [],
+      "root_uri_patterns": [
+        "stack.yaml",
+        "package.yaml"
+      ]
     }
   ],
   "html": [

--- a/settings/haskell-language-server.vim
+++ b/settings/haskell-language-server.vim
@@ -1,0 +1,14 @@
+augroup vim_lsp_settings_haskell_language_server
+  au!
+  LspRegisterServer {
+      \ 'name': 'haskell-language-server',
+      \ 'cmd': {server_info->lsp_settings#get('haskell-language-server', 'cmd', [lsp_settings#exec_path('haskell-language-server-wrapper'), '--lsp'])},
+      \ 'root_uri':{server_info->lsp_settings#get('haskell-language-server', 'root_uri', lsp_settings#root_uri('haskell-language-server'))},
+      \ 'initialization_options': lsp_settings#get('haskell-language-server', 'initialization_options', v:null),
+      \ 'allowlist': lsp_settings#get('haskell-language-server', 'allowlist', ['haskell']),
+      \ 'blocklist': lsp_settings#get('haskell-language-server', 'blocklist', []),
+      \ 'config': lsp_settings#get('haskell-language-server', 'config', lsp_settings#server_config('haskell-language-server')),
+      \ 'workspace_config': lsp_settings#get('haskell-language-server', 'workspace_config', {}),
+      \ 'semantic_highlight': lsp_settings#get('haskell-language-server', 'semantic_highlight', {}),
+      \ }
+augroup END


### PR DESCRIPTION
Even though the haskell-language-server project provides usable static binaries, I didn't create installers. That is because different versions of binaries must be downloaded, depending on the version of the used GHC (Glasgow Haskell Compiler).