### PR TITLE
Fix path for detect local settings properly

### DIFF
--- a/autoload/lsp_settings/profile.vim
+++ b/autoload/lsp_settings/profile.vim
@@ -22,7 +22,7 @@ endfunction
 
 function! lsp_settings#profile#load_local() abort
   try
-    let l:dir = expand('%:h')
+    let l:dir = expand('%:p:h')
     let l:root = finddir('.vim-lsp-settings', l:dir . ';')
     if empty(l:root)
       return


### PR DESCRIPTION
When I add local settings.json at project root, and open under project root directory's file(such as `src/foo.ts`),
vim-lsp-settings did not read settings.json

This PR fixs open child file from project root can load local settings.json file.

## .vimrc
```vim
autocmd!
set nocompatible
set rtp+=$HOME/.vim/pack/bundle/opt/vim-lsp
set rtp+=$HOME/.vim/pack/bundle/opt/vim-lsp-settings
syntax enable
filetype plugin indent on

let g:lsp_settings = {}
let g:lsp_settings_filetype_typescript = ['deno']
function! s:on_lsp_buffer_enabled()
  setlocal omnifunc=lsp#complete
  if exists('+tagfunc') | setlocal tagfunc=lsp#tagfunc | endif
endfunction
augroup lsp-install
  autocmd!
  autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled()
augroup END
```

### Project structure

```
root@f8d15ba89d05:~/src/ts$ tree
.
|-- index.ts
|-- node_modules
|-- package.json
`-- src
    `-- foo.ts
2 directories, 3 files
```

```
root@f8d15ba89d05:~/src/ts$ cat .vim-lsp-settings/settings.json 
{   
    "deno": {
        "disabled": 1
    }
}
```

## Steps to reproduce

1. cd to project root(`~/src/ts` is project root)
2. open index.ts -> local settings works fine
3. open src/foo.ts -> local settings not work