### PR TITLE
Add psalm-language-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Because there is no way to update a server, please run `:LspInstallServer` again
 | Lua              | sumneko-lua-language-server       | Yes       | Yes           |
 | Nim              | nimls                             | No        | No            |
 | PHP              | intelephense                      | Yes       | Yes           |
+| PHP              | psalm-language-server             | Yes       | Yes           |
 | OCaml            | ocaml-lsp                         | UNIX Only | Yes           |
 | Python           | pyls-all (pyls with dependencies) | Yes       | Yes           |
 | Python           | pyls (pyls without dependencies)  | Yes       | Yes           |

--- a/installer/install-psalm-language-server.cmd
+++ b/installer/install-psalm-language-server.cmd
@@ -1,0 +1,10 @@
+@echo off
+
+call composer require vimeo/psalm
+
+echo @echo off ^
+
+call %%~dp0\vendor\bin\psalm-language-server.cmd %%* ^
+
+> %1.cmd
+

--- a/installer/install-psalm-language-server.sh
+++ b/installer/install-psalm-language-server.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+
+composer require vimeo/psalm
+ln -s "./vendor/bin/psalm-language-server" .

--- a/settings.json
+++ b/settings.json
@@ -607,6 +607,19 @@
       "requires": [
         "npm"
       ]
+    },
+    {
+      "command": "psalm-language-server",
+      "config": {
+        "refresh_pattern": "\\(\\$[a-zA-Z0-9_:]*\\|\\k\\+\\)$"
+      },
+      "requires": [
+        "composer"
+      ],
+      "root_uri_patterns": [
+        "psalm.xml",
+        "psalm.xml.dist"
+      ]
     }
   ],
   "plaintex": [

--- a/settings/psalm-language-server.vim
+++ b/settings/psalm-language-server.vim
@@ -1,0 +1,14 @@
+augroup vim_lsp_settings_psalm_language_server
+  au!
+  LspRegisterServer {
+      \ 'name': 'psalm-language-server',
+      \ 'cmd': {server_info->lsp_settings#get('psalm-language-server', 'cmd', [lsp_settings#exec_path('psalm-language-server')])},
+      \ 'root_uri':{server_info->lsp_settings#get('psalm-language-server', 'root_uri', lsp_settings#root_uri('psalm-language-server'))},
+      \ 'initialization_options': lsp_settings#get('psalm-language-server', 'initialization_options', {}),
+      \ 'allowlist': lsp_settings#get('psalm-language-server', 'allowlist', ['php']),
+      \ 'blocklist': lsp_settings#get('psalm-language-server', 'blocklist', []),
+      \ 'config': lsp_settings#get('psalm-language-server', 'config', lsp_settings#server_config('psalm-language-server')),
+      \ 'workspace_config': lsp_settings#get('psalm-language-server', 'workspace_config', {}),
+      \ 'semantic_highlight': lsp_settings#get('psalm-language-server', 'semantic_highlight', {}),
+      \ }
+augroup END


### PR DESCRIPTION
## Description

Add `psalm-language-server` for PHP.

This project started as a static analysis tool, but now it also has the features of a language server.

- psalm
  - https://psalm.dev/
- Using Psalm’s Language Server
  - https://psalm.dev/docs/running_psalm/language_server/

## Demo

![add-psalm-ls](https://user-images.githubusercontent.com/188642/105978143-8c1ddd00-60d5-11eb-9982-5add30f7d4c8.gif)

## Notes (Just a hint for future searchers)

"psalm-language-server" will not start unless there is a configuration file (`psalm.xml` or `psalm.xml.dist`) in the project root.

The output result of `:LspStatus` command is `psalm-language-server: exited`.

