### PR TITLE
Don't consider servers which are disabled or excluded for suggestion or for install

### DIFF
--- a/autoload/lsp_settings.vim
+++ b/autoload/lsp_settings.vim
@@ -91,11 +91,30 @@ function! s:vim_lsp_installer(ft, ...) abort
     let l:servers += s:settings['_']
   endif
 
+  let l:default = get(g:, 'lsp_settings_filetype_' . a:ft, '')
+
   let l:name = get(a:000, 0, '')
   for l:conf in l:servers
     if !empty(l:name) && l:conf.command != l:name
       continue
     endif
+
+    if lsp_settings#get(l:conf.command, 'disabled', get(l:conf, 'disabled', 0))
+      continue
+    endif
+
+    if type(l:default) ==# v:t_list
+      if len(l:default) ># 0 && index(l:default, l:server.command) == -1
+        continue
+      endif
+    elseif type(l:default) ==# v:t_string
+      if !empty(l:default) && l:default != l:server.command
+        continue
+      endif
+    else
+      continue
+    endif
+
     let l:command = printf('%s/install-%s', s:installer_dir, l:conf.command)
     if has('win32')
       let l:command = substitute(l:command, '/', '\', 'g') . '.cmd'

--- a/autoload/lsp_settings.vim
+++ b/autoload/lsp_settings.vim
@@ -100,18 +100,30 @@ function! s:vim_lsp_installer(ft, ...) abort
     endif
 
     if lsp_settings#get(l:conf.command, 'disabled', get(l:conf, 'disabled', 0))
+      if !empty(l:name) && l:conf.command == l:name
+        call lsp_settings#utils#warning(l:name . ' requested but is disabled by global or local settings')
+      endif
       continue
     endif
 
     if type(l:default) ==# v:t_list
       if len(l:default) ># 0 && index(l:default, l:server.command) == -1
+        if !empty(l:name) && l:conf.command == l:name
+          call lsp_settings#utils#warning(l:name . ' requested but is disabled by g:lsp_settings_filetype_' . a:ft)
+        endif
         continue
       endif
     elseif type(l:default) ==# v:t_string
       if !empty(l:default) && l:default != l:server.command
+        if !empty(l:name) && l:conf.command == l:name
+          call lsp_settings#utils#warning(l:name . ' requested but is disabled by g:lsp_settings_filetype_' . a:ft)
+        endif
         continue
       endif
     else
+      if !empty(l:name) && l:conf.command == l:name
+        call lsp_settings#utils#warning(l:name . ' requested but is disabled by g:lsp_settings_filetype_' . a:ft)
+      endif
       continue
     endif
 


### PR DESCRIPTION
When opening a perl file with all default settings, despite efm-langserver being disabled by default, it is still shown as an install suggestion.  Similarly, if you run `:LspInstallServer` it offers to install efm-langserver.

Perl currently has 3 servers with no installers defined, plus efm-langserver added to the end of the list, and all are checked regardless of the disabled status or being excluded by a user-defined `g:lsp_settings_filetype_...` variable, so efm-langserver is checked and suggested for install.

This case isn't as noticeable for filetypes with no servers defined or with installers available, but does show up for languages where there are installable servers that have been disabled by user preference.

This PR duplicates the checks that happen in `vim_lsp_load_or_suggest` to the similar loop in `vim_lsp_installer` which is searching for the first available installer.  The second commit adds a warning when the user requests a specific server to be installed and that server is currently disabled by config - they _could_ have installed it before this change but they'll want to fix their config in order to use that server anyway.