### PR TITLE
Update volar-server to 0.28.0

### DIFF
--- a/installer/install-volar-server.cmd
+++ b/installer/install-volar-server.cmd
@@ -1,4 +1,4 @@
 @echo off
 
-call "%~dp0\npm_install.cmd" volar-server @volar/server@0.27.30
+call "%~dp0\npm_install.cmd" volar-server @volar/server@0.28.0
 call npm install typescript@4.4

--- a/installer/install-volar-server.sh
+++ b/installer/install-volar-server.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-"$(dirname "$0")/npm_install.sh" volar-server @volar/server@0.27.30
+"$(dirname "$0")/npm_install.sh" volar-server @volar/server@0.28.0
 npm install typescript@4.4

--- a/settings/volar-server.vim
+++ b/settings/volar-server.vim
@@ -146,8 +146,6 @@ let g:vim_lsp_settings_volar_config = {
 \     },
 \     'autoCompleteRefs': v:true,
 \     "takeOverBuiltinTsExtension": v:false,
-\     'tsPlugin': v:false,
-\     'checkVueTscVersion': v:false,
 \     'preferredTagNameCase': 'auto',
 \     'preferredAttrNameCase': 'auto',
 \     'preview': {


### PR DESCRIPTION
Update volar-server to 0.28.0

Also, add experimental feature which invokes multiple volar servers like the original vscode extension.
cf) https://github.com/johnsoncodehk/volar/blob/3dd9a2c0826000892d7e5779728083da4ca9e58b/packages/client/src/extension.ts#L174
This can be enabled by following setting.
```vim
let g:vim_lsp_settings_volar_experimental_multiple_servers = v:true
```