### PR TITLE
Update install-metals.sh to always install the latest release

### DIFF
--- a/installer/install-metals.cmd
+++ b/installer/install-metals.cmd
@@ -5,7 +5,7 @@ setlocal
 curl -Lo coursier https://git.io/coursier-cli
 curl -Lo coursier.bat https://git.io/coursier-bat
 
-set VERSION=0.11.3
+set VERSION=0.11.2
 set JAVA_FLAGS=
 if "%HTTPS_PROXY%" neq "" (
   set JAVA_FLAGS=-Dhttps.proxyHost=%HTTPS_PROXY%

--- a/installer/install-metals.sh
+++ b/installer/install-metals.sh
@@ -5,7 +5,7 @@ set -e
 curl -Lo ./coursier https://git.io/coursier-cli
 chmod +x ./coursier
 
-version="0.11.3"
+version=$(curl -LsS "https://scalameta.org/metals/latests.json" | grep -o '"release": "[^"]*"' | grep -o '[\.0-9]*')
 java_flags=()
 
 if [[ -n "${https_proxy}" ]]; then


### PR DESCRIPTION
Changed the shell script to always download a proper release version of metals automatically. But as for install-metals.cmd, I don't have any knowledge about .cmd, so it wasn't changed.
Also because the previous commit 895408f7a022e9226ce6b0387d958ac20a52ae36 was wrong, the version specified in the .cmd script is reverted to 0.11.2.