### PR TITLE
Fix warnings about the deprecated options of bundle

### DIFF
--- a/installer/install-ruby_language_server.cmd
+++ b/installer/install-ruby_language_server.cmd
@@ -2,7 +2,9 @@
 
 git clone --depth=1 https://github.com/kwerle/ruby_language_server .
 
-call bundle install --without development --path vendor/bundle
+call bundle config set --local path vendor/bundle
+call bundle config set --local without development
+call bundle install
 
 echo @echo off ^
 

--- a/installer/install-ruby_language_server.sh
+++ b/installer/install-ruby_language_server.sh
@@ -3,7 +3,9 @@
 set -e
 
 git clone --depth=1 https://github.com/kwerle/ruby_language_server .
-bundle install --without development --path vendor/bundle
+bundle config set --local path vendor/bundle
+bundle config set --local without development
+bundle install
 
 cat <<EOF >ruby_language_server
 #!/usr/bin/env bash

--- a/installer/install-solargraph.cmd
+++ b/installer/install-solargraph.cmd
@@ -2,7 +2,9 @@
 
 git clone --depth=1 https://github.com/castwide/solargraph .
 
-call bundle install --without development --path vendor/bundle
+call bundle config set --local path vendor/bundle
+call bundle config set --local without development
+call bundle install
 
 echo @echo off ^
 

--- a/installer/install-solargraph.sh
+++ b/installer/install-solargraph.sh
@@ -3,7 +3,9 @@
 set -e
 
 git clone --depth=1 https://github.com/castwide/solargraph .
-bundle install --without development --path vendor/bundle
+bundle config set --local path vendor/bundle
+bundle config set --local without development
+bundle install
 
 cat <<EOF >solargraph
 #!/usr/bin/env bash

--- a/installer/install-steep.cmd
+++ b/installer/install-steep.cmd
@@ -2,7 +2,9 @@
 
 git clone --depth=1 https://github.com/soutaro/steep.git .
 
-call bundle install --without development --path vendor/bundle
+call bundle config set --local path vendor/bundle
+call bundle config set --local without development
+call bundle install
 
 echo @echo off ^
 

--- a/installer/install-steep.sh
+++ b/installer/install-steep.sh
@@ -3,7 +3,9 @@
 set -e
 
 git clone --depth=1 https://github.com/soutaro/steep.git .
-bundle install --without development --path vendor/bundle
+bundle config set --local path vendor/bundle
+bundle config set --local without development
+bundle install
 
 cat <<EOF >steep
 #!/usr/bin/env bash

--- a/installer/install-typeprof.cmd
+++ b/installer/install-typeprof.cmd
@@ -2,7 +2,9 @@
 
 git clone --depth=1 https://github.com/ruby/typeprof .
 
-call bundle install --without development --path vendor/bundle
+call bundle config set --local path vendor/bundle
+call bundle config set --local without development
+call bundle install
 
 echo @echo off ^
 

--- a/installer/install-typeprof.sh
+++ b/installer/install-typeprof.sh
@@ -3,7 +3,9 @@
 set -e
 
 git clone --depth=1 -b lsp-test https://github.com/ruby/typeprof .
-bundle install --without development --path vendor/bundle
+bundle config set --local path vendor/bundle
+bundle config set --local without development
+bundle install
 
 cat <<EOF >typeprof
 #!/usr/bin/env bash


### PR DESCRIPTION
Use `bundle config set --local` to set `path` and `without` flags.