### PR TITLE
Prefer terraform-ls over terraform-lsp

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1320,9 +1320,9 @@
   ],
   "terraform": [
     {
-      "command": "terraform-lsp",
-      "url": "https://github.com/juliosueiras/terraform-lsp",
-      "description": "Language Server Protocol for Terraform",
+      "command": "terraform-ls",
+      "url": "https://github.com/hashicorp/terraform-ls",
+      "description": "Terraform Language Server",
       "requires": [],
       "vim_plugin": {
         "extensions": [
@@ -1333,9 +1333,9 @@
       }
     },
     {
-      "command": "terraform-ls",
-      "url": "https://github.com/hashicorp/terraform-ls",
-      "description": "Terraform Language Server",
+      "command": "terraform-lsp",
+      "url": "https://github.com/juliosueiras/terraform-lsp",
+      "description": "Language Server Protocol for Terraform",
       "requires": [],
       "vim_plugin": {
         "extensions": [


### PR DESCRIPTION
The LSP terraform-ls is official from Hashicorp and is focused on stability over experimental features, as terraform-lsp is focused. The relationship between the two is described in the [terraform-ls README][] and reiterated in the [terraform-lsp README][].

[terraform-ls README]: https://github.com/hashicorp/terraform-ls#terraform-ls-vs-terraform-lsp
[terraform-lsp README]: https://github.com/juliosueiras/terraform-lsp

Based on this, and the fact that both LSPs are well maintained, I believe that vim-lsp-settings should prefer installing terraform-ls over terraform-lsp.