### PR TITLE
add support for rust-analyzer.runSingle for cargo

### DIFF
--- a/autoload/lsp_settings/utils.vim
+++ b/autoload/lsp_settings/utils.vim
@@ -68,3 +68,16 @@ function! lsp_settings#utils#load_schemas(name) abort
   let l:schemas = json_decode(join(readfile(s:catalog_path), "\n"))['schemas']
   return extend(l:schemas, lsp_settings#get(a:name, 'schemas', []))
 endfunction
+
+function! lsp_settings#utils#term_start(cmd, options) abort
+    let l:options = {}
+    if has_key(a:options, 'cwd')
+        let l:options['cwd'] = a:options['cwd']
+    endif
+    if has('nvim')
+        split new
+        call termopen(a:cmd, l:options)
+    else
+        call term_start(a:cmd, l:options)
+    endif
+endfunction

--- a/settings/rust-analyzer.vim
+++ b/settings/rust-analyzer.vim
@@ -35,6 +35,34 @@ function! s:rust_analyzer_apply_source_change(context)
     endif
 endfunction
 
+function! s:rust_analyzer_run_single(context) abort
+    let l:command = get(a:context, 'command', {})
+    let l:arguments = get(l:command, 'arguments', [])
+	let l:argument = get(l:arguments, 0, {})
+
+    if !has_key(l:argument, 'kind')
+        call lsp_settings#utils#error('unsupported rust-analyzer.runSingle command. ' . json_encode(l:command))
+        return
+    endif
+
+    if l:argument['kind'] == 'cargo'
+        let l:label = get(l:argument, 'label', 'cargo')
+        let l:args = get(l:argument, 'args', {})
+        let l:workspaceRoot = get(l:args, 'workspaceRoot', getcwd())
+        let l:cargoArgs = get(l:args, 'cargoArgs', [])
+        let l:cargoExtraArgs = get(l:args, 'cargoExtraArgs', [])
+        let l:cmd = ['cargo'] + l:cargoArgs
+
+        if !empty(l:cargoExtraArgs)
+            let l:cmd += ['--'] + l:cargoExtraArgs
+        endif
+
+        call lsp_settings#utils#term_start(l:cmd, {'cwd': l:workspaceRoot})
+    else
+        call lsp_settings#utils#error('unsupported rust-analyzer.runSingle command. ' . json_encode(l:command))
+    endif
+endfunction
+
 let s:setup = 0
 
 function! s:register_command()
@@ -47,5 +75,6 @@ function! s:register_command()
   augroup END
   if exists('*lsp#register_command')
     call lsp#register_command('rust-analyzer.applySourceChange', function('s:rust_analyzer_apply_source_change'))
+    call lsp#register_command('rust-analyzer.runSingle', function('s:rust_analyzer_run_single'))
   endif
 endfunction

--- a/settings/rust-analyzer.vim
+++ b/settings/rust-analyzer.vim
@@ -51,10 +51,11 @@ function! s:rust_analyzer_run_single(context) abort
         let l:workspaceRoot = get(l:args, 'workspaceRoot', getcwd())
         let l:cargoArgs = get(l:args, 'cargoArgs', [])
         let l:cargoExtraArgs = get(l:args, 'cargoExtraArgs', [])
-        let l:cmd = ['cargo'] + l:cargoArgs
+        let l:executableArgs = get(l:args, 'executableArgs', [])
+        let l:cmd = ['cargo'] + l:cargoArgs + l:cargoExtraArgs
 
-        if !empty(l:cargoExtraArgs)
-            let l:cmd += ['--'] + l:cargoExtraArgs
+        if !empty(l:executableArgs)
+            let l:cmd += ['--'] + l:executableArgs
         endif
 
         call lsp_settings#utils#term_start(l:cmd, {'cwd': l:workspaceRoot})

--- a/settings/rust-analyzer.vim
+++ b/settings/rust-analyzer.vim
@@ -45,7 +45,7 @@ function! s:rust_analyzer_run_single(context) abort
         return
     endif
 
-    if l:argument['kind'] == 'cargo'
+    if l:argument['kind'] ==# 'cargo'
         let l:label = get(l:argument, 'label', 'cargo')
         let l:args = get(l:argument, 'args', {})
         let l:workspaceRoot = get(l:args, 'workspaceRoot', getcwd())


### PR DESCRIPTION
Demo: https://asciinema.org/a/381194

This is how it shows in vim:
![image](https://user-images.githubusercontent.com/287744/103142514-3068ca00-46b9-11eb-9149-f3ba19661cc6.png)
![image](https://user-images.githubusercontent.com/287744/103142681-25fbff80-46bc-11eb-8a29-c39551908547.png)


This is how vscode works:
![image](https://user-images.githubusercontent.com/287744/103142512-1c24cd00-46b9-11eb-91f4-ab568d8d40e3.png)
![image](https://user-images.githubusercontent.com/287744/103142684-36ac7580-46bc-11eb-8f0b-94627f9ccf31.png)

In the future we might want vim-lsp to support virtual text for codelens so it is easier to discover like in vscode. Currently it is a bit difficult to see.
![image](https://user-images.githubusercontent.com/287744/103142699-9e62c080-46bc-11eb-9f1c-96aca5e49145.png)


Added a util method so we can easily spawn terminal in both vim and neovim. `lsp_settings#utils#term_start`.

This would be really useful to run tests or snippet of code. This could ideally help remove plugins such as [vim-test](https://github.com/vim-test/vim-test)