### PR TITLE
Fix fsautocomplete installer excutable fetching

### DIFF
--- a/installer/install-fsautocomplete.sh
+++ b/installer/install-fsautocomplete.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if command -v dotnet >/dev/null 2>&1; then
   echo "dotnet installed"
   dotnetcmd=dotnet

--- a/installer/install-fsautocomplete.sh
+++ b/installer/install-fsautocomplete.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 if command -v dotnet >/dev/null 2>&1; then
   echo "dotnet installed"
   dotnetcmd=dotnet
@@ -12,17 +10,4 @@ else
   dotnetcmd="\\$DIR/.dotnet/dotnet"
 fi
 
-url="https://github.com/fsharp/FsAutoComplete/releases/latest/download/fsautocomplete.netcore.zip"
-zip=fsautocomplete.zip
-curl -L "$url" -o "$zip"
-unzip -o -d "fsautocomplete.netcore" "$zip"
-rm "$zip"
-
-cat <<EOF >fsautocomplete
-#!/bin/sh
-
-DIR=\$(cd \$(dirname \$0); pwd)
-$dotnetcmd \$DIR/fsautocomplete.netcore/fsautocomplete.dll
-EOF
-
-chmod +x fsautocomplete
+$dotnetcmd tool install --tool-path . fsautocomplete


### PR DESCRIPTION
[fsautocomplete](https://github.com/fsharp/FsAutoComplete) stopped releasing server executables directly for now.

Since 

- a maintainer [recommends installing the server via package manager](https://github.com/fsharp/FsAutoComplete/issues/883) and
- installer is unavailable for now,

I propose to update the installer to get the server via `dotnet tool install` (nuget package manager).

I updated and checked the installer shell script on macos but couldn't do this for batchfile because I have no windows machine. Sorry for this.

ref: fsharp/FsAutoComplete/issues/883