### PR TITLE
Fix deno settings

### DIFF
--- a/settings/deno.vim
+++ b/settings/deno.vim
@@ -101,7 +101,7 @@ function! s:handle_deno_location(ctx, server, type, data) abort "ctx = {counter,
                 " `s:ensure_start()` checks path is remote uri like or not.
                 " `deno://http/` is detected as remote uri and finish.
                 let a:ctx['target_uri'] = l:target_uri =~# 'deno://' ? substitute(l:target_uri, '^deno:\/\/', 'deno:', '') : l:target_uri
-            elseif l:target_uri =~# 'deno:/'
+            elseif l:target_uri =~# 'deno:/' || l:target_uri =~# 'deno:asset/'
                 " deno 1.7.5 response `deno:/`
                 " deno lsp encode `@` such as `std@0.87.0` to `std%400.87.0`
                 " It's hard to handle in vim-lsp, so decode `@` for filepath.


### PR DESCRIPTION
Fix definition jump did not work at Deno namespace, like `Deno.listen|`(`|` is cursor).

Current

https://user-images.githubusercontent.com/56591/142882178-c8a7c898-4694-4e25-9f5d-f0a62a3d1e15.mp4

Fix

https://user-images.githubusercontent.com/56591/142882235-93ef3398-33cd-4c2e-8b60-6502a711068c.mp4

I'm not sure which version did't work...