### PR TITLE
[improve] update example auto-complete plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ Plug 'prabirshrestha/asyncomplete.vim'
 Plug 'prabirshrestha/asyncomplete-lsp.vim'
 ```
 
-#### deoplete.nvim
+#### ddc.vim
 ```viml
-Plug 'Shougo/deoplete.nvim'
-Plug 'lighttiger2505/deoplete-vim-lsp'
+Plug 'Shougo/ddc.vim'
+Plug 'shun/ddc-vim-lsp'
 ```
 
 ### LSP server download directory


### PR DESCRIPTION
## What I did ?
change example plugin from deoplete.nvim to ddc.vim.
## Why
Because author of deoplete.nvim said 
>Note: The development of this plugin is finished. Accepts minor patches and issues but no new features. ddc.vim is the next generation auto completion plugin. Consider migrating to it.
