### PR TITLE
fix: npm (un)install with whitespace paths

### DIFF
--- a/installer/npm_install.cmd
+++ b/installer/npm_install.cmd
@@ -14,6 +14,6 @@ call npm install "%2"
 
 echo @echo off ^
 
-call %%~dp0\node_modules\.bin\%1.cmd %%* ^
+call ^"%%~dp0\node_modules\.bin\%1.cmd^" %%* ^
 
-> %1.cmd
+> "%1.cmd"


### PR DESCRIPTION
When doing 
`:LspInstallServer yaml-language-server`
vim-lsp-settings is trying to install the server to: `C:\Users\Dominic Della Valle\AppData\Local\vim-lsp-settings\servers\yaml-language-server`.

But fails with:
```
Installing yaml-language-server
Error detected while processing function <SNR>63_vim_lsp_install_server:
line   28:
CreateProcess failed
Press ENTER or type command to continue
```
because the command being executed is interpreted as `C:\Users\Dominic` due to the space in the username.

This fixes it, but I'm not familiar with Vimscript.
If there's a more conventional way to join the paths for `mkdir` or translate them before passing them to `termopen`|`term_start` it can be changed. But otherwise I think it will be okay.

The changes to the `.cmd` file are similar to https://github.com/mattn/vim-lsp-settings/pull/319 
They do the same thing as the changes to the `.vim` file, but in batch instead of Vimscript.