### PR TITLE
[POC] Support installing the server with custom version

### DIFF
--- a/autoload/lsp_settings.vim
+++ b/autoload/lsp_settings.vim
@@ -113,10 +113,14 @@ function! s:vim_lsp_installer(ft, ...) abort
     if l:missing !=# 0
       continue
     endif
+
     if lsp_settings#executable(l:command)
-      return [l:conf.command, l:command]
+      let l:version = lsp_settings#get(l:conf.command, 'version', '')
+      return [l:conf.command, l:command . ' ' . l:version]
     endif
+
   endfor
+
   return [v:false] " placeholder, so that empty() returns false, but len() < 2 returns true
 endfunction
 

--- a/installer/install-clojure-lsp.cmd
+++ b/installer/install-clojure-lsp.cmd
@@ -1,5 +1,5 @@
 @echo off
 
 setlocal
-set VERSION=2021.02.01-20.37.52
+set VERSION=%1:-2021.02.01-20.37.52%
 curl -L -o clojure-lsp.cmd https://github.com/clojure-lsp/clojure-lsp/releases/download/%VERSION%/clojure-lsp

--- a/installer/install-clojure-lsp.sh
+++ b/installer/install-clojure-lsp.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-version="2021.02.01-20.37.52"
+version=${1:-"2021.02.01-20.37.52"}
 curl -L -o clojure-lsp "https://github.com/clojure-lsp/clojure-lsp/releases/download/$version/clojure-lsp"
 chmod +x clojure-lsp

--- a/installer/install-elixir-ls.cmd
+++ b/installer/install-elixir-ls.cmd
@@ -1,7 +1,7 @@
 @echo off
 
 setlocal
-set VERSION=0.6.2
+set VERSION=%1:-0.6.2
 curl -L -o elixir-ls.zip "https://github.com/elixir-lsp/elixir-ls/releases/download/v%VERSION%/elixir-ls.zip"
 call "%~dp0\run_unzip.cmd" elixir-ls.zip
 del elixir-ls.zip

--- a/installer/install-elixir-ls.sh
+++ b/installer/install-elixir-ls.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-version="v0.6.2"
+version=${1:-"v0.6.2"}
 url="https://github.com/elixir-lsp/elixir-ls/releases/download/$version/elixir-ls.zip"
 curl -LO "$url"
 unzip elixir-ls.zip


### PR DESCRIPTION
### Why?

There are some LSP servers that have a steady update rate, and in order to not flood this repository with PR just to update the version I through that having custom-defined versions to install would be nice

### How it's done?

First we need to add the configuration as a `version` key in the language server configuration, for example:

```vim
let g:lsp_settings = { 'clojure-lsp': { 'version': '2021.05.22-16.50.45' } }
```

Then this version is retrieved in the language-server install process and is passed to the installer script as an argument when called, e.g. `installer/install-clojure-lsp.sh 2021.05.22-16.50.45`

Not sure if this the best approach ☝️  but is the one with the smaller footprint that I could think of

I already changed the `clojure-lsp` installer to test this approach and has worked nicely.

### Caveats

Each installer script (that install a specific version) would need to be changed in order to support this custom version argument, however, it would not break for current not changed installer scripts since the argument would be ignored

### Next steps?

Not sure, maybe change all installer scripts to support this argument? Another different approach? Being ok with having to send PRs to this repository 

Update: kinda related to #311?