### PR TITLE
fix: deny filter fix removal

### DIFF
--- a/autoload/lsp_settings/profile.vim
+++ b/autoload/lsp_settings/profile.vim
@@ -57,8 +57,10 @@ function! s:filter_deny_keys(settings) abort
   endif
   for [l:name, l:setting] in items(a:settings)
     for [l:k, l:v] in items(l:setting)
-      for l:k in keys(l:deny_keys)
-        call remove(l:setting, l:k)
+      for l:deny in l:deny_keys
+        if has_key(l:v, l:deny)
+          call remove(l:v, l:deny)
+        endif
       endfor
     endfor
   endfor


### PR DESCRIPTION
## Problem

deny filter ( https://github.com/mattn/vim-lsp-settings/commit/5f1de5bd02a5875b40d35614b57a90e522b16dc2 ) implements.
And now this filter is not work fine.

## Fix

example

```json
{
  "yaml-language-server": {
    "workspace_config": {
      "yaml": {
        "schemas": {
          "https://mattn.github.io/efm-langserver/schema.json": "config/efm-langserver/config.yaml"
        }
      }
    }
  }
}
```

in https://github.com/tsuyoshicho/vim-efm-langserver-settings. work fine this PR.

---

## fix detail

```
loop

lang-server : langserver-setting pickup (ex yaml-language-server and these config)
 config-name : config-data pickup (ex workspace_config and these config)
  deny-key (ex `cmd`)
   check deny target key in config-data
     remove from config-data
```