### PR TITLE
Add useLibraryCodeForTypes to pyright for jump to library

### DIFF
--- a/settings/pyright-langserver.vim
+++ b/settings/pyright-langserver.vim
@@ -8,7 +8,8 @@ augroup vim_lsp_settings_pyright_langserver
       \ 'allowlist': lsp_settings#get('pyright-langserver', 'allowlist', ['python']),
       \ 'blocklist': lsp_settings#get('pyright-langserver', 'blocklist', []),
       \ 'config': lsp_settings#get('pyright-langserver', 'config', lsp_settings#server_config('pyright-langserver')),
-      \ 'workspace_config': lsp_settings#get('pyright-langserver', 'workspace_config', {}),
+      \ 'workspace_config': lsp_settings#get('pyright-langserver', 'workspace_config', {
+      \ }),
       \ 'semantic_highlight': lsp_settings#get('pyright-langserver', 'semantic_highlight', {}),
       \ }
 augroup END


### PR DESCRIPTION
Currently default pyright setting can't `:LspDefinition` to 3rd party library.
Add `useLibraryCodeForTypes` to workspace_config for enable `:LspDefinition`


before

https://user-images.githubusercontent.com/56591/103451594-27a37400-4d09-11eb-8007-5a065a105486.mp4

after

https://user-images.githubusercontent.com/56591/103451596-31c57280-4d09-11eb-8088-d6059055a729.mp4