### PR TITLE
Fix vim-language-server asyncomplete refresh pattern

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1136,7 +1136,7 @@
         "npm"
       ],
       "config": {
-        "refresh_pattern": "\\([bwtglsav]:\\)\\?\\k*$"
+        "refresh_pattern": "\\%([bwtglsav]:\\k*\\|\\k\\+\\)$"
       },
       "root_uri_patterns": [
         ".vim/",


### PR DESCRIPTION
Currently, the completion will be invoked when the cursor is onto the empty line.