### PR TITLE
Fix eslint-language-server repository in `settings.json`

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -599,7 +599,7 @@
     },
     {
       "command": "eslint-language-server",
-      "url": "https://www.npmjs.com/package/eslint-language-server",
+      "url": "https://github.com/microsoft/vscode-eslint",
       "description": "eslint language server",
       "requires": [
         "node"


### PR DESCRIPTION
This PR fixes the minor problem and does NOT affect the code's behavior.

The problem is, https://www.npmjs.com/package/eslint-language-server is different from https://github.com/microsoft/vscode-eslint .
Although the source code for `eslint-language-server` is seemed to be retrieved from https://github.com/microsoft/vscode-eslint , `settings.json` indicates the wrong repository.

It looks like this URL does not impact the behavior of the tool.
However, while I inspected the `eslint-language-server`, mistakenly saw the wrong repository because of the `settings.json`. So decided to contribute.

Lastly, thanks for your fantastic work!