### PR TITLE
fix installer for rust analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 servers/*
 unzip.exe
 gzip.exe
+busybox.exe
 doc/tags

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 servers/*
 unzip.exe
+gzip.exe
 doc/tags

--- a/installer/install-rust-analyzer.cmd
+++ b/installer/install-rust-analyzer.cmd
@@ -1,6 +1,7 @@
 @echo off
 
 setlocal
-curl -L -o "rust-analyzer-windows.exe" "https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/rust-analyzer-windows.exe"
+curl -L -o "rust-analyzer-windows.gz" "https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/rust-analyzer-x86_64-pc-windows-msvc.gz"
+call "%~dp0\run_gzip.cmd" rust-analyzer-windows.gz
 
-move rust-analyzer-windows.exe rust-analyzer.exe
+move rust-analyzer-windows rust-analyzer.exe

--- a/installer/install-rust-analyzer.sh
+++ b/installer/install-rust-analyzer.sh
@@ -6,14 +6,15 @@ os=$(uname -s | tr "[:upper:]" "[:lower:]")
 
 case $os in
 linux)
-  platform="linux"
+  platform="x86_64-unknown-linux-gnu"
   ;;
 darwin)
-  platform="mac"
+  platform="x86_64-apple-darwin"
   ;;
 esac
 
-curl -L -o "rust-analyzer-$platform" "https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/rust-analyzer-$platform"
+curl -L -o "rust-analyzer-$platform.gz" "https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/rust-analyzer-$platform.gz"
+gzip -d "rust-analyzer-$platform.gz"
 
 mv rust-analyzer-$platform rust-analyzer
 chmod +x rust-analyzer

--- a/installer/run_gzip.cmd
+++ b/installer/run_gzip.cmd
@@ -4,6 +4,6 @@ where gzip 2>NUL
 if %ERRORLEVEL% equ 0 (
     gzip -d %*
 ) else (
-    curl -L -o %~dp0\gzip.exe https://github.com/mattn/vim-lsp-settings/releases/download/v0.0.1/gzip.exe
-    %~dp0\gzip -d %*
+    curl -L -o %~dp0\busybox.exe https://github.com/mattn/vim-lsp-settings/releases/download/v0.0.1/busybox.exe
+    %~dp0\busybox gzip -d %*
 )

--- a/installer/run_gzip.cmd
+++ b/installer/run_gzip.cmd
@@ -1,0 +1,9 @@
+@echo off
+
+where gzip 2>NUL
+if %ERRORLEVEL% equ 0 (
+    gzip -d %*
+) else (
+    curl -L -o %~dp0\gzip.exe https://github.com/mattn/vim-lsp-settings/releases/download/v0.0.1/gzip.exe
+    %~dp0\gzip -d %*
+)


### PR DESCRIPTION
- [x] fix x64 linux
- [ ] fix arm linux
- [x] fix x64 mac
- [ ] fix arm mac
- [x] fix x64 win
- [ ] fix arm win 

Seems like direct executable are no longer availalbe so need to get the `.gz` version instead.https://github.com/rust-analyzer/rust-analyzer/releases