### PR TITLE
Fix duplicate command error on re-sourcing settings scripts

### DIFF
--- a/settings/gopls.vim
+++ b/settings/gopls.vim
@@ -22,9 +22,8 @@ augroup vim_lsp_settings_gopls
   autocmd User lsp_setup call s:register_command()
 augroup END
 
-let s:setup = 0
 function! s:register_command() abort
-    if s:setup == 1 | return | endif
+    if get(s:, 'setup') | return | endif
     let s:setup = 1
     call lsp#register_command('gopls.test', function('s:gopls_test'))
     call lsp#register_command('gopls.generate', function('s:gopls_generate'))

--- a/settings/rust-analyzer.vim
+++ b/settings/rust-analyzer.vim
@@ -85,12 +85,8 @@ function! s:rust_analyzer_run_single(context) abort
     endif
 endfunction
 
-let s:setup = 0
-
 function! s:register_command() abort
-  if s:setup == 1
-    return
-  endif
+  if get(s:, 'setup') | return | endif
   let s:setup = 1
   augroup vimlsp_settings_rust_analyzer
     au!


### PR DESCRIPTION
Recently in the commit 90d5216ef25ae82baf8870b676bad9ed60a79089, gopls setting file is sourced on both `*.go` and `go.mod`. But when I

- open a go.mod file
- open a example.go file,

I get the following error.
```
Error detected while processing function <lambda>56[1]..BufRead Autocommands for "*.go"..FileType Autocommands for "go"..function <SNR>76_vim_lsp_load_or_s
uggest[105]..User Autocommands for "lsp_setup"..function <SNR>131_register_command[3]..lsp#register_command[1]..lsp#ui#vim#execute_command#_register[2]..function <lambda>56[1]..BufRead Autocommands
for "*.go"..FileType Autocommands for "go"..function <SNR>76_vim_lsp_load_or_suggest[105]..User Autocommands for "lsp_setup"..function <SNR>131_register_command[3]..lsp#register_command[1]..lsp#ui#v
im#execute_command#_register:
line    2:
E605: Exception not caught: lsp#ui#vim#execute_command#_register_command: gopls.test already registered.
```
This occurs because the script is loaded by `exe 'source' l:script` (I mean not autoload) and `let s:setup = 0` is executed on the second run. So in order to load the script by `source` and also avoid re-registration of the commands, we need to remove `let s:setup = 0` from the toplevel of the scripts.