### PR TITLE
Update elixir-ls version to 0.7.0

### DIFF
--- a/installer/install-elixir-ls.cmd
+++ b/installer/install-elixir-ls.cmd
@@ -1,7 +1,7 @@
 @echo off
 
 setlocal
-set VERSION=0.6.2
+set VERSION=0.7.0
 curl -L -o elixir-ls.zip "https://github.com/elixir-lsp/elixir-ls/releases/download/v%VERSION%/elixir-ls.zip"
 call "%~dp0\run_unzip.cmd" elixir-ls.zip
 del elixir-ls.zip

--- a/installer/install-elixir-ls.sh
+++ b/installer/install-elixir-ls.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-version="v0.6.2"
+version="v0.7.0"
 url="https://github.com/elixir-lsp/elixir-ls/releases/download/$version/elixir-ls.zip"
 curl -LO "$url"
 unzip elixir-ls.zip


### PR DESCRIPTION
The used version of [elixir-ls](https://github.com/elixir-lsp/elixir-ls) 0.6.2 does not work with the latest version of Elixir, it's better to use the latest version (0.7.0)