### PR TITLE
fix ocaml-lsp install error.

### DIFF
--- a/installer/install-ocaml-lsp.sh
+++ b/installer/install-ocaml-lsp.sh
@@ -5,7 +5,7 @@ set -e
 DEFAULT_DIR="$(pwd)"
 
 # We should not download GitHub's zip file here, because it doesn't include some submodules.
-git clone --recurse-submodules http://github.com/ocaml/ocaml-lsp.git ocaml-lsp-files  --depth=1
+git clone --recurse-submodules http://github.com/ocaml/ocaml-lsp.git ocaml-lsp-files --depth=1
 cd ocaml-lsp-files
 
 rm -r lsp/test
@@ -14,7 +14,7 @@ export OPAMROOT
 
 opam init -a -n
 eval "$(opam env)" 2> /dev/null
-opam switch create . -y
+opam switch create . --with-test -y
 opam exec --switch=. dune build
 
 rm -rf .git


### PR DESCRIPTION
The following error occurred when I run `:LspInstallServer` on *.ml file .

```
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-> installed seq.base
-> installed ocamlfind.1.9.1
-> installed ocamlbuild.0.14.0
-> installed uchar.0.0.2
-> installed topkg.1.0.3
-> installed uutf.1.0.2
-> installed dune.2.8.5
-> installed dune-build-info.2.8.5
-> installed easy-format.1.3.2
-> installed result.1.5
-> installed pp.1.1.2
-> installed csexp.1.5.1
-> installed cppo.1.6.7
-> installed re.1.9.0
-> installed jsonrpc.1.6.1
-> installed biniou.1.2.1
-> installed yojson.1.7.0
-> installed ppx_yojson_conv_lib.v0.14.0
-> installed dot-merlin-reader.4.1
-> installed lsp.1.6.1
-> installed ocaml-lsp-server.1.6.1
Done.
# Run eval $(opam env) to update the current shell environment
Error: Program menhir not found in the tree or in PATH
 (context: default)
Hint: opam install menhir
File "fiber-unix/test/dune", line 20, characters 7-17:
20 |   (pps ppx_expect)))
            ^^^^^^^^^^
Error: Library "ppx_expect" not found.
Hint: try:
  dune external-lib-deps --missing @@default
File "jsonrpc-fiber/test/dune", line 22, characters 7-17:
22 |   (pps ppx_expect)))
            ^^^^^^^^^^
Error: Library "ppx_expect" not found.
Hint: try:
  dune external-lib-deps --missing @@default
File "lsp-fiber/test/dune", line 7, characters 7-17:
7 |   (pps ppx_expect))
           ^^^^^^^^^^
Error: Library "ppx_expect" not found.
Hint: try:
  dune external-lib-deps --missing @@default
File "ocaml-lsp-server/vendor/merlin/src/ocaml/preprocess/dune", line 49, characters 11-39:
49 |    (copy %{lib:menhirLib:menhirLib.mli} menhirLib.mli))))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: Library "menhirLib" not found.
Hint: try:
  dune external-lib-deps --missing @@default
File "ocaml-lsp-server/vendor/merlin/src/ocaml/preprocess/explain/dune", line 3, characters 17-26:
3 |  (libraries unix menhirSdk))
                     ^^^^^^^^^
Error: Library "menhirSdk" not found.
Hint: try:
  dune external-lib-deps --missing @@default
File "ocaml-lsp-server/vendor/merlin/src/ocaml/preprocess/printer/dune", line 3, characters 17-26:
3 |  (libraries unix menhirSdk))
                     ^^^^^^^^^
Error: Library "menhirSdk" not found.
Hint: try:
  dune external-lib-deps --missing @@default
File "ocaml-lsp-server/vendor/merlin/src/ocaml/preprocess/recover/dune", line 3, characters 17-26:
3 |  (libraries unix menhirSdk))
                     ^^^^^^^^^
Error: Library "menhirSdk" not found.
Hint: try:
  dune external-lib-deps --missing @@default
```

After edited the script, and it seems to be working fine.