### PR TITLE
Fix deno lsp did not work at `.git` contained directory

### DIFF
--- a/settings/deno.vim
+++ b/settings/deno.vim
@@ -14,7 +14,7 @@ augroup vim_lsp_settings_deno
       \   },
       \ }),
       \ 'allowlist': lsp_settings#get('deno', 'allowlist', ['typescript', 'javascript', 'typescriptreact', 'javascriptreact']),
-      \ 'blocklist': lsp_settings#get('deno', 'blocklist', {c->empty(lsp_settings#root_path(['node_modules'])) ? [] : ['typescript', 'javascript', 'typescriptreact', 'javascriptreact']}),
+      \ 'blocklist': lsp_settings#get('deno', 'blocklist', {c->empty(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), 'node_modules/')) ? [] : ['typescript', 'javascript', 'typescriptreact', 'javascriptreact']}),
       \ 'config': lsp_settings#get('deno', 'config', lsp_settings#server_config('deno')),
       \ 'workspace_config': lsp_settings#get('deno', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('deno', 'semantic_highlight', {}),


### PR DESCRIPTION
closes #394 

Checklist

- [x] TS project which contains`node_modules` directory
- [x] Deno project which does not contains `node_modules` directory
- [x] Deno project which contains `.git` directory
