### PR TITLE
Add remark-language-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ You can change the directory to install servers by set `g:lsp_settings_servers_d
 | Lisp             | cl-lsp                              | Yes       | No            |
 | Lua              | emmylua-ls                          | Yes       | Yes           |
 | Lua              | sumneko-lua-language-server         | Yes       | Yes           |
+| Markdown         | remark-language-server              | Yes       | Yes           |
 | Nim              | nimls                               | No        | No            |
 | PHP              | intelephense                        | Yes       | Yes           |
 | PHP              | psalm-language-server               | Yes       | Yes           |

--- a/installer/install-remark-language-server.cmd
+++ b/installer/install-remark-language-server.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+call "%~dp0\npm_install.cmd" remark-language-server remark-language-server

--- a/installer/install-remark-language-server.sh
+++ b/installer/install-remark-language-server.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+"$(dirname "$0")/npm_install.sh" remark-language-server remark-language-server

--- a/settings.json
+++ b/settings.json
@@ -644,6 +644,14 @@
       "requires": []
     }
   ],
+  "markdown": [
+    {
+      "command": "remark-language-server",
+      "requires": [
+        "npm"
+      ]
+    }
+  ],
   "nim": [
     {
       "command": "nimlsp",

--- a/settings/remark-language-server.vim
+++ b/settings/remark-language-server.vim
@@ -1,0 +1,14 @@
+augroup vim_lsp_settings_remark_language_server
+  au!
+  LspRegisterServer {
+      \ 'name': 'remark-language-server',
+      \ 'cmd': {server_info->lsp_settings#get('remark-language-server', 'cmd', [lsp_settings#exec_path('typescript-language-server')]+lsp_settings#get('remark-language-server', 'args', ['--stdio']))},
+      \ 'root_uri':{server_info->lsp_settings#get('remark-language-server', 'root_uri', lsp_settings#root_uri('remark-language-server'))},
+      \ 'initialization_options': lsp_settings#get('remark-language-server', 'initialization_options', v:null),
+      \ 'allowlist': lsp_settings#get('remark-language-server', 'allowlist', ['markdown']),
+      \ 'blocklist': lsp_settings#get('remark-language-server', 'blocklist', []),
+      \ 'config': lsp_settings#get('remark-language-server', 'config', lsp_settings#server_config('remark-language-server')),
+      \ 'workspace_config': lsp_settings#get('remark-language-server', 'workspace_config', {}),
+      \ 'semantic_highlight': lsp_settings#get('remark-language-server', 'semantic_highlight', {}),
+      \ }
+augroup END

--- a/settings/remark-language-server.vim
+++ b/settings/remark-language-server.vim
@@ -2,7 +2,7 @@ augroup vim_lsp_settings_remark_language_server
   au!
   LspRegisterServer {
       \ 'name': 'remark-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('remark-language-server', 'cmd', [lsp_settings#exec_path('typescript-language-server')]+lsp_settings#get('remark-language-server', 'args', ['--stdio']))},
+      \ 'cmd': {server_info->lsp_settings#get('remark-language-server', 'cmd', [lsp_settings#exec_path('remark-language-server')]+lsp_settings#get('remark-language-server', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('remark-language-server', 'root_uri', lsp_settings#root_uri('remark-language-server'))},
       \ 'initialization_options': lsp_settings#get('remark-language-server', 'initialization_options', v:null),
       \ 'allowlist': lsp_settings#get('remark-language-server', 'allowlist', ['markdown']),


### PR DESCRIPTION
This is a language server for linting and formatting markdown files using remark.

I used `typescript-language-server` and `yaml-language-server` for reference. Any feedback is welcome. :)

/cc @wooorm @ChristianMurphy @Murderlon