### PR TITLE
Fix `lsp_settings#merge`

### DIFF
--- a/autoload/lsp_settings.vim
+++ b/autoload/lsp_settings.vim
@@ -167,7 +167,7 @@ function! lsp_settings#merge(name, key, default) abort
   if type(a:default) ==# v:t_func
     return extend(l:config, a:default(a:name, a:key))
   endif
-  return extend(l:config, a:default)
+  return lsp_settings#utils#extend(l:config, a:default)
 endfunction
 
 function! lsp_settings#get(name, key, default) abort

--- a/autoload/lsp_settings/profile.vim
+++ b/autoload/lsp_settings/profile.vim
@@ -1,58 +1,3 @@
-function! s:extend(lhs, rhs) abort
-  let [l:lhs, l:rhs] = [a:lhs, a:rhs]
-  if type(l:lhs) ==# 3
-    if type(l:rhs) ==# 3
-      " [1,2,3]+[4,5,6]=[1,2,3,4,5,6]
-      let l:lhs += l:rhs
-    elseif type(l:rhs) ==# 4
-      " [1,2,3]+{'a':1,'b':2}= [1,2,3,{'a':1},{'b':2}]
-      let l:lhs += map(keys(l:rhs), '{v:val : l:rhs[v:val]}')
-    endif
-  elseif type(l:lhs) ==# 4
-    if type(l:rhs) ==# 3
-      " {'a':1,'b':2}+[{'c':3},{'d':4},5]= {'a':1,'b':2,'c':3,'d':4}
-      for l:V in l:rhs
-        if type(l:V) != 4
-          continue
-        endif
-        for l:k in keys(l:V)
-          let l:lhs[l:k] = l:V[l:k]
-        endfor
-      endfor
-    elseif type(l:rhs) ==# 4
-      " {'a':1,'b':2}+{'c':3,'d':4}= {'a':1,'b':2,'c':3,'d':4}
-      for l:key in keys(l:rhs)
-        if type(l:rhs[l:key]) ==# 3
-          " {'a':1,'b':2}+{'c':[1]}={'a':1,'b':2,'c':[1]}
-          if !has_key(l:lhs, l:key)
-            let l:lhs[l:key] = []
-          endif
-          if type(l:lhs[l:key]) == 3
-            " {'a':[1],'b':2}+{'a':[2]}={'a':[1,2],'b':2}
-            let l:lhs[l:key] += l:rhs[l:key]
-          elseif type(l:lhs[l:key]) == 4
-            " {'a':{'aa':1},'b':2}+{'a':[2]}={'a':[2],'b':2}
-            for l:k in keys(l:rhs[l:key])
-              let l:lhs[l:key][l:k] = l:rhs[l:key][l:k]
-            endfor
-          endif
-        elseif type(l:rhs[l:key]) ==# 4
-          " {'a':{'aa':1},'b':2}+{'a':{'ab':2]}={'a':{'aa':1,'ab':2},'b':2}
-          if has_key(l:lhs, l:key)
-            call s:extend(l:lhs[l:key], l:rhs[l:key])
-          else
-            let l:lhs[l:key] = l:rhs[l:key]
-          endif
-        else
-          " {'a':{'aa':1},'b':2}+{'a':1}={'a':1,'b':2}
-          let l:lhs[l:key] = l:rhs[l:key]
-        endif
-      endfor
-    endif
-  endif
-  return l:lhs
-endfunction
-
 function! s:filter_deny_keys(settings) abort
   let l:deny_keys = get(g:, 'lsp_settings_deny_local_keys', ['cmd'])
   if empty(l:deny_keys)
@@ -89,7 +34,7 @@ function! lsp_settings#profile#load_local() abort
     if has_key(g:, 'lsp_settings')
       for [l:k, l:v] in items(l:settings)
         if has_key(g:lsp_settings, l:k)
-          let g:lsp_settings[l:k] = s:extend(g:lsp_settings[l:k], l:v)
+          let g:lsp_settings[l:k] = lsp_settings#utils#extend(g:lsp_settings[l:k], l:v)
         else
           let g:lsp_settings[l:k] = l:v
         endif

--- a/autoload/lsp_settings/utils.vim
+++ b/autoload/lsp_settings/utils.vim
@@ -95,3 +95,62 @@ function! lsp_settings#utils#term_start(cmd, options) abort
         call term_start(a:cmd, l:options)
     endif
 endfunction
+
+function! s:extend(lhs, rhs) abort
+  let [l:lhs, l:rhs] = [a:lhs, a:rhs]
+  if type(l:lhs) ==# 3
+    if type(l:rhs) ==# 3
+      " [1,2,3]+[4,5,6]=[1,2,3,4,5,6]
+      let l:lhs += l:rhs
+    elseif type(l:rhs) ==# 4
+      " [1,2,3]+{'a':1,'b':2}= [1,2,3,{'a':1},{'b':2}]
+      let l:lhs += map(keys(l:rhs), '{v:val : l:rhs[v:val]}')
+    endif
+  elseif type(l:lhs) ==# 4
+    if type(l:rhs) ==# 3
+      " {'a':1,'b':2}+[{'c':3},{'d':4},5]= {'a':1,'b':2,'c':3,'d':4}
+      for l:V in l:rhs
+        if type(l:V) != 4
+          continue
+        endif
+        for l:k in keys(l:V)
+          let l:lhs[l:k] = l:V[l:k]
+        endfor
+      endfor
+    elseif type(l:rhs) ==# 4
+      " {'a':1,'b':2}+{'c':3,'d':4}= {'a':1,'b':2,'c':3,'d':4}
+      for l:key in keys(l:rhs)
+        if type(l:rhs[l:key]) ==# 3
+          " {'a':1,'b':2}+{'c':[1]}={'a':1,'b':2,'c':[1]}
+          if !has_key(l:lhs, l:key)
+            let l:lhs[l:key] = []
+          endif
+          if type(l:lhs[l:key]) == 3
+            " {'a':[1],'b':2}+{'a':[2]}={'a':[1,2],'b':2}
+            let l:lhs[l:key] += l:rhs[l:key]
+          elseif type(l:lhs[l:key]) == 4
+            " {'a':{'aa':1},'b':2}+{'a':[2]}={'a':[2],'b':2}
+            for l:k in keys(l:rhs[l:key])
+              let l:lhs[l:key][l:k] = l:rhs[l:key][l:k]
+            endfor
+          endif
+        elseif type(l:rhs[l:key]) ==# 4
+          " {'a':{'aa':1},'b':2}+{'a':{'ab':2]}={'a':{'aa':1,'ab':2},'b':2}
+          if has_key(l:lhs, l:key)
+            call s:extend(l:lhs[l:key], l:rhs[l:key])
+          else
+            let l:lhs[l:key] = l:rhs[l:key]
+          endif
+        else
+          " {'a':{'aa':1},'b':2}+{'a':1}={'a':1,'b':2}
+          let l:lhs[l:key] = l:rhs[l:key]
+        endif
+      endfor
+    endif
+  endif
+  return l:lhs
+endfunction
+
+function! lsp_settings#utils#extend(lhs, rhs) abort
+  return s:extend(a:lhs, a:rhs)
+endfunction


### PR DESCRIPTION
`lsp_settings#merge` doesn't merge settings.

e.g. yaml-language-server settings:

https://github.com/mattn/vim-lsp-settings/blob/cb25a3685f6c1cee08ff01c6add8f78a1fd5fc46/settings/yaml-language-server.vim#L11

in this case, `lsp_settings#merge(...)` calls and returns `extend(g:lsp_settings['yaml-language-server'], {'yaml': ...})`
but this processing overwrites user settings `g:lsp_settings['yaml-language-server']` by the default values,
so, as a result, user settings is ignored.

This PR replaces `extend` in `lsp_settings#merge` by `s:extend` at lsp_settings/profile.vim, which can merges settings as expected.