### PR TITLE
fix perl installer

### DIFF
--- a/installer/install-perlnavigator.sh
+++ b/installer/install-perlnavigator.sh
@@ -17,6 +17,6 @@ esac
 
 curl -L -o perlnavigator-$os-x86_64.zip "https://github.com/bscan/PerlNavigator/releases/latest/download/perlnavigator-$os-x86_64.zip"
 unzip perlnavigator-$os-x86_64.zip
-mv perlnavigator-os-x86_64/perlnavigator .
-rm -rf perlnavigator-os-x86_64 perlnavigator-os-x86_64.zip
+mv perlnavigator-$os-x86_64/perlnavigator .
+rm -rf perlnavigator-$os-x86_64 perlnavigator-$os-x86_64.zip
 


### PR DESCRIPTION
I got the following error when I did LspInstallServer with perl, so I fixed the installer.

```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 14.6M  100 14.6M    0     0  17.0M      0 --:--:-- --:--:-- --:--:-- 26.9M
Archive:  perlnavigator-macos-x86_64.zip
   creating: perlnavigator-macos-x86_64/
  inflating: perlnavigator-macos-x86_64/perlnavigator
mv: rename perlnavigator-os-x86_64/perlnavigator to ./perlnavigator: No such file or directory
```