### PR TITLE
Add support for texlab aarch64-apple-darwin

### DIFF
--- a/installer/install-texlab.sh
+++ b/installer/install-texlab.sh
@@ -3,6 +3,7 @@
 set -e
 
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
+arch=$(uname -m)
 
 case $os in
 linux) ;;
@@ -15,5 +16,21 @@ darwin)
   ;;
 esac
 
-url="https://github.com/latex-lsp/texlab/releases/latest/download/texlab-x86_64-$os.tar.gz"
+case $arch in
+x86_64) ;;
+arm64)
+  if [ "$os" == "linux" ]; then
+    printf "%s doesn't supported by bash installer" "$os"
+    exit 1
+  fi
+  arch="aarch64"
+  ;;
+*)
+  printf "%s doesn't supported by bash installer" "$os"
+  exit 1
+  ;;
+esac
+
+
+url="https://github.com/latex-lsp/texlab/releases/latest/download/texlab-$arch-$os.tar.gz"
 curl -L "$url" | tar xzv


### PR DESCRIPTION
By this pull request https://github.com/latex-lsp/texlab/pull/591, TexLab began to distribute the binary for aarch64-apple-darwin (unfortunately not for Linux aarch64).
If you could merge this patch, aarch64-apple-darwin or M1 and M2 mac users can download TexLab using vim-lsp-settings.

I would appreciate it if you could check this pull request.