### PR TITLE
Install an arch-appropriate terraform-ls

### DIFF
--- a/installer/install-terraform-ls.sh
+++ b/installer/install-terraform-ls.sh
@@ -3,20 +3,37 @@
 set -e
 
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
-version=$(basename $(curl -Ls -o /dev/null -w %\{url_effective\} https://github.com/hashicorp/terraform-ls/releases/latest))
-filename="terraform-ls_$(echo "$version" | awk '{print substr($0, 2)}').zip"
+arch=$(uname -m | tr "[:upper:]" "[:lower:]")
 
 case $os in
-darwin | linux)
-  url="https://github.com/hashicorp/terraform-ls/releases/download/${version}/terraform-ls_$(echo "$version" | awk '{print substr($0, 2)}')_${os}_amd64.zip"
-  curl -L "$url" -o "$filename"
-  ;;
+darwin | linux) ;;
+
 *)
-  printf "%s doesn't supported" "$os"
+  printf "%s is not supported" "$os"
   exit 1
   ;;
-
 esac
+
+case $arch in
+x86_64*) arch=amd64 ;;
+386*) arch=386 ;;
+arm64*) arch=arm64 ;;
+*)
+  printf "%s is not supported" "$arch"
+  exit 1
+  ;;
+esac
+
+version=$(
+  curl --location --silent "https://api.github.com/repos/hashicorp/terraform-ls/releases/latest" |
+    awk 'match($0, /"tag_name": "(.+)"/, a) { print a[1] }'
+)
+short_version=$(echo "${version}" | awk 'match($0, /v(.+)/, a) { print a[1] }')
+filename="terraform-ls_${short_version}"
+url="https://github.com/hashicorp/terraform-ls/releases/download/${version}/${filename}_${os}_${arch}.zip"
+filename="${filename}.zip"
+
+curl -L --progress-bar "$url" -o "$filename"
 
 unzip "$filename"
 rm "$filename"


### PR DESCRIPTION
Changed the version to download based on the architecture detected, not
just the OS.

Based on work I did a few months ago for
https://github.com/cbuschka/tfvm/blob/main/install.sh