### PR TITLE
Update sumneko-lua-language-server to 1.8.1

### DIFF
--- a/installer/install-sumneko-lua-language-server.cmd
+++ b/installer/install-sumneko-lua-language-server.cmd
@@ -1,7 +1,7 @@
 @echo off
 
 setlocal
-set VERSION=0.20.3
+set VERSION=1.8.1
 curl -L -o "vscode-lua.vsix" "https://github.com/sumneko/vscode-lua/releases/download/v%VERSION%/lua-%VERSION%.vsix"
 
 call "%~dp0\run_unzip.cmd" vscode-lua.vsix

--- a/installer/install-sumneko-lua-language-server.sh
+++ b/installer/install-sumneko-lua-language-server.sh
@@ -13,7 +13,7 @@ darwin)
 	;;
 esac
 
-version="0.20.3"
+version="1.8.1"
 url="https://github.com/sumneko/vscode-lua/releases/download/v$version/lua-$version.vsix"
 asset="vscode-lua.vsix"
 


### PR DESCRIPTION
I tried it in my environment and it seemed to work fine, so I upgraded it.

- GitHub release
    - https://github.com/sumneko/vscode-lua/releases/tag/v1.8.1