### PR TITLE
Make tailwindcss languageId configurable via settings

### DIFF
--- a/settings/tailwindcss-intellisense.vim
+++ b/settings/tailwindcss-intellisense.vim
@@ -10,5 +10,6 @@ augroup vim_lsp_settings_tailwindcss-intellisense
       \ 'config': lsp_settings#get('tailwindcss-intellisense', 'config', lsp_settings#server_config('tailwindcss-intellisense')),
       \ 'workspace_config': lsp_settings#get('tailwindcss-intellisense', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('tailwindcss-intellisense', 'semantic_highlight', {}),
+      \ 'languageId': {server_info->lsp_settings#get('tailwindcss-intellisense', 'languageId', {x->&filetype})},
       \ }
 augroup END


### PR DESCRIPTION
I've been trying to use the [tailwindcss-intellisense](https://github.com/tailwindlabs/tailwindcss-intellisense) LSP to autocomplete styles on a ruby on rails project. It works great with vanilla html and css files, but not for eruby templates or scss styles. I did some digging, and traced the issue to [this line in vim-lsp](https://github.com/prabirshrestha/vim-lsp/blob/66b56c026fa24f76f38d3bc99bd478eff9aa4be3/autoload/lsp.vim#L952):
```vimscript
let l:language_id = has_key(l:server_info, 'languageId') ?  l:server_info['languageId'](l:server_info) : &filetype
```
It's passing `filetype` to the LSP server as the `languageId` parameter. The LSP server knows how to handle html and css, but doesn't recognize the `eruby` or `scss` filetypes.

This pull request makes `languageId` configurable for the tailwindcss-intellisense integration. This allows users to configure it based on their needs. In my case, it allows me to enable eruby and scss support like this:
```vimscript
function! TailwindLanguageId(...) abort
  if &filetype ==# 'eruby'
    return b:eruby_subtype
  elseif &filetype ==# 'scss'
    return 'css'
  else
    return &filetype
  end
endfunction

let g:lsp_settings = {
\   'tailwindcss-intellisense': {
\       'allowlist': ['html', 'css', 'eruby', 'scss'],
\       'languageId': function('TailwindLanguageId'),
\   }
\}
```