### PR TITLE
fixed perlnavigator workspace_config

### DIFF
--- a/settings/perlnavigator.vim
+++ b/settings/perlnavigator.vim
@@ -8,7 +8,7 @@ augroup vim_lsp_settings_perlnavigator
       \ 'allowlist': lsp_settings#get('perlnavigator', 'allowlist', ['perl']),
       \ 'blocklist': lsp_settings#get('perlnavigator', 'blocklist', []),
       \ 'config': lsp_settings#get('perlnavigator', 'config', lsp_settings#server_config('perlnavigator')),
-      \ 'workspace_config': lsp_settings#get('perlnavigator', 'workspace_config', {'perlnavigator': { 'perlPath': 'perl', 'enableWarnings': v:true, 'perltidyProfile': '', 'perlcriticProfile': '', 'perlcriticEnabled': v:true, 'severity5': 'warning', 'severity4': 'info', 'severity3': 'hint', 'severity2': 'hint', 'severity1': 'hint', 'includePaths': [], 'logging': v:false, 'trace': { 'server': 'verbose' }}}),
+      \ 'workspace_config': lsp_settings#get('perlnavigator', 'workspace_config', {'perlnavigator': { 'perlPath': 'perl', 'enableWarnings': v:true, 'perltidyProfile': '', 'perlcriticProfile': '', 'perlcriticEnabled': v:true, 'severity5': 'warning', 'severity4': 'info', 'severity3': 'hint', 'severity2': 'hint', 'severity1': 'hint', 'includePaths': ['lib'], 'logging': v:false, 'trace': { 'server': 'verbose' }}}),
       \ 'semantic_highlight': lsp_settings#get('perlnavigator', 'semantic_highlight', {}),
       \ }
   autocmd User lsp_setup let g:lsp_experimental_workspace_folders = 1

--- a/settings/perlnavigator.vim
+++ b/settings/perlnavigator.vim
@@ -8,7 +8,7 @@ augroup vim_lsp_settings_perlnavigator
       \ 'allowlist': lsp_settings#get('perlnavigator', 'allowlist', ['perl']),
       \ 'blocklist': lsp_settings#get('perlnavigator', 'blocklist', []),
       \ 'config': lsp_settings#get('perlnavigator', 'config', lsp_settings#server_config('perlnavigator')),
-      \ 'workspace_config': {server_info->lsp_settings#get('perlnavigator', 'workspace_config', {'perlnavigator': { 'perlPath': 'perl', 'enableWarnings': v:true, 'perltidyProfile': '', 'perlcriticProfile': '', 'perlcriticEnabled': v:true, 'severity5': 'warning', 'severity4': 'info', 'severity3': 'hint', 'severity2': 'hint', 'severity1': 'hint', 'includePaths': [], 'logging': v:false, 'trace': { 'server': 'verbose' }}})},
+      \ 'workspace_config': lsp_settings#get('perlnavigator', 'workspace_config', {'perlnavigator': { 'perlPath': 'perl', 'enableWarnings': v:true, 'perltidyProfile': '', 'perlcriticProfile': '', 'perlcriticEnabled': v:true, 'severity5': 'warning', 'severity4': 'info', 'severity3': 'hint', 'severity2': 'hint', 'severity1': 'hint', 'includePaths': [], 'logging': v:false, 'trace': { 'server': 'verbose' }}}),
       \ 'semantic_highlight': lsp_settings#get('perlnavigator', 'semantic_highlight', {}),
       \ }
   autocmd User lsp_setup let g:lsp_experimental_workspace_folders = 1


### PR DESCRIPTION
This pull request fixed `perlnavigator` workspace_config. Specifically, the following errors were fixed.

> s:on_stdout client option on_notification() error", "Vim(call):E474: Error while dumping encode_tv2json()

Related issue: #568