### PR TITLE
Use latest release for omnisharp

### DIFF
--- a/installer/install-omnisharp-lsp.cmd
+++ b/installer/install-omnisharp-lsp.cmd
@@ -1,8 +1,7 @@
 @echo off
 
 setlocal
-set VERSION=1.37.5
-curl -L -o omnisharp-win-x64.zip "https://github.com/OmniSharp/omnisharp-roslyn/releases/download/v%VERSION%/omnisharp-win-x64.zip"
+curl -L -o omnisharp-win-x64.zip "https://github.com/OmniSharp/omnisharp-roslyn/releases/latest/download/omnisharp-win-x64.zip"
 call "%~dp0\run_unzip.cmd" omnisharp-win-x64.zip
 del omnisharp-win-x64.zip
 

--- a/installer/install-omnisharp-lsp.sh
+++ b/installer/install-omnisharp-lsp.sh
@@ -17,8 +17,7 @@ darwin)
   ;;
 esac
 
-version="v1.37.5"
-url="https://github.com/OmniSharp/omnisharp-roslyn/releases/download/$version/omnisharp-$os$arch.tar.gz"
+url="https://github.com/OmniSharp/omnisharp-roslyn/releases/latest/download/omnisharp-$os$arch.tar.gz"
 curl -L "$url" | tar xz
 
 chmod +x run


### PR DESCRIPTION
Changed to use the latest release for omnisharp. I haven't ran into any issues with updating manually to the latest version when they're released