### PR TITLE
Use compatible awk expression

### DIFF
--- a/installer/install-terraform-ls.sh
+++ b/installer/install-terraform-ls.sh
@@ -25,7 +25,7 @@ arm64*) arch=arm64 ;;
 esac
 
 version=$(basename $(curl -Ls -o /dev/null -w %\{url_effective\} https://github.com/hashicorp/terraform-ls/releases/latest))
-short_version=$(echo "$version" | awk '{print substr($0, 2)}')
+short_version=$(echo "$version" | cut -c2-)
 filename="terraform-ls_${short_version}"
 url="https://github.com/hashicorp/terraform-ls/releases/download/${version}/${filename}_${os}_${arch}.zip"
 filename="${filename}.zip"

--- a/installer/install-terraform-ls.sh
+++ b/installer/install-terraform-ls.sh
@@ -24,11 +24,8 @@ arm64*) arch=arm64 ;;
   ;;
 esac
 
-version=$(
-  curl --location --silent "https://api.github.com/repos/hashicorp/terraform-ls/releases/latest" |
-    awk 'match($0, /"tag_name": "(.+)"/, a) { print a[1] }'
-)
-short_version=$(echo "${version}" | awk 'match($0, /v(.+)/, a) { print a[1] }')
+version=$(basename $(curl -Ls -o /dev/null -w %\{url_effective\} https://github.com/hashicorp/terraform-ls/releases/latest))
+short_version=$(echo "$version" | awk '{print substr($0, 2)}')
 filename="terraform-ls_${short_version}"
 url="https://github.com/hashicorp/terraform-ls/releases/download/${version}/${filename}_${os}_${arch}.zip"
 filename="${filename}.zip"


### PR DESCRIPTION
Undo the awk expression change introduced in PR #537 . The third argument
is not supported by the non-GNU awk installed on MacOS by default.

Fixes issue #540 