### PR TITLE
Update pyls-ms to 0.5.59

### DIFF
--- a/installer/install-pyls-ms.cmd
+++ b/installer/install-pyls-ms.cmd
@@ -5,7 +5,7 @@ set VERSION=3.1.1
 curl -L -o dotnet-runtime-%VERSION%-win-x64.zip "https://download.visualstudio.microsoft.com/download/pr/d9768135-4646-4839-9eea-b404bb940452/8275e4320514bab636b1627c62906ef9/dotnet-runtime-%VERSION%-win-x64.zip"
 call "%~dp0\run_unzip.cmd" dotnet-runtime-%VERSION%-win-x64.zip
 
-set VERSION=0.5.51
+set VERSION=0.5.59
 set url=https://pvsc.blob.core.windows.net/python-language-server-stable/Python-Language-Server-win-x64.%VERSION%.nupkg
 
 set nupkg=./pyls.nupkg

--- a/installer/install-pyls-ms.sh
+++ b/installer/install-pyls-ms.sh
@@ -17,7 +17,7 @@ darwin)
 *) ;;
 esac
 
-version="0.5.51"
+version="0.5.59"
 url="https://pvsc.azureedge.net/python-language-server-stable/Python-Language-Server-${system}-x64.${version}.nupkg"
 
 nupkg="./pyls.nupkg"


### PR DESCRIPTION
## Description

I tried it in my environment and it seemed to work fine, so I upgraded it.

## Download URL

**osx**

https://pvsc.blob.core.windows.net/python-language-server-stable/Python-Language-Server-osx-x64.0.5.59.nupkg

**win**

https://pvsc.blob.core.windows.net/python-language-server-stable/Python-Language-Server-win-x64.0.5.59.nupkg

**linux**

https://pvsc.blob.core.windows.net/python-language-server-stable/Python-Language-Server-linux-x64.0.5.59.nupkg
