### PR TITLE
chore: bump tailwindcss-intellisense to 0.5.10

### DIFF
--- a/installer/install-tailwindcss-intellisense.cmd
+++ b/installer/install-tailwindcss-intellisense.cmd
@@ -1,7 +1,7 @@
 @echo off
 
 setlocal
-set VERSION=0.5.9
+set VERSION=0.5.10
 curl -L -o "vscode-tailwindcss.vsix" "https://github.com/tailwindlabs/tailwindcss-intellisense/releases/download/v%VERSION%/vscode-tailwindcss-%VERSION%.vsix"
 
 call "%~dp0\run_unzip.cmd" vscode-tailwindcss.vsix

--- a/installer/install-tailwindcss-intellisense.sh
+++ b/installer/install-tailwindcss-intellisense.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-version="0.4.1"
+version="0.5.10"
 url="https://github.com/tailwindlabs/tailwindcss-intellisense/releases/download/v$version/vscode-tailwindcss-$version.vsix"
 asset="vscode-tailwindcss.vsix"
 


### PR DESCRIPTION
This fixes using [Just-in-Time Mode](https://tailwindcss.com/docs/just-in-time-mode) in TailwindCSS 2.1.

As I bumped the `.cmd` file on macOS, I had this strange symbol when diffing the change.  Is that something that I can solve myself?

![Screen Shot 2021-04-14 at 18 25 34](https://user-images.githubusercontent.com/33870508/114745559-0f52e480-9d4f-11eb-9bcf-baf53676d084.png)

I'm running 0.5.10 just fine using the download script.  Using vanilla `vim-lsp` though.