### PR TITLE
puppet: add puppet-languageserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ You can change the directory to install servers by set `g:lsp_settings_servers_d
 | PHP              | intelephense                        | Yes       | Yes           |
 | PHP              | psalm-language-server               | Yes       | Yes           |
 | OCaml            | ocaml-lsp                           | UNIX Only | Yes           |
+| Puppet           | puppet-languageserver               | Yes       | Yes           |
 | Python           | pyls-all (pyls with dependencies)   | Yes       | Yes           |
 | Python           | pyls (pyls without dependencies)    | Yes       | Yes           |
 | Python           | pyls-ms (Microsoft Version)         | Yes       | Yes           |

--- a/installer/install-puppet-ls.sh
+++ b/installer/install-puppet-ls.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -o errexit
+
+git clone --depth=1 https://github.com/puppetlabs/puppet-editor-services.git .
+bundle config set --local path 'vendor/bundle'
+bundle install
+bundle exec rake gem_revendor
+
+cat <<'EOF' >puppet-ls
+#!/usr/bin/env bash
+set -o errexit
+cd "$(dirname "$0")"
+exec bundle exec ruby ./puppet-languageserver "$@"
+EOF
+
+chmod +x puppet-ls

--- a/settings.json
+++ b/settings.json
@@ -779,6 +779,16 @@
       }
     }
   ],
+  "puppet": [
+    {
+      "command": "puppet-ls",
+      "requires": [
+        "git",
+        "ruby",
+        "bundler"
+      ]
+    }
+  ],
   "python": [
     {
       "command": "pylsp-all",

--- a/settings/puppet-ls.vim
+++ b/settings/puppet-ls.vim
@@ -1,0 +1,14 @@
+augroup vim_lsp_settings_puppet-ls
+  au!
+  LspRegisterServer {
+      \ 'name': 'puppet-ls',
+      \ 'cmd': {server_info->lsp_settings#get('puppet-ls', 'cmd', [lsp_settings#exec_path('puppet-ls')]+lsp_settings#get('puppet-ls', 'args', ['--stdio']))},
+      \ 'root_uri':{server_info->lsp_settings#get('puppet-ls', 'root_uri', lsp_settings#root_uri('puppet-ls'))},
+      \ 'initialization_options': lsp_settings#get('puppet-ls', 'initialization_options', {'diagnostics': 'false'}),
+      \ 'allowlist': lsp_settings#get('puppet-ls', 'allowlist', ['puppet']),
+      \ 'blocklist': lsp_settings#get('puppet-ls', 'blocklist', []),
+      \ 'config': lsp_settings#get('puppet-ls', 'config', lsp_settings#server_config('puppet-ls')),
+      \ 'workspace_config': lsp_settings#get('puppet-ls', 'workspace_config', {}),
+      \ 'semantic_highlight': lsp_settings#get('puppet-ls', 'semantic_highlight', {}),
+      \ }
+augroup END


### PR DESCRIPTION
Adds a puppet language server:

https://github.com/puppetlabs/puppet-editor-services.git

Install config only for UNIX boxes, as I lack a windows box to test on.

Fixes: https://github.com/mattn/vim-lsp-settings/issues/448