### PR TITLE
Changed "lemminx" download URL and upgraded version

### DIFF
--- a/installer/install-lemminx.cmd
+++ b/installer/install-lemminx.cmd
@@ -1,19 +1,11 @@
 @echo off
 
-curl -LO "https://repo.eclipse.org/content/repositories/lemminx-snapshots/org/eclipse/org.eclipse.lemminx/0.11.0-SNAPSHOT/org.eclipse.lemminx-0.11.0-20200309.180941-1-uber.jar"
-
 setlocal
-set VSCODE_XML_VERSION=0.11.0
-set LEMMINX_VERSION=0.11.1
-set URL=https://github.com/redhat-developer/vscode-xml/releases/download/%VSCODE_XML_VERSION%/redhat.vscode-xml-%VSCODE_XML_VERSION%.vsix
-set EXTENTION=redhat.vscode-xml-%VSCODE_XML_VERSION%.vsix
-set LEMMINX_JAR=org.eclipse.lemminx-%LEMMINX_VERSION%-uber.jar
+set VERSION=0.14.1
+set URL=https://repo.eclipse.org/content/repositories/lemminx-releases/org/eclipse/lemminx/org.eclipse.lemminx/%VERSION%/org.eclipse.lemminx-%VERSION%-uber.jar
+set LEMMINX_JAR=org.eclipse.lemminx-%VERSION%-uber.jar
 
-curl -L %URL% -o %EXTENTION%
-call "%~dp0\run_unzip.cmd" -d vscode-xml %EXTENTION%
-
-del %EXTENTION%
-copy vscode-xml\extension\server\%LEMMINX_JAR% .
+curl -L %URL% -o %LEMMINX_JAR%
 
 echo @echo off ^
 

--- a/installer/install-lemminx.sh
+++ b/installer/install-lemminx.sh
@@ -2,20 +2,11 @@
 
 set -e
 
-# Latest version is available on https://repo.eclipse.org/content/repositories/lemminx-snapshots/org/eclipse/org.eclipse.lemminx/.
-# But the lemminx snapshot jar on repo.eclipse.org seems to be obsolete when a new version is released.
-# To avoid confusion, this script refers to lemminx bundled with vscode-xml.
+version="0.14.1"
+url="https://repo.eclipse.org/content/repositories/lemminx-releases/org/eclipse/lemminx/org.eclipse.lemminx/${version}/org.eclipse.lemminx-${version}-uber.jar"
+lemminx_jar="org.eclipse.lemminx-${version}-uber.jar"
 
-vscode_xml_version="0.11.0"
-lemminx_version="0.11.1"
-url="https://github.com/redhat-developer/vscode-xml/releases/download/${vscode_xml_version}/redhat.vscode-xml-${vscode_xml_version}.vsix"
-extention="redhat.vscode-xml-${vscode_xml_version}.vsix"
-lemminx_jar="org.eclipse.lemminx-${lemminx_version}-uber.jar"
-
-curl -L "$url" -o "$extention"
-unzip -d vscode-xml "$extention"
-rm "$extention"
-ln -s "vscode-xml/extension/server/${lemminx_jar}" .
+curl -L "$url" -o "${lemminx_jar}"
 
 cat <<EOF >lemminx
 #!/usr/bin/env bash


### PR DESCRIPTION
The latest version of lemminx now seems to be `v0.14.1`.

Unfortunately, the "GitHub release" of `vscode-xml` has only been uploaded up to "vsix" of `v0.12.0`. https://github.com/redhat-developer/vscode-xml/releases/tag/0.12.0

I found a URL where I could get the latest official version and changed it to use that.

- https://repo.eclipse.org/content/repositories/lemminx-releases/org/eclipse/lemminx/org.eclipse.lemminx

In my environment, I was able to install and run it successfully on Mac and Windowns.

----

As a side note, I found this URL from `coc-xml` (fork of vscode-xml).