### PR TITLE
Do not use shellescape for escaping strings in execute-commands.

### DIFF
--- a/autoload/lsp_settings.vim
+++ b/autoload/lsp_settings.vim
@@ -400,10 +400,10 @@ function! s:vim_lsp_install_server(ft, command, bang) abort
   call lsp_settings#utils#msg('Installing ' . l:entry[0])
   if has('nvim')
     split new
-    call termopen(shellescape(l:entry[1]), {'cwd': l:server_install_dir, 'on_exit': function('s:vim_lsp_install_server_post', [l:entry[0]])}) | startinsert
+    call termopen(lsp_settings#utils#shellescape(l:entry[1]), {'cwd': l:server_install_dir, 'on_exit': function('s:vim_lsp_install_server_post', [l:entry[0]])}) | startinsert
   else
     if has('win32')
-      let l:bufnr = term_start(shellescape(l:entry[1]), {'cwd': l:server_install_dir})
+      let l:bufnr = term_start(lsp_settings#utils#shellescape(l:entry[1]), {'cwd': l:server_install_dir})
     else
       let l:bufnr = term_start(l:entry[1], {'cwd': l:server_install_dir})
     endif

--- a/autoload/lsp_settings/utils.vim
+++ b/autoload/lsp_settings/utils.vim
@@ -154,3 +154,8 @@ endfunction
 function! lsp_settings#utils#extend(lhs, rhs) abort
   return s:extend(a:lhs, a:rhs)
 endfunction
+
+function! lsp_settings#utils#shellescape(path) abort
+  let l:quote = &shellxquote == '"' ?  "'" : '"'
+  return l:quote .. a:path .. l:quote
+endfunction

--- a/autoload/lsp_settings/utils.vim
+++ b/autoload/lsp_settings/utils.vim
@@ -156,6 +156,6 @@ function! lsp_settings#utils#extend(lhs, rhs) abort
 endfunction
 
 function! lsp_settings#utils#shellescape(path) abort
-  let l:quote = &shellxquote == '"' ?  "'" : '"'
+  let l:quote = &shellxquote ==# '"' ?  "'" : '"'
   return l:quote . a:path . l:quote
 endfunction

--- a/autoload/lsp_settings/utils.vim
+++ b/autoload/lsp_settings/utils.vim
@@ -157,5 +157,5 @@ endfunction
 
 function! lsp_settings#utils#shellescape(path) abort
   let l:quote = &shellxquote == '"' ?  "'" : '"'
-  return l:quote .. a:path .. l:quote
+  return l:quote . a:path . l:quote
 endfunction

--- a/settings/pyls-ms.vim
+++ b/settings/pyls-ms.vim
@@ -13,7 +13,7 @@ augroup vim_lsp_settings_pyls_ms
       \        'InterpreterPath': lsp_settings#get('pyls-ms', 'python-path', {key, name->exepath('python')}),
       \        'UseDefaultDatabase': v:true,
       \        'Version': lsp_settings#get('pyls-ms', 'python-ver', {key, name->trim(matchstr(system(
-      \          shellescape(lsp_settings#get('pyls-ms', 'python-path', {key, name->exepath('python')})) . ' -V'
+      \          lsp_settings#utils#shellescape(lsp_settings#get('pyls-ms', 'python-path', {key, name->exepath('python')})) . ' -V'
       \        ), '\s\zs\S\+'))}),
       \      },
       \    },


### PR DESCRIPTION
Fixes #513