### PR TITLE
test and generate codelens support for gopls 

### DIFF
--- a/settings/gopls.vim
+++ b/settings/gopls.vim
@@ -9,6 +9,7 @@ augroup vim_lsp_settings_gopls
       \     'completeUnimported': v:true,
       \     'matcher': 'fuzzy',
       \     'codelens': {
+      \         'generate': v:true,
       \         'test': v:true,
       \     },
       \ }),
@@ -26,6 +27,7 @@ function! s:register_command() abort
     if s:setup == 1 | return | endif
     let s:setup = 1
     call lsp#register_command('gopls.test', function('s:gopls_test'))
+    call lsp#register_command('gopls.generate', function('s:gopls_generate'))
 endfunction
 
 function! s:gopls_test(context) abort
@@ -42,4 +44,15 @@ function! s:gopls_test(context) abort
     else
         call lsp_settings#utils#error('Unsupported gopls.test ' . json_encode(l:command))
     endif
+endfunction
+
+function! s:gopls_generate(context) abort
+    let l:command = get(a:context, 'command', {})
+    let l:arguments = get(l:command, 'arguments', [])
+    let l:package = l:arguments[0]
+    let l:recursive = l:arguments[1]
+
+    let l:cmd = ['go', 'generate', l:recursive ? './..' : l:package]
+
+    call lsp_settings#utils#term_start(l:cmd, {})
 endfunction

--- a/settings/gopls.vim
+++ b/settings/gopls.vim
@@ -4,11 +4,42 @@ augroup vim_lsp_settings_gopls
       \ 'name': 'gopls',
       \ 'cmd': {server_info->lsp_settings#get('gopls', 'cmd', [lsp_settings#exec_path('gopls')])},
       \ 'root_uri':{server_info->lsp_settings#get('gopls', 'root_uri', lsp_settings#root_uri('gopls'))},
-      \ 'initialization_options': lsp_settings#get('gopls', 'initialization_options', {"diagnostics": v:true, 'completeUnimported': v:true, 'matcher': 'fuzzy'}),
+      \ 'initialization_options': lsp_settings#get('gopls', 'initialization_options', {
+      \     'diagnostics': v:true,
+      \     'completeUnimported': v:true,
+      \     'matcher': 'fuzzy',
+      \     'codelens': {
+      \         'test': v:true,
+      \     },
+      \ }),
       \ 'allowlist': lsp_settings#get('gopls', 'allowlist', ['go']),
       \ 'blocklist': lsp_settings#get('gopls', 'blocklist', []),
       \ 'config': lsp_settings#get('gopls', 'config', lsp_settings#server_config('gopls')),
       \ 'workspace_config': lsp_settings#get('gopls', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('gopls', 'semantic_highlight', {}),
       \ }
+  autocmd User lsp_setup call s:register_command()
 augroup END
+
+let s:setup = 0
+function! s:register_command() abort
+    if s:setup == 1 | return | endif
+    let s:setup = 1
+    call lsp#register_command('gopls.test', function('s:gopls_test'))
+endfunction
+
+function! s:gopls_test(context) abort
+    let l:command = get(a:context, 'command', {})
+    let l:arguments = get(l:command, 'arguments', [])
+    let l:testfile = lsp#utils#uri_to_path(get(l:arguments, 0, ''))
+    let l:package = fnamemodify(l:testfile, ':h')
+    let l:test = get(l:arguments, 1, [])
+    let l:cmd = ['go']
+
+    if len(l:test) > 0
+        let l:cmd += ['test', '-run', l:test[0], l:package]
+        call lsp_settings#utils#term_start(l:cmd, {})
+    else
+        call lsp_settings#utils#error('Unsupported gopls.test ' . json_encode(l:command))
+    endif
+endfunction


### PR DESCRIPTION
Add support for `gopls.test` and `gopls.generate`.

# gopls.test

* open a go test file and type `:LspCodeLens` to see available choices
![image](https://user-images.githubusercontent.com/287744/103471931-a1ecec00-4d3b-11eb-889e-313f4eb4ac3d.png)
* Select an input and run the test.
![image](https://user-images.githubusercontent.com/287744/103471939-d06ac700-4d3b-11eb-9b38-66c5c59d9a2f.png)

# gopls.generate

* open a go file that has `//go:generate` and type `:LspCodeLens` to see available choices
![image](https://user-images.githubusercontent.com/287744/103471952-f3957680-4d3b-11eb-96be-cff24cc846e4.png)
* Unfortunately `go generate` command doesn't any output so we see the following empty terminal but it does run.
![image](https://user-images.githubusercontent.com/287744/103471964-158ef900-4d3c-11eb-9d53-e4e789336fc0.png)

@mattn I don't use go so took some to figure out how to run commands. I didn't implement for benchmark yet since I dont know how to do it. Feel free to merge and then add those support or edit this PR directly.

We should look into improving the UI for codelens selection. https://github.com/vim/vim/issues/7553

There are more command available if we want to add in the future.

https://github.com/golang/tools/blob/fa6651ede5aa469c35af97715cb06fb43ff99ec3/internal/lsp/source/command.go#L58-L76. I will let folks who work on go add others.

```go
var Commands = []*Command{
	CommandGenerate,
	CommandFillStruct,
	CommandRegenerateCgo,
	CommandTest,
	CommandTidy,
	CommandUpdateGoSum,
	CommandUndeclaredName,
	CommandGoGetPackage,
	CommandAddDependency,
	CommandUpgradeDependency,
	CommandRemoveDependency,
	CommandVendor,
	CommandExtractVariable,
	CommandExtractFunction,
	CommandToggleDetails,
	CommandGenerateGoplsMod,
}
```