### PR TITLE
Force yaml formatting to be enabled

### DIFF
--- a/settings/yaml-language-server.vim
+++ b/settings/yaml-language-server.vim
@@ -22,6 +22,11 @@ endfunction
 
 function! s:on_lsp_buffer_enabled() abort
   command! -buffer -nargs=1 LspYamlSetSchema call <SID>set_schema(<q-args>)
+  " Force formatting to be enabled
+  let l:capabilities = lsp#get_server_capabilities('yaml-language-server')
+  if !empty(l:capabilities)
+    let l:capabilities.documentFormattingProvider = v:true
+  endif
 endfunction
 
 augroup lsp_install_yaml


### PR DESCRIPTION
Relates: https://github.com/redhat-developer/yaml-language-server/issues/486

yaml-language-server can use prettier as a formatter.
This PR forces formatting capability to be enabled, so `:LspDocumentFormat` works in yaml files.