### PR TITLE
Add support for http(s) proxy when pulling metals artifacts with java

### DIFF
--- a/installer/install-metals.sh
+++ b/installer/install-metals.sh
@@ -6,4 +6,22 @@ curl -Lo ./coursier https://git.io/coursier-cli
 chmod +x ./coursier
 
 version="0.9.10"
-java -jar ./coursier bootstrap --ttl Inf "org.scalameta:metals_2.12:$version" -r "bintray:scalacenter/releases" -r "sonatype:public" -r "sonatype:snapshots" -o ./metals
+java_flags=()
+
+if [[ -n "${https_proxy}" ]]; then
+  readonly https_proxy_without_protocol="${https_proxy#http://}"
+  java_flags+=("-Dhttps.proxyHost=${https_proxy_without_protocol%:*}")
+  java_flags+=("-Dhttps.proxyPort=${https_proxy_without_protocol##*:}")
+fi
+
+if [[ -n "${http_proxy}" ]]; then
+  http_proxy_without_protocol="${http_proxy#http://}"
+  java_flags+=("-Dhttp.proxyHost=${http_proxy_without_protocol%:*}")
+  java_flags+=("-Dhttp.proxyPort=${http_proxy_without_protocol##*:}")
+fi
+
+if [[ -n "${no_proxy}" ]]; then
+  java_flags+=("-Dhttp.nonProxyHosts=${no_proxy}")
+fi
+
+java "${java_flags[@]}" -jar ./coursier bootstrap --ttl Inf "org.scalameta:metals_2.12:${version}" -r "bintray:scalacenter/releases" -r "sonatype:public" -r "sonatype:snapshots" -o ./metals


### PR DESCRIPTION
Behind a corporate proxy I couldn't install metals lsp due to proxy issues.

This PR adds support for proxy when calling java binary in installer/install-metals.sh 