### PR TITLE
Fix executing job failed: No such file or directory

### DIFF
--- a/autoload/lsp_settings.vim
+++ b/autoload/lsp_settings.vim
@@ -362,7 +362,11 @@ function! s:vim_lsp_install_server(ft, command, bang) abort
     split new
     call termopen(shellescape(l:entry[1]), {'cwd': l:server_install_dir, 'on_exit': function('s:vim_lsp_install_server_post', [l:entry[0]])}) | startinsert
   else
-    let l:bufnr = term_start(shellescape(l:entry[1]), {'cwd': l:server_install_dir})
+    if has('win32')
+      let l:bufnr = term_start(shellescape(l:entry[1]), {'cwd': l:server_install_dir})
+    else
+      let l:bufnr = term_start(l:entry[1], {'cwd': l:server_install_dir})
+    endif
     let l:job = term_getjob(l:bufnr)
     if l:job != v:null
       call job_setoptions(l:job, {'exit_cb': function('s:vim_lsp_install_server_post', [l:entry[0]])})


### PR DESCRIPTION
ref https://github.com/mattn/vim-lsp-settings/commit/104d20f4fe090b01d0ca777beab5901419183db3#diff-0f71cac29b971dde1e0f11724d4769272fa5b266f39676c9dfcd26f43f9a4d40R365

This commit raise `:LspInstallServer pyright-langserver` fail and show following message.

```
executing job failed: No such file or directory
```