### PR TITLE
Support deno.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,9 @@ If you installed `rls` already, you can use `rls` without configurations. But if
 
 ### deno (TypeScript)
 
-To use deno, `node_modules` should **not** located on the project directory or traversing the filesystem upwards.
+To use deno, `deno.json(c)` should located on the project directory or traversing the filesystem upwards.
+
+If `deno.json` does not located, `node_modules` should **not** located on the project directory or traversing the filesystem upwards.
 
 When editing Node projects, the following warning message is shown.
 

--- a/settings/deno.vim
+++ b/settings/deno.vim
@@ -1,3 +1,17 @@
+function! Vim_lsp_settings_deno_get_blocklist() abort
+    if !empty(lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'deno.json'))
+        return []
+    endif
+    if !empty(lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'deno.jsonc'))
+        return []
+    endif
+
+    if empty(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), 'node_modules/'))
+        return []
+    endif
+    return lsp_settings#utils#warning('server "deno" is disabled since "node_modules" is found', ['typescript', 'javascript', 'typescriptreact', 'javascriptreact'])
+endfunction
+
 augroup vim_lsp_settings_deno
   au!
   LspRegisterServer {
@@ -20,7 +34,7 @@ augroup vim_lsp_settings_deno
       \   'internalDebug': lsp_settings#get('deno', 'internalDebug', v:false),
       \ }),
       \ 'allowlist': lsp_settings#get('deno', 'allowlist', ['typescript', 'javascript', 'typescriptreact', 'javascriptreact']),
-      \ 'blocklist': lsp_settings#get('deno', 'blocklist', {c->empty(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), 'node_modules/')) ? [] : lsp_settings#utils#warning('server "deno" is disabled since "node_modules" is found', ['typescript', 'javascript', 'typescriptreact', 'javascriptreact'])}),
+      \ 'blocklist': lsp_settings#get('deno', 'blocklist', Vim_lsp_settings_deno_get_blocklist()),
       \ 'config': lsp_settings#get('deno', 'config', lsp_settings#server_config('deno')),
       \ 'workspace_config': lsp_settings#get('deno', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('deno', 'semantic_highlight', {}),


### PR DESCRIPTION
Since deno v1.14, deno can set deno.json or deno.jsonc.
If deno.json found at root project, change blocklist.