### PR TITLE
Fix Clangd installation failure on ubuntu 22.04

### DIFF
--- a/installer/install-clangd.sh
+++ b/installer/install-clangd.sh
@@ -58,6 +58,8 @@ filename() {
     14.04 | 16.04 | 18.04 | 20.04)
       local platform="linux-gnu-ubuntu-$ubuntu_version"
       ;;
+    22.04)
+      local platform="linux-gnu-ubuntu-20.04"
     esac
     ;;
   # Check LinuxMint version


### PR DESCRIPTION
When I install clangd on ubuntu22.04, it fails with the following error:

```bash
  1 /usr/bin/lsb_release
  2 Downloading clangd and LLVM...
  3   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
  4                                  Dload  Upload   Total   Spent    Left  Speed
  5   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  6 100  383M  100  383M    0     0  7063k      0  0:00:55  0:00:55 --:--:-- 7477k
  7 ./clangd: error while loading shared libraries: libz3.so.4.8: cannot open shared object file: No such file or direct    ory 
```

This is probably due to an older unsupported version of clangd (clang + llvm-9.0.0-x86_64-pc-linux-gnu.tar.xz).

However, it looks like there is still no binary for 22.04 at https://github.com/llvm/llvm-project/releases?page=1.

So, until the official clangd for 22.04 is posted on the above page, the clangd for 20.04 (https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/clang + llvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04) Why not try installing it?

I made the above change to install clangd and confirmed that it works fine.

Also, I think the clangd version is a bit old overall (currently clangd version-9 - clangd version 11), how about raising this version?

Thanks for the great plugin!