### PR TITLE
Revert "fix to use yarn in yaml-language-server"

### DIFF
--- a/installer/install-yaml-language-server.cmd
+++ b/installer/install-yaml-language-server.cmd
@@ -1,3 +1,3 @@
 @echo off
 
-call "%~dp0\yarn_install.cmd" yaml-language-server yaml-language-server
+call "%~dp0\npm_install.cmd" yaml-language-server yaml-language-server

--- a/installer/install-yaml-language-server.sh
+++ b/installer/install-yaml-language-server.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-"$(dirname "$0")/yarn_install.sh" yaml-language-server yaml-language-server
+"$(dirname "$0")/npm_install.sh" yaml-language-server yaml-language-server


### PR DESCRIPTION
This reverts commit 25b05bcd98a9c13e99e72f8ee5e8350d271e40b1.

Since yaml-language-server is available via npm, we can use npm to
install the server again. And npm command is more available than yarn.

Ref: https://github.com/redhat-developer/yaml-language-server/issues/521
Ref: https://github.com/redhat-developer/yaml-language-server/pull/528