### PR TITLE
feat: vim-language-server latest config apply

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1090,6 +1090,9 @@
       "requires": [
         "npm"
       ],
+      "config": {
+        "refresh_pattern": "\\([bwtglsav]:\\)\\?\\k*$"
+      },
       "root_uri_patterns": [
         ".vim/",
         "vimfiles/"

--- a/settings/vim-language-server.vim
+++ b/settings/vim-language-server.vim
@@ -4,7 +4,12 @@ augroup vim_lsp_settings_vim_language_server
       \ 'name': 'vim-language-server',
       \ 'cmd': {server_info->lsp_settings#get('vim-language-server', 'cmd', [lsp_settings#exec_path('vim-language-server'), '--stdio'])},
       \ 'root_uri':{server_info->lsp_settings#get('vim-language-server', 'root_uri', lsp_settings#root_uri('vim-language-server'))},
-      \ 'initialization_options': extend({'vimruntime': $VIMRUNTIME, 'runtimepath': &rtp, 'iskeyword': &isk}, lsp_settings#get('vim-language-server', 'initialization_options', {}), 'force'),
+      \ 'initialization_options': extend({
+      \   'vimruntime': $VIMRUNTIME,
+      \   'runtimepath': &rtp,
+      \   'iskeyword': &isk,
+      \   'diagnostic': {'enable': v:true}
+      \  }, lsp_settings#get('vim-language-server', 'initialization_options', {}), 'force'),
       \ 'allowlist': lsp_settings#get('vim-language-server', 'allowlist', ['vim']),
       \ 'blocklist': lsp_settings#get('vimbash-language-server', 'blocklist', []),
       \ 'config': lsp_settings#get('vim-language-server', 'config', lsp_settings#server_config('vim-language-server')),

--- a/settings/vim-language-server.vim
+++ b/settings/vim-language-server.vim
@@ -5,6 +5,7 @@ augroup vim_lsp_settings_vim_language_server
       \ 'cmd': {server_info->lsp_settings#get('vim-language-server', 'cmd', [lsp_settings#exec_path('vim-language-server'), '--stdio'])},
       \ 'root_uri':{server_info->lsp_settings#get('vim-language-server', 'root_uri', lsp_settings#root_uri('vim-language-server'))},
       \ 'initialization_options': extend({
+      \   'isNeovim': has('nvim'),
       \   'vimruntime': $VIMRUNTIME,
       \   'runtimepath': &rtp,
       \   'iskeyword': &isk,

--- a/settings/vim-language-server.vim
+++ b/settings/vim-language-server.vim
@@ -4,7 +4,7 @@ augroup vim_lsp_settings_vim_language_server
       \ 'name': 'vim-language-server',
       \ 'cmd': {server_info->lsp_settings#get('vim-language-server', 'cmd', [lsp_settings#exec_path('vim-language-server'), '--stdio'])},
       \ 'root_uri':{server_info->lsp_settings#get('vim-language-server', 'root_uri', lsp_settings#root_uri('vim-language-server'))},
-      \ 'initialization_options': extend({'vimruntime': $VIMRUNTIME, 'runtimepath': &rtp}, lsp_settings#get('vim-language-server', 'initialization_options', {}), 'force'),
+      \ 'initialization_options': extend({'vimruntime': $VIMRUNTIME, 'runtimepath': &rtp, 'iskeyword': &isk}, lsp_settings#get('vim-language-server', 'initialization_options', {}), 'force'),
       \ 'allowlist': lsp_settings#get('vim-language-server', 'allowlist', ['vim']),
       \ 'blocklist': lsp_settings#get('vimbash-language-server', 'blocklist', []),
       \ 'config': lsp_settings#get('vim-language-server', 'config', lsp_settings#server_config('vim-language-server')),

--- a/settings/vim-language-server.vim
+++ b/settings/vim-language-server.vim
@@ -8,7 +8,7 @@ augroup vim_lsp_settings_vim_language_server
       \   'isNeovim': has('nvim'),
       \   'vimruntime': $VIMRUNTIME,
       \   'runtimepath': &rtp,
-      \   'iskeyword': &isk,
+      \   'iskeyword': &isk . ',:',
       \   'diagnostic': {'enable': v:true}
       \  }, lsp_settings#get('vim-language-server', 'initialization_options', {}), 'force'),
       \ 'allowlist': lsp_settings#get('vim-language-server', 'allowlist', ['vim']),


### PR DESCRIPTION
# Description

## Detail

Add below "initializationOptions" params:

- isNeovim : check has('nvim')
- iskeyword : copy form `iskeyword` option (isk) that appended ":"
- diagnostic.enable : set true

see https://github.com/iamcco/vim-language-server

And add config "refresh_pattern"

--

## Pros/Cons

### Pros

- neovim work fine
- completion work "s", "s:", "s:f".... suggeste to "s:funcname".
- and also work all other g:, l:....

### Cons

Nothing for my investigated result.


## Tuning

If reviewer think needing to add/remove config, please comment.