### PR TITLE
Add support for open-browser.vim

### DIFF
--- a/autoload/lsp_settings/ui.vim
+++ b/autoload/lsp_settings/ui.vim
@@ -24,7 +24,7 @@ function! s:open() abort
     for l:conf in l:settings[l:ft]
       if l:conf.command ==# l:command
         let l:cmd = ''
-        if exists('openbrowser#open()')
+        if exists('g:loaded_openbrowser') && g:loaded_openbrowser
           call openbrowser#open(l:conf.url)
         elseif has('win32') || has('win64')
           silent! exec printf('!start rundll32 url.dll,FileProtocolHandler %s', l:conf.url)

--- a/autoload/lsp_settings/ui.vim
+++ b/autoload/lsp_settings/ui.vim
@@ -24,7 +24,9 @@ function! s:open() abort
     for l:conf in l:settings[l:ft]
       if l:conf.command ==# l:command
         let l:cmd = ''
-        if has('win32') || has('win64')
+        if exists('openbrowser#open()')
+          call openbrowser#open(l:conf.url)
+        elseif has('win32') || has('win64')
           silent! exec printf('!start rundll32 url.dll,FileProtocolHandler %s', l:conf.url)
         elseif has('mac') || has('macunix') || has('gui_macvim') || system('uname') =~? '^darwin'
           call system(printf('open "%s"', l:conf.url))


### PR DESCRIPTION
I made the plugin that it use [tyru/open-browser.vim](https://github.com/tyru/open-browser.vim) in `:LspManageServers` if exists.