### PR TITLE
Prevent `remark-language-server` for `markdown`

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,99 +79,99 @@ You can change the directory to install servers by set `g:lsp_settings_servers_d
 
 ## Supported Languages
 
-| Language         | Language Server                     | Installer | Local Install |
-|------------------|-------------------------------------|:---------:|:-------------:|
-| Apex/VisualForce | apex-jorje-lsp                      | Yes       | Yes           |
-| Bash             | bash-language-server                | Yes       | Yes           |
-| C#               | omnisharp                           | Yes       | Yes           |
-| C/C++            | clangd                              | Yes       | Yes           |
-| COBOL            | cobol-language-support              | Yes       | Yes           |
-| CSS              | css-languageserver                  | Yes       | Yes           |
-| CSS              | tailwindcss-intellisense            | Yes       | Yes           |
-| Clojure          | clojure-lsp                         | Yes       | Yes           |
-| Clojure          | clj-kondo-lsp                       | Yes       | Yes           |
-| Cmake            | cmake-language-server               | Yes       | Yes           |
-| D                | dls                                 | Yes       | No            |
-| D                | serve-d                             | Yes       | No            |
-| Dart             | analysis-server-dart-snapshot       | Yes       | Yes           |
-| Dockerfile       | dockerfile-language-server-nodejs   | Yes       | Yes           |
-| Dot              | dot-language-server                 | Yes       | Yes           |
-| Elixir           | elixir-ls                           | Yes       | Yes           |
-| Elm              | elm-language-server                 | Yes       | Yes           |
-| Erlang           | erlang-ls                           | Yes       | Yes           |
-| F#               | fsharp-language-server              | Yes       | Yes           |
-| Fortran          | fortls                              | Yes       | Yes           |
-| Go               | gopls                               | Yes       | Yes           |
-| Go               | golangci-lint-langserver            | Yes       | Yes           |
-| GraphQL          | graphql-language-service-cli        | Yes       | Yes           |
-| GraphQL          | gql-language-server                 | Yes       | Yes           |
-| Groovy           | groovy-language-server              | Yes       | Yes           |
-| Haskell          | haskell-ide-engine                  | No        | No            |
-| Haskell          | haskell-language-server             | No        | No            |
-| HTML             | html-languageserver                 | Yes       | Yes           |
-| HTML             | angular-language-server             | Yes       | Yes           |
-| HTML             | tailwindcss-intellisense            | Yes       | Yes           |
-| JSON             | json-languageserver                 | Yes       | Yes           |
-| JSON             | rome                                | Yes       | Yes           |
-| Java             | eclipse-jdt-ls                      | Yes       | Yes           |
-| Java             | java-language-server                | No        | Yes           |
-| JavaScript       | typescript-language-server          | Yes       | Yes           |
-| JavaScript       | javascript-typescript-stdio         | Yes       | Yes           |
-| JavaScript       | rome                                | Yes       | Yes           |
-| JavaScript       | flow                                | Yes       | Yes           |
-| JavaScript       | eslint-language-server              | Yes       | Yes           |
-| Julia            | LanguageServer.jl                   | Yes       | No            |
-| Kotlin           | kotlin-language-server              | Yes       | Yes           |
-| Lisp             | cl-lsp                              | Yes       | No            |
-| Lua              | emmylua-ls                          | Yes       | Yes           |
-| Lua              | sumneko-lua-language-server         | Yes       | Yes           |
-| Markdown         | remark-language-server              | Yes       | Yes           |
-| Nim              | nimls                               | No        | No            |
-| PHP              | intelephense                        | Yes       | Yes           |
-| PHP              | psalm-language-server               | Yes       | Yes           |
-| OCaml            | ocaml-lsp                           | UNIX Only | Yes           |
-| Puppet           | puppet-languageserver               | Yes       | Yes           |
-| Python           | pyls-all (pyls with dependencies)   | Yes       | Yes           |
-| Python           | pyls (pyls without dependencies)    | Yes       | Yes           |
-| Python           | pyls-ms (Microsoft Version)         | Yes       | Yes           |
-| Python           | jedi-language-server                | Yes       | Yes           |
-| Python           | pyright-langserver                  | Yes       | Yes           |
-| Python           | pylsp-all (pylsp with dependencies) | Yes       | Yes           |
-| Python           | pylsp (pylsp without dependencies)  | Yes       | Yes           |
-| Prisma           | prisma-language-server              | Yes       | Yes           |
-| R                | languageserver                      | Yes       | No            |
-| Racket           | racket-lsp                          | Yes       | No            |
-| Reason           | reason-language-server              | Yes       | Yes           |
-| Ruby             | solargraph                          | Yes       | Yes           |
-| Ruby             | typeprof                            | Yes       | Yes           |
-| Rust             | rls                                 | Yes       | No            |
-| Rust             | rust-analyzer                       | Yes       | Yes           |
-| Sphinx           | esbonio                             | Yes       | Yes           |
-| SQL              | sql-language-server                 | Yes       | Yes           |
-| SQL              | sqls                                | Yes       | Yes           |
-| Scala            | Metals                              | Yes       | Yes           |
-| Svelte           | svelte-language-server              | Yes       | Yes           |
-| Swift            | sourcekit-lsp                       | Yes       | No            |
-| SystemVerilog    | svls                                | Yes       | Yes           |
-| TeX              | texlab                              | Yes       | Yes           |
-| TeX              | digestif                            | Yes       | No            |
-| Terraform        | terraform-lsp                       | Yes       | Yes           |
-| Terraform        | terraform-ls                        | Yes       | Yes           |
-| TOML             | taplo-lsp                           | No        | Yes           |
-| TTCN-3           | ntt                                 | Yes       | Yes           |
-| TypeScript       | typescript-language-server          | Yes       | Yes           |
-| TypeScript       | deno                                | Yes       | Yes           |
-| TypeScript       | rome                                | Yes       | Yes           |
-| TypeScript       | eslint-language-server              | Yes       | Yes           |
-| Vim              | vim-language-server                 | Yes       | Yes           |
-| Vala             | vala-language-server                | No        | No            |
-| Vue              | vue-language-server                 | Yes       | Yes           |
-| Vue              | volar-server                        | Yes       | Yes           |
-| V                | vls                                 | Yes       | Yes           |
-| XML              | lemminx                             | Yes       | Yes           |
-| YAML             | yaml-language-server                | Yes       | Yes           |
-| ZIG              | zls                                 | No        | No            |
-| *                | efm-langserver                      | Yes       | Yes           |
+| Language          | Language Server                     | Installer | Local Install |
+| ----------------- | ----------------------------------- | :-------: | :-----------: |
+| Apex/VisualForce  | apex-jorje-lsp                      |    Yes    |      Yes      |
+| Bash              | bash-language-server                |    Yes    |      Yes      |
+| C#                | omnisharp                           |    Yes    |      Yes      |
+| C/C++             | clangd                              |    Yes    |      Yes      |
+| COBOL             | cobol-language-support              |    Yes    |      Yes      |
+| CSS               | css-languageserver                  |    Yes    |      Yes      |
+| CSS               | tailwindcss-intellisense            |    Yes    |      Yes      |
+| Clojure           | clojure-lsp                         |    Yes    |      Yes      |
+| Clojure           | clj-kondo-lsp                       |    Yes    |      Yes      |
+| Cmake             | cmake-language-server               |    Yes    |      Yes      |
+| D                 | dls                                 |    Yes    |      No       |
+| D                 | serve-d                             |    Yes    |      No       |
+| Dart              | analysis-server-dart-snapshot       |    Yes    |      Yes      |
+| Dockerfile        | dockerfile-language-server-nodejs   |    Yes    |      Yes      |
+| Dot               | dot-language-server                 |    Yes    |      Yes      |
+| Elixir            | elixir-ls                           |    Yes    |      Yes      |
+| Elm               | elm-language-server                 |    Yes    |      Yes      |
+| Erlang            | erlang-ls                           |    Yes    |      Yes      |
+| F#                | fsharp-language-server              |    Yes    |      Yes      |
+| Fortran           | fortls                              |    Yes    |      Yes      |
+| Go                | gopls                               |    Yes    |      Yes      |
+| Go                | golangci-lint-langserver            |    Yes    |      Yes      |
+| GraphQL           | graphql-language-service-cli        |    Yes    |      Yes      |
+| GraphQL           | gql-language-server                 |    Yes    |      Yes      |
+| Groovy            | groovy-language-server              |    Yes    |      Yes      |
+| Haskell           | haskell-ide-engine                  |    No     |      No       |
+| Haskell           | haskell-language-server             |    No     |      No       |
+| HTML              | html-languageserver                 |    Yes    |      Yes      |
+| HTML              | angular-language-server             |    Yes    |      Yes      |
+| HTML              | tailwindcss-intellisense            |    Yes    |      Yes      |
+| JSON              | json-languageserver                 |    Yes    |      Yes      |
+| JSON              | rome                                |    Yes    |      Yes      |
+| Java              | eclipse-jdt-ls                      |    Yes    |      Yes      |
+| Java              | java-language-server                |    No     |      Yes      |
+| JavaScript        | typescript-language-server          |    Yes    |      Yes      |
+| JavaScript        | javascript-typescript-stdio         |    Yes    |      Yes      |
+| JavaScript        | rome                                |    Yes    |      Yes      |
+| JavaScript        | flow                                |    Yes    |      Yes      |
+| JavaScript        | eslint-language-server              |    Yes    |      Yes      |
+| Julia             | LanguageServer.jl                   |    Yes    |      No       |
+| Kotlin            | kotlin-language-server              |    Yes    |      Yes      |
+| Lisp              | cl-lsp                              |    Yes    |      No       |
+| Lua               | emmylua-ls                          |    Yes    |      Yes      |
+| Lua               | sumneko-lua-language-server         |    Yes    |      Yes      |
+| Markdown (remark) | remark-language-server              |    Yes    |      Yes      |
+| Nim               | nimls                               |    No     |      No       |
+| PHP               | intelephense                        |    Yes    |      Yes      |
+| PHP               | psalm-language-server               |    Yes    |      Yes      |
+| OCaml             | ocaml-lsp                           | UNIX Only |      Yes      |
+| Puppet            | puppet-languageserver               |    Yes    |      Yes      |
+| Python            | pyls-all (pyls with dependencies)   |    Yes    |      Yes      |
+| Python            | pyls (pyls without dependencies)    |    Yes    |      Yes      |
+| Python            | pyls-ms (Microsoft Version)         |    Yes    |      Yes      |
+| Python            | jedi-language-server                |    Yes    |      Yes      |
+| Python            | pyright-langserver                  |    Yes    |      Yes      |
+| Python            | pylsp-all (pylsp with dependencies) |    Yes    |      Yes      |
+| Python            | pylsp (pylsp without dependencies)  |    Yes    |      Yes      |
+| Prisma            | prisma-language-server              |    Yes    |      Yes      |
+| R                 | languageserver                      |    Yes    |      No       |
+| Racket            | racket-lsp                          |    Yes    |      No       |
+| Reason            | reason-language-server              |    Yes    |      Yes      |
+| Ruby              | solargraph                          |    Yes    |      Yes      |
+| Ruby              | typeprof                            |    Yes    |      Yes      |
+| Rust              | rls                                 |    Yes    |      No       |
+| Rust              | rust-analyzer                       |    Yes    |      Yes      |
+| Sphinx            | esbonio                             |    Yes    |      Yes      |
+| SQL               | sql-language-server                 |    Yes    |      Yes      |
+| SQL               | sqls                                |    Yes    |      Yes      |
+| Scala             | Metals                              |    Yes    |      Yes      |
+| Svelte            | svelte-language-server              |    Yes    |      Yes      |
+| Swift             | sourcekit-lsp                       |    Yes    |      No       |
+| SystemVerilog     | svls                                |    Yes    |      Yes      |
+| TeX               | texlab                              |    Yes    |      Yes      |
+| TeX               | digestif                            |    Yes    |      No       |
+| Terraform         | terraform-lsp                       |    Yes    |      Yes      |
+| Terraform         | terraform-ls                        |    Yes    |      Yes      |
+| TOML              | taplo-lsp                           |    No     |      Yes      |
+| TTCN-3            | ntt                                 |    Yes    |      Yes      |
+| TypeScript        | typescript-language-server          |    Yes    |      Yes      |
+| TypeScript        | deno                                |    Yes    |      Yes      |
+| TypeScript        | rome                                |    Yes    |      Yes      |
+| TypeScript        | eslint-language-server              |    Yes    |      Yes      |
+| Vim               | vim-language-server                 |    Yes    |      Yes      |
+| Vala              | vala-language-server                |    No     |      No       |
+| Vue               | vue-language-server                 |    Yes    |      Yes      |
+| Vue               | volar-server                        |    Yes    |      Yes      |
+| V                 | vls                                 |    Yes    |      Yes      |
+| XML               | lemminx                             |    Yes    |      Yes      |
+| YAML              | yaml-language-server                |    Yes    |      Yes      |
+| ZIG               | zls                                 |    No     |      No       |
+| \*                | efm-langserver                      |    Yes    |      Yes      |
 
 ## Notes
 

--- a/settings.json
+++ b/settings.json
@@ -817,14 +817,6 @@
       "requires": []
     }
   ],
-  "markdown": [
-    {
-      "command": "remark-language-server",
-      "requires": [
-        "npm"
-      ]
-    }
-  ],
   "nim": [
     {
       "command": "nimlsp",

--- a/settings/remark-language-server.vim
+++ b/settings/remark-language-server.vim
@@ -1,14 +1,14 @@
 augroup vim_lsp_settings_remark_language_server
   au!
   LspRegisterServer {
-      \ 'name': 'remark-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('remark-language-server', 'cmd', [lsp_settings#exec_path('remark-language-server')]+lsp_settings#get('remark-language-server', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('remark-language-server', 'root_uri', lsp_settings#root_uri('remark-language-server'))},
-      \ 'initialization_options': lsp_settings#get('remark-language-server', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('remark-language-server', 'allowlist', ['markdown']),
-      \ 'blocklist': lsp_settings#get('remark-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('remark-language-server', 'config', lsp_settings#server_config('remark-language-server')),
-      \ 'workspace_config': lsp_settings#get('remark-language-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('remark-language-server', 'semantic_highlight', {}),
-      \ }
+        \ 'name': 'remark-language-server',
+        \ 'cmd': {server_info->lsp_settings#get('remark-language-server', 'cmd', [lsp_settings#exec_path('remark-language-server')]+lsp_settings#get('remark-language-server', 'args', ['--stdio']))},
+        \ 'root_uri':{server_info->lsp_settings#get('remark-language-server', 'root_uri', lsp_settings#root_uri('remark-language-server'))},
+        \ 'initialization_options': lsp_settings#get('remark-language-server', 'initialization_options', v:null),
+        \ 'allowlist': lsp_settings#get('remark-language-server', 'allowlist', []),
+        \ 'blocklist': lsp_settings#get('remark-language-server', 'blocklist', []),
+        \ 'config': lsp_settings#get('remark-language-server', 'config', lsp_settings#server_config('remark-language-server')),
+        \ 'workspace_config': lsp_settings#get('remark-language-server', 'workspace_config', {}),
+        \ 'semantic_highlight': lsp_settings#get('remark-language-server', 'semantic_highlight', {}),
+        \ }
 augroup END


### PR DESCRIPTION
Resolves #543, #527

The current configuration for `remark-language-server` has it proposed for installation whenever a markdown file is edited. This is incorrect, as `remark-language-server` is _only_ for use in a `remark` project, which implies a lot of extra baggage (node-base infrastructure, configuration, etc.) not expected by most users.

As it does appears that `vim-lsp` and `vim-lsp-settings` allow only filetype server identification by default, this PR:

- removes the `markdown` entry from the `allowlist` for   `remark-language-server`;
- removes the `markdown` entry from `settings.json` (as `remark-language-server` was the only LS there, and
  `remark-language-server` is _not_ a markdown language server);
- and updates the compatibility listing so that `remark-language-server` is noted as `Markdown (remark)`.

My personal preference would be to wholly _remove_ `remark-language-server` (it provides value to a very small group of
developers), but as it _may_ be possible to extend the `allow` test in the future so as to detect appropriate configuration, there is currently no reason to remove it, so long as it is possible to install `remark-language-server` where required.

Current testing suggests that this is _not_ possible, and a modification to `settings.json` to put `node_modules/.bin/remark` 
in the `requires` block for `remark-language-server` won’t work as it is not necessary to install `remark-cli` in a remark project. (That is, it _does_ appear to work, but it does _not_ appear to work _well_, and we still see the stupid error message from `remark-language-server`.)

If we want to keep `remark-language-server` (I personally see negative value in it) for any use whatsoever, then I believe that `vim-lsp-settings` _and/or_ `vim-lsp` need to be modified so that it will only be suggested for installation or started if preconditions are met.