### PR TITLE
Update omnisharp-lsp to support net6.0

### DIFF
--- a/installer/install-omnisharp-lsp.cmd
+++ b/installer/install-omnisharp-lsp.cmd
@@ -1,7 +1,8 @@
 @echo off
 setlocal
 
-for /f "delims=" %%i IN ('dotnet --version') DO set version=%%i
+for /f "delims=" %%i in ('dotnet --version') do set version=%%i
+
 
 set mainVersion=%version:.=&rem %
 

--- a/installer/install-omnisharp-lsp.cmd
+++ b/installer/install-omnisharp-lsp.cmd
@@ -1,13 +1,21 @@
 @echo off
-
 setlocal
-curl -L -o omnisharp-win-x64.zip "https://github.com/OmniSharp/omnisharp-roslyn/releases/latest/download/omnisharp-win-x64.zip"
-call "%~dp0\run_unzip.cmd" omnisharp-win-x64.zip
-del omnisharp-win-x64.zip
+
+for /f "delims=" %%i IN ('dotnet --version') DO set version=%%i
+
+set mainVersion=%version:.=&rem %
+
+if /i "%mainVersion%" geq "6" (
+	curl -L -o omnisharp.zip "https://github.com/OmniSharp/omnisharp-roslyn/releases/latest/download/omnisharp-win-x64-net6.0.zip"
+) else (
+	curl -L -o omnisharp.zip "https://github.com/OmniSharp/omnisharp-roslyn/releases/latest/download/omnisharp-win-x64.zip"
+)
+
+call "%~dp0\run_unzip.cmd" omnisharp.zip
+del omnisharp.zip
 
 echo @echo off ^
 
 %%~dp0\omnisharp.exe %%* ^
 
 > omnisharp-lsp.cmd
-

--- a/installer/install-omnisharp-lsp.sh
+++ b/installer/install-omnisharp-lsp.sh
@@ -4,6 +4,8 @@ set -e
 
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
 arch="-x64"
+net6=""
+version=$(dotnet --version)
 
 case $os in
 linux) ;;
@@ -17,7 +19,29 @@ darwin)
   ;;
 esac
 
-url="https://github.com/OmniSharp/omnisharp-roslyn/releases/latest/download/omnisharp-$os$arch.tar.gz"
+case $version in
+  (*"."*)
+    mainVersion=${version%%"."*}
+    ;;
+  (*)
+    mainVersion=$version
+    ;;
+esac
+
+if [ "$mainVersion" -ge "6" ]; then
+  net6="-net6.0"
+
+cat <<EOF >run
+#!/usr/bin/env bash
+
+base_dir="\$(cd "\$(dirname "\$0")" && pwd -P)"
+omnisharp_cmd=\${base_dir}/OmniSharp
+
+"\${omnisharp_cmd}" "\$@"
+EOF
+fi
+
+url="https://github.com/OmniSharp/omnisharp-roslyn/releases/latest/download/omnisharp-$os$arch$net6.tar.gz"
 curl -L "$url" | tar xz
 
 chmod +x run


### PR DESCRIPTION
Net6.0 omnisharp-roslyn needs a extra url parameter to be downloaded. This patch detects the current SDK version and downloads the proper server.