### PR TITLE
Update arch name

### DIFF
--- a/installer/install-rust-analyzer.sh
+++ b/installer/install-rust-analyzer.sh
@@ -19,7 +19,7 @@ linux)
 darwin)
   if [[ $arch == "x86_64" ]]; then
     platform="x86_64-apple-darwin"
-  elif [[ $arch == "aarch64" ]]; then
+  elif [[ $arch == "arm64" ]]; then
     platform="aarch64-apple-darwin"
   else
     echo "unknown architecture: $arch"

--- a/installer/install-rust-analyzer.sh
+++ b/installer/install-rust-analyzer.sh
@@ -19,7 +19,7 @@ linux)
 darwin)
   if [[ $arch == "x86_64" ]]; then
     platform="x86_64-apple-darwin"
-  elif [[ $arch == "arm64" ]]; then
+  elif [[ $arch == "aarch64" || $arch == "arm64" ]]; then
     platform="aarch64-apple-darwin"
   else
     echo "unknown architecture: $arch"


### PR DESCRIPTION
Thank you for supporting aarch64 architecture. However `uname -m` output for apple aarch64 may be `arm64`.

Here is my m1 MacBook Air output.

```bash
$ uname -ms
Darwin arm64
```

And also shown below.

>Ok, apparently the output is like this:
Darwin MacBook-Pro.local 20.1.0 Darwin Kernel Version 20.1.0: Sat Oct 31 00:07:10 PDT 2020; root:xnu-7195.50.7~2/RELEASE_ARM64_T8101 arm64
https://developer.apple.com/forums/thread/668206