### PR TITLE
Update Metals to 0.9.10

### DIFF
--- a/installer/install-metals.cmd
+++ b/installer/install-metals.cmd
@@ -5,5 +5,5 @@ setlocal
 curl -Lo coursier https://git.io/coursier-cli
 curl -Lo coursier.bat https://git.io/coursier-bat
 
-set VERSION=0.9.4
+set VERSION=0.9.10
 java %JAVA_OPTS% -jar coursier bootstrap --ttl Inf "org.scalameta:metals_2.12:%VERSION%" -r "bintray:scalacenter/releases" -r "sonatype:public" -r "sonatype:snapshots" -o metals

--- a/installer/install-metals.sh
+++ b/installer/install-metals.sh
@@ -5,5 +5,5 @@ set -e
 curl -Lo ./coursier https://git.io/coursier-cli
 chmod +x ./coursier
 
-version="0.9.4"
+version="0.9.10"
 java -jar ./coursier bootstrap --ttl Inf "org.scalameta:metals_2.12:$version" -r "bintray:scalacenter/releases" -r "sonatype:public" -r "sonatype:snapshots" -o ./metals


### PR DESCRIPTION
Bumps the version number for the installers for Scala Metals