### PR TITLE
FIx artifact url in intall-fsautocomplete.sh,cmd

### DIFF
--- a/installer/install-fsautocomplete.cmd
+++ b/installer/install-fsautocomplete.cmd
@@ -6,7 +6,7 @@ set HASH=d9768135-4646-4839-9eea-b404bb940452/8275e4320514bab636b1627c62906ef9
 curl -L -o dotnet-runtime-%VERSION%-win-x64.zip "https://download.visualstudio.microsoft.com/download/pr/%HASH%/dotnet-runtime-%VERSION%-win-x64.zip"
 call "%~dp0\run_unzip.cmd" dotnet-runtime-%VERSION%-win-x64.zip
 
-set url=https://ci.appveyor.com/api/projects/fsautocomplete/fsautocomplete/artifacts/bin/pkgs/fsautocomplete.netcore.zip?branch=master
+set url=https://github.com/fsharp/FsAutoComplete/releases/latest/download/fsautocomplete.netcore.zip
 
 set zip=fsautocomplete.zip
 curl -L %url% -o %zip%

--- a/installer/install-fsautocomplete.sh
+++ b/installer/install-fsautocomplete.sh
@@ -12,7 +12,7 @@ else
   dotnetcmd="\\$DIR/.dotnet/dotnet"
 fi
 
-url="https://ci.appveyor.com/api/projects/fsautocomplete/fsautocomplete/artifacts/bin/pkgs/fsautocomplete.netcore.zip?branch=master"
+url="https://github.com/fsharp/FsAutoComplete/releases/latest/download/fsautocomplete.netcore.zip"
 zip=fsautocomplete.zip
 curl -L "$url" -o "$zip"
 unzip -o -d "fsautocomplete.netcore" "$zip"


### PR DESCRIPTION
[FSAC seems to be started to release artifacts on Github release](https://github.com/fsharp/FsAutoComplete/commit/c8d28c4dca230d0f319bb4efce574650fb245071#diff-5ebd60ceb88910043c04c5a665d836197d7184488edcf52f590e8fcad6101519R124). Since FSAC doesn't use Appveyor anymore for build and deployment, its artifact url is also not available.

```
~/.local/src/vim-lsp-settings/installer: curl 'https://ci.appveyor.com/api/projects/fsautocomplete/fsautocomplete/artifacts/bin/pkgs/fsautocomplete.netcore.zip?branch=master'
{"message":"Artifact not found or access denied."}% 
```

This PR updates the artifact url of the FSAC in installer/install-fsautocomplete.fs/cmd`

Tested on macOS/Apple silicon.