### PR TITLE
Fix dependency for graphql-language-service-cli

### DIFF
--- a/installer/install-graphql-language-server.cmd
+++ b/installer/install-graphql-language-server.cmd
@@ -6,7 +6,6 @@ if not exist package.json (
 	echo {"name":""}>package.json
 )
 
-call npm install "graphql"
 call npm install "graphql-language-service-cli"
 
 echo @echo off ^

--- a/installer/install-graphql-language-server.sh
+++ b/installer/install-graphql-language-server.sh
@@ -9,6 +9,5 @@ if [ ! -f package.json ]; then
   echo '{"name": ""}' >package.json
 fi
 
-npm install "graphql"
 npm install "graphql-language-service-cli"
 ln -s "./node_modules/.bin/graphql-lsp" graphql-language-server


### PR DESCRIPTION
When installing graphql-language-service-cli, the following error occurs.

```console
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: @undefined
npm ERR! Found: graphql@15.6.0
npm ERR! node_modules/graphql
npm ERR!   graphql@"^15.6.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer graphql@">= v14.5.0 <= 15.5.0" from graphql-language-service-cli@3.1.13
npm ERR! node_modules/graphql-language-service-cli
npm ERR!   graphql-language-service-cli@"*" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /Users/*********/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/*********/.npm/_logs/2021-10-04T15_36_55_335Z-debug.log
```

It seems the graphql-language-service-cli not follows newer version of graphql.
So I removed graphql from the installation script and it worked.
NOTE: I checkd it only macOS. 