### PR TITLE
Update terraform-ls version to latest ( 0.15.0 )

### DIFF
--- a/installer/install-terraform-ls.cmd
+++ b/installer/install-terraform-ls.cmd
@@ -1,7 +1,7 @@
 @echo off
 
 setlocal
-set VERSION=0.8.0
+set VERSION=0.15.0
 curl -L -o terraform-ls_v%VERSION%.windows.x86_64.zip "https://github.com/hashicorp/terraform-ls/releases/download/v%VERSION%/terraform-ls_%VERSION%_windows_amd64.zip"
 call "%~dp0\run_unzip.cmd" terraform-ls_v%VERSION%.windows.x86_64.zip
 del terraform-ls_v%VERSION%.windows.x86_64.zip

--- a/installer/install-terraform-ls.sh
+++ b/installer/install-terraform-ls.sh
@@ -3,7 +3,7 @@
 set -e
 
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
-version="0.8.0"
+version="0.15.0"
 filename="terraform-ls_${version}.zip"
 
 case $os in


### PR DESCRIPTION
0.15.0 has released at 2021-03-12
https://github.com/hashicorp/terraform-ls/releases

In my local PC, 0.15.0 works well.
(Please tell me if there is another requirement to merge. :pray: )
