### PR TITLE
Update installing terraform-ls fixed version to latest version

### DIFF
--- a/installer/install-terraform-ls.cmd
+++ b/installer/install-terraform-ls.cmd
@@ -1,7 +1,7 @@
 @echo off
 
 setlocal
-set VERSION=0.15.0
-curl -L -o terraform-ls_v%VERSION%.windows.x86_64.zip "https://github.com/hashicorp/terraform-ls/releases/download/v%VERSION%/terraform-ls_%VERSION%_windows_amd64.zip"
-call "%~dp0\run_unzip.cmd" terraform-ls_v%VERSION%.windows.x86_64.zip
-del terraform-ls_v%VERSION%.windows.x86_64.zip
+for /f "usebackq" %%V in (`curl -Ls -o nul -w %%{url_effective} https://github.com/hashicorp/terraform-ls/releases/latest`) do set VERSION=%%~nxV
+curl -L -o terraform-ls_%VERSION%.windows.x86_64.zip "https://github.com/hashicorp/terraform-ls/releases/download/%VERSION%/terraform-ls_%VERSION:~1%_windows_amd64.zip"
+call "%~dp0\run_unzip.cmd" terraform-ls_%VERSION%.windows.x86_64.zip
+del terraform-ls_%VERSION%.windows.x86_64.zip

--- a/installer/install-terraform-ls.sh
+++ b/installer/install-terraform-ls.sh
@@ -3,12 +3,12 @@
 set -e
 
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
-version="0.15.0"
-filename="terraform-ls_${version}.zip"
+version=$(basename $(curl -Ls -o /dev/null -w %\{url_effective\} https://github.com/hashicorp/terraform-ls/releases/latest))
+filename="terraform-ls_$(echo "$version" | awk '{print substr($0, 2)}').zip"
 
 case $os in
 darwin | linux)
-  url="https://github.com/hashicorp/terraform-ls/releases/download/v${version}/terraform-ls_${version}_${os}_amd64.zip"
+  url="https://github.com/hashicorp/terraform-ls/releases/download/${version}/terraform-ls_$(echo "$version" | awk '{print substr($0, 2)}')_${os}_amd64.zip"
   curl -L "$url" -o "$filename"
   ;;
 *)


### PR DESCRIPTION
Currently, terraform-ls is installed with a fixed version, but I changed it to install the latest version.
If this is acceptable, remove terraform-ls and run `:LspInstallServer` again, and it will be up-to-date, making it easier to upgrade.