### PR TITLE
Update ntt release URL

### DIFF
--- a/installer/install-ntt.cmd
+++ b/installer/install-ntt.cmd
@@ -1,5 +1,4 @@
 @echo off
 
 setlocal
-set VERSION=0.5
 curl -L "https://github.com/nokia/ntt/releases/latest/download/ntt_windows_x86_64.tar.gz" | tar xz ntt.exe

--- a/installer/install-ntt.cmd
+++ b/installer/install-ntt.cmd
@@ -2,4 +2,4 @@
 
 setlocal
 set VERSION=0.5
-curl -L "https://github.com/nokia/ntt/releases/download/v%VERSION%/ntt_windows_x86_64.tar.gz" | tar xz ntt.exe
+curl -L "https://github.com/nokia/ntt/releases/latest/download/ntt_windows_x86_64.tar.gz" | tar xz ntt.exe

--- a/installer/install-ntt.sh
+++ b/installer/install-ntt.sh
@@ -8,7 +8,7 @@ os="$(uname -s | tr "[:upper:]" "[:lower:]")"
 
 case "${os}" in
 darwin|linux)
-  url="https://github.com/nokia/ntt/releases/download/v${version}/ntt_${os}_x86_64.tar.gz"
+  url="https://github.com/nokia/ntt/releases/latest/download/ntt_${os}_x86_64.tar.gz"
   curl -L "$url" | tar xz ntt
   chmod +x ntt
   ;;

--- a/installer/install-ntt.sh
+++ b/installer/install-ntt.sh
@@ -3,7 +3,6 @@
 set -e
 set -o pipefail
 
-version="0.5"
 os="$(uname -s | tr "[:upper:]" "[:lower:]")"
 
 case "${os}" in


### PR DESCRIPTION
This PR replaces the old TTCN-3 language server URL with one pointing always to the latest language server version.
