### PR TITLE
Migrate Metals to 2.13

### DIFF
--- a/installer/install-metals.sh
+++ b/installer/install-metals.sh
@@ -24,4 +24,4 @@ if [[ -n "${no_proxy}" ]]; then
   java_flags+=("-Dhttp.nonProxyHosts=${no_proxy}")
 fi
 
-java "${java_flags[@]}" -jar ./coursier bootstrap --ttl Inf "org.scalameta:metals_2.12:${version}" -r "bintray:scalacenter/releases" -r "sonatype:public" -r "sonatype:snapshots" -o ./metals
+java "${java_flags[@]}" -jar ./coursier bootstrap --ttl Inf "org.scalameta:metals_2.13:${version}" -r "bintray:scalacenter/releases" -r "sonatype:public" -r "sonatype:snapshots" -o ./metals


### PR DESCRIPTION
Metals has been migrated to 2.13 since v0.11.3.
https://scalameta.org/metals/blog/2022/04/26/aluminium