### PR TITLE
Fix: lsp_settings#complete_uninstall() returns duplicate values

### DIFF
--- a/autoload/lsp_settings.vim
+++ b/autoload/lsp_settings.vim
@@ -295,7 +295,7 @@ function! lsp_settings#complete_uninstall(arglead, cmdline, cursorpos) abort
       call add(l:installers, l:conf.command)
     endfor
   endfor
-  return filter(uniq(l:installers), 'stridx(v:val, a:arglead) == 0')
+  return filter(uniq(sort(l:installers)), 'stridx(v:val, a:arglead) == 0')
 endfunction
 
 function! lsp_settings#complete_install(arglead, cmdline, cursorpos) abort


### PR DESCRIPTION
Before:
<img width="380" alt="image" src="https://user-images.githubusercontent.com/45391880/163194091-a7d7c952-744a-4fc7-9da5-af21b10d4d3a.png">
After:
<img width="392" alt="image" src="https://user-images.githubusercontent.com/45391880/163193957-25e0f399-6421-4d1b-a36a-dedc3a5cd758.png">
