### PR TITLE
fix: local settings deny filter more brush up

### DIFF
--- a/autoload/lsp_settings/profile.vim
+++ b/autoload/lsp_settings/profile.vim
@@ -55,8 +55,14 @@ function! s:filter_deny_keys(settings) abort
   if empty(l:deny_keys)
     return
   endif
-  for [l:name, l:setting] in items(a:settings)
-    for [l:k, l:v] in items(l:setting)
+  for l:setting in values(a:settings)
+    if v:t_dict !=# type(l:setting)
+      continue
+    endif
+    for l:v in values(l:setting)
+      if v:t_dict !=# type(l:v)
+        continue
+      endif
       for l:deny in l:deny_keys
         if has_key(l:v, l:deny)
           call remove(l:v, l:deny)


### PR DESCRIPTION
## Problem

related #452 

Previous PR fix `cmd` and other removal target process fine.

But that PR implicit premise `json converted settings are all vim dict`.
This implicit is false.

### For example

```json
{
  "deno": {
    "disabled": true
  }
}
```

(top level key:value, value as non dict)

see https://github.com/mattn/vim-lsp-settings#extra-configurations

---

## Solusion

This PR fix below:

- langserver settings(ex "deno": __target__ ) check dict
- setting value(ex "workspace_config": __terget__ ) check dict

and process brush up(memory saving, speed up?)

- this function need only values, replace `items()` to `values()`

Regerd.