### PR TITLE
Add :LspCargoReload for rust-analyzer

### DIFF
--- a/settings/rust-analyzer.vim
+++ b/settings/rust-analyzer.vim
@@ -22,6 +22,9 @@ augroup END
 function! s:on_lsp_buffer_enabled() abort
   command! -buffer LspOpenCargoToml call <SID>open_cargo_toml()
   nnoremap <buffer> <plug>(lsp-open-cargo-toml) :<c-u>call <SID>open_cargo_toml()<cr>
+
+  command! -buffer LspCargoReload call <SID>reload_workspace()
+  nnoremap <buffer> <plug>(lsp-cargo-reload) :<c-u>call <SID>reload_workspace()<cr>
 endfunction
 
 function! s:open_cargo_toml() abort
@@ -35,6 +38,18 @@ function! s:open_cargo_toml() abort
         \ lsp#callbag#subscribe({
         \   'next':{x->lsp#utils#location#_open_lsp_location(x['response']['result'])},
         \   'error':{e->lsp_settings#utils#error(e)},
+        \ })
+        \ )
+endfunction
+
+function! s:reload_workspace() abort
+    call lsp#callbag#pipe(
+        \ lsp#request('rust-analyzer', {
+        \   'method': 'rust-analyzer/reloadWorkspace',
+        \ }),
+        \ lsp#callbag#subscribe({
+        \   'next': {x -> execute('echo "Cargo workspace reloaded"', '')},
+        \   'error': {e -> lsp_settings#utils#error(e)},
         \ })
         \ )
 endfunction


### PR DESCRIPTION
Similiar to neovim/nvim-lspconfig#755, adds a command `:LspCargoReload` to [reload the workspace](https://github.com/rust-analyzer/rust-analyzer/blob/911ff38eae53eeba7e94a6b01d44eef568b8c476/docs/dev/lsp-extensions.md#reload-workspace).

I find this useful as rust-analyzer sometimes doesn't detect changes to `Cargo.toml`.
This is especially annoying when editing dependencies, as they won't be resolved unless the server is restarted.

Hopefully this is fine. 😄