### PR TITLE
Add graphql-language-service-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Because there is no way to update a server, please run `:LspInstallServer` again
 | Fortran          | fortls                            | Yes       | Yes           |
 | Go               | gopls                             | Yes       | Yes           |
 | Go               | golangci-lint-langserver          | Yes       | Yes           |
+| GraphQL          | graphql-language-service-cli      | Yes       | Yes           |
 | GraphQL          | gql-language-server               | Yes       | Yes           |
 | Groovy           | groovy-language-server            | Yes       | Yes           |
 | Haskell          | haskell-ide-engine                | No        | No            |
@@ -165,6 +166,16 @@ There is a Linux OS/version that does not run the locally installed clangd due t
 ### rls (Rust)
 
 If you installed rls already, you can use rls without configurations. But if you have not installed rls yet, you can install it by following [these instructions](https://github.com/rust-lang/rls#setup).
+
+### graphql-language-service-cli(GraphQL)
+
+To use graphql-language-service-cli, the [GraphQL Config](https://graphql-config.com/introduction#examples) has to be located on the top of project directory. The schema must be pointed to the schema file correctly.
+
+```json
+{
+  "schema": "./schema.graphql"
+}
+```
 
 ### gql-language-server (GraphQL)
 

--- a/installer/install-graphql-language-server.cmd
+++ b/installer/install-graphql-language-server.cmd
@@ -1,0 +1,14 @@
+@echo off
+
+if not exist package.json (
+	call npm init -y
+
+	echo {"name":""}>package.json
+)
+
+call npm install "graphql"
+call npm install "graphql-language-service-cli"
+
+echo @echo off ^
+
+call %%~dp0\node_modules\.bin\graphql-lsp %%* graphql-language-server

--- a/installer/install-graphql-language-server.cmd
+++ b/installer/install-graphql-language-server.cmd
@@ -11,4 +11,6 @@ call npm install "graphql-language-service-cli"
 
 echo @echo off ^
 
-call %%~dp0\node_modules\.bin\graphql-lsp %%* graphql-language-server
+call %%~dp0\node_modules\.bin\graphql-lsp %%* ^
+
+> graphql-language-server.cmd

--- a/installer/install-graphql-language-server.sh
+++ b/installer/install-graphql-language-server.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ ! -f package.json ]; then
+  # Avoid the problem of not being able to install the same package as name in package.json.
+  # Create an empty package.json.
+  npm init -y
+  echo '{"name": ""}' >package.json
+fi
+
+npm install "graphql"
+npm install "graphql-language-service-cli"
+ln -s "./node_modules/.bin/graphql-lsp" graphql-language-server

--- a/settings.json
+++ b/settings.json
@@ -302,6 +302,28 @@
   ],
   "graphql": [
     {
+      "command": "graphql-language-server",
+      "requires": [
+        "npm"
+      ],
+      "root_uri_patterns": [
+        ".graphqlrc",
+        ".graphqlrc.json",
+        ".graphqlrc.yml",
+        ".graphqlrc.yaml",
+        ".graphql.config.js",
+        ".graphqlrc.js",
+        "package.json",
+        "tsconfig.json"
+      ],
+      "vim_plugin": {
+        "extensions": [
+          "graphql"
+        ],
+        "name": "jparise/vim-graphql"
+      }
+    },
+    {
       "command": "gql-language-server",
       "requires": [
         "npm",

--- a/settings/graphql-language-server.vim
+++ b/settings/graphql-language-server.vim
@@ -1,0 +1,14 @@
+augroup vim_lsp_settings_graphql-language-server
+  au!
+  LspRegisterServer {
+      \ 'name': 'graphql-language-server',
+      \ 'cmd': {server_info->lsp_settings#get('graphql-language-server', 'cmd', [lsp_settings#exec_path('graphql-language-server'), 'server', '--method', 'stream'])},
+      \ 'root_uri':{server_info->lsp_settings#get('graphql-language-server', 'root_uri', lsp_settings#root_uri('graphql-language-server'))},
+      \ 'initialization_options': lsp_settings#get('graphql-language-server', 'initialization_options', {'diagnostics': 'true'}),
+      \ 'allowlist': lsp_settings#get('graphql-language-server', 'allowlist', ['graphql']),
+      \ 'blocklist': lsp_settings#get('graphql-language-server', 'blocklist', []),
+      \ 'config': lsp_settings#get('graphql-language-server', 'config', lsp_settings#server_config('graphql-language-server')),
+      \ 'workspace_config': lsp_settings#get('graphql-language-server', 'workspace_config', {}),
+      \ 'semantic_highlight': lsp_settings#get('graphql-language-server', 'semantic_highlight', {}),
+      \ }
+augroup END


### PR DESCRIPTION
Add [graphql-language-service-cli](https://github.com/graphql/graphiql/tree/main/packages/graphql-language-service-cli#readme) for GraphQL.

## Screencast
https://user-images.githubusercontent.com/56591/107531680-6e399780-6c00-11eb-8dd0-0fe0e225c263.mp4

## How to setup

- `:LspInstallServer graphql-language-server`
- Add `.graphqlrc` file to your project root(`.graphqlrc.{js,json,yml,yaml}` or `.graphqlrc.js`).
- `.graphqlrc` should include schema file path
e.g.
```
{
  "schema": "./schema.graphql"
}
```
- download(or generate) GitHub graphql schema 
  - e.g `curl -O https://raw.githubusercontent.com/octokit/graphql-schema/master/schema.graphql` 
- Edit sample.graphql

## Help wanted

I'm not familier with Windows cmd.
Please review `installer/install-graphql-language-server.cmd` file 🙇 