### PR TITLE
Use clangd in Command Line Tools for Xcode on MacOS

### DIFF
--- a/installer/install-clangd.sh
+++ b/installer/install-clangd.sh
@@ -2,6 +2,17 @@
 
 set -e
 
+# On MacOS, use clangd in Command Line Tools for Xcode.
+if command -v xcrun 2>/dev/null && xcrun --find clangd 2>/dev/null; then
+  cat <<'EOF' >clangd
+#!/usr/bin/env bash
+
+exec xcrun --run clangd "$@"
+EOF
+  chmod +x clangd
+  exit
+fi
+
 if command -v lsb_release 2>/dev/null; then
   distributor_id=$(lsb_release -a 2>&1 | grep 'Distributor ID' | awk '{print $3}')
 elif [ -e /etc/fedora-release ]; then


### PR DESCRIPTION
Currently, `install-clang.sh` does not work on M1 Mac.

```sh
Downloading clangd and LLVM...
unxz: (stdin): File format not recognized
tar: clang+llvm-9.0.0-arm64-apple-darwin: Not found in archive
tar: Error exit delayed from previous errors.
```

Even in the [latest 12.0.0 release](https://github.com/llvm/llvm-project/releases/tag/llvmorg-12.0.0), `arm64-apple-darwin` is not available.

But most MacOS users (developers) uses Command Line Tools for Xcode, and it contains the llvm toolchains. This pull request fixes the installation script to use the CLT clangd if possible.