### PR TITLE
installers bash -> POSIX /bin/sh

### DIFF
--- a/installer/go_install.sh
+++ b/installer/go_install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Usage
 # $ go_install [GO_GET_URLPATH]

--- a/installer/install-analysis-server-dart-snapshot.sh
+++ b/installer/install-analysis-server-dart-snapshot.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -20,7 +20,7 @@ unzip "$filename"
 rm "$filename"
 
 cat <<EOF >analysis-server-dart-snapshot
-#!/usr/bin/env bash
+#!/bin/sh
 
 DIR=\$(cd \$(dirname \$0); pwd)/dart-sdk
 \$DIR/bin/dart language-server \$*

--- a/installer/install-angular-language-server.sh
+++ b/installer/install-angular-language-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -6,7 +6,7 @@ set -e
 "$(dirname "$0")/npm_install.sh" angular-language-server @angular/language-server
 
 cat <<EOF >angular-language-server
-#!/usr/bin/env bash
+#!/bin/sh
 
 DIR=\$(cd \$(dirname \$0); pwd)
 node \$DIR/node_modules/@angular/language-server/index.js --ngProbeLocations \$DIR/node_modules/@angular/language-service --tsProbeLocations \$DIR/node_modules/typescript \$*

--- a/installer/install-apex-jorje-lsp.sh
+++ b/installer/install-apex-jorje-lsp.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 curl -o apex-jorje-lsp.jar -L "https://github.com/forcedotcom/salesforcedx-vscode/blob/develop/packages/salesforcedx-vscode-apex/out/apex-jorje-lsp.jar?raw=true"
 

--- a/installer/install-bash-language-server.sh
+++ b/installer/install-bash-language-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-cl-lsp.sh
+++ b/installer/install-cl-lsp.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 ros install cxxxr/lem cxxxr/cl-lsp

--- a/installer/install-clangd.sh
+++ b/installer/install-clangd.sh
@@ -1,11 +1,11 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
 # On MacOS, use clangd in Command Line Tools for Xcode.
 if command -v xcrun 2>/dev/null && xcrun --find clangd 2>/dev/null; then
   cat <<'EOF' >clangd
-#!/usr/bin/env bash
+#!/bin/sh
 
 exec xcrun --run clangd "$@"
 EOF
@@ -34,42 +34,40 @@ else
 fi
 
 filename() {
-  local distributor_id=$1
-  local version=$2
+  distributor_id=$1
+  version=$2
 
-  local os
   os=$(uname -s | tr "[:upper:]" "[:lower:]")
 
   case $os in
   linux)
-    local platform="pc-linux-gnu"
+    platform="pc-linux-gnu"
     ;;
   darwin)
-    local platform="apple-darwin"
+    platform="apple-darwin"
     ;;
   esac
 
   case $distributor_id in
   # Check Ubuntu version
   Ubuntu)
-    local ubuntu_version
+    ubuntu_version
     ubuntu_version=$(lsb_release -a 2>&1 | grep 'Release' | awk '{print $2}')
     case $ubuntu_version in
     14.04 | 16.04 | 18.04 | 20.04)
-      local platform="linux-gnu-ubuntu-$ubuntu_version"
+      platform="linux-gnu-ubuntu-$ubuntu_version"
       ;;
     esac
     ;;
   # Check LinuxMint version
   LinuxMint)
-    local linuxmint_version
     linuxmint_version=$(lsb_release -a 2>&1 | grep 'Release' | awk '{print $2}')
     case $linuxmint_version in
     19 | 19.1 | 19.2 | 19.3)
-      local platform="linux-gnu-ubuntu-18.04"
+      platform="linux-gnu-ubuntu-18.04"
       ;;
     18 | 18.1 | 18.2 | 18.3)
-      local platform="linux-gnu-ubuntu-16.04"
+      platform="linux-gnu-ubuntu-16.04"
       ;;
     esac
     ;;
@@ -77,21 +75,20 @@ filename() {
   Fedora | Oracle | CentOS)
     case $version in
     9.0.0 | 10.0.0)
-      local platform="linux-sles11.3"
+      platform="linux-sles11.3"
       ;;
     11.0.0)
-      local platform="linux-sles12.4"
+      platform="linux-sles12.4"
       ;;
     esac
     ;;
   esac
 
   # Check Architecture
-  local arch
   arch=$(uname -m)
   case $arch in
   aarch64)
-    local platform="linux-gnu"
+    platform="linux-gnu"
     ;;
   esac
 
@@ -107,10 +104,10 @@ url_v11="https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/$
 
 response_code=$(curl -sIL "${url_v11}" -o /dev/null -w "%{response_code}")
 
-if [ "${response_code}" == "404" ]; then
+if [ "${response_code}" = "404" ]; then
   response_code=$(curl -sIL "${url_v10}" -o /dev/null -w "%{response_code}")
 
-  if [ "${response_code}" == "404" ]; then
+  if [ "${response_code}" = "404" ]; then
     url="${url_v9}"
     filename="${filename_v9}"
   else

--- a/installer/install-clj-kondo-lsp.sh
+++ b/installer/install-clj-kondo-lsp.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 VERSION="2020.05.09"
 curl -L -o clj-kondo-lsp https://github.com/borkdude/clj-kondo/releases/download/v$VERSION/clj-kondo-lsp-server-$VERSION-standalone.jar

--- a/installer/install-clojure-lsp.sh
+++ b/installer/install-clojure-lsp.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-cmake-language-server.sh
+++ b/installer/install-cmake-language-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-cobol-language-support.sh
+++ b/installer/install-cobol-language-support.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -10,7 +10,7 @@ unzip "$filename"
 rm "$filename"
 
 cat <<EOF >./cobol-language-support
-#!/usr/bin/env bash
+#!/bin/sh
 DIR=\$(cd \$(dirname \$0); pwd)
 java "-Dline.speparator=\r\n" -jar "\$DIR/extension/server/lsp-service-cobol-$version.jar" pipeEnabled
 EOF

--- a/installer/install-css-languageserver.sh
+++ b/installer/install-css-languageserver.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-deno.sh
+++ b/installer/install-deno.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -9,7 +9,7 @@ linux)
   filename="deno-x86_64-unknown-linux-gnu.zip"
   ;;
 darwin)
-  if [ $(uname -m) == "x86_64" ]; then
+  if [ $(uname -m) = "x86_64" ]; then
     filename="deno-x86_64-apple-darwin.zip"
   else
     filename="deno-aarch64-apple-darwin.zip"

--- a/installer/install-dls.sh
+++ b/installer/install-dls.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-docker-langserver.sh
+++ b/installer/install-docker-langserver.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-dot-language-server.sh
+++ b/installer/install-dot-language-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-eclipse-jdt-ls.sh
+++ b/installer/install-eclipse-jdt-ls.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -8,15 +8,15 @@ tar xvf jdt-language-server-latest.tar.gz
 rm jdt-language-server-latest.tar.gz
 
 osType="$(uname -s)"
-echo $osType
-case $osType in
+echo "$osType"
+case "$osType" in
     Darwin*)    configDir=config_mac;;
     Linux*)     configDir=config_linux;;
     *)          configDir=config_linux
 esac
 
 cat <<EOF > eclipse-jdt-ls
-#!/usr/bin/env bash
+#!/bin/sh
 DIR=\$(cd \$(dirname \$0); pwd)
 LAUNCHER=\$(ls \$DIR/plugins/org.eclipse.equinox.launcher_*.jar)
 java -Declipse.application=org.eclipse.jdt.ls.core.id1 -Dosgi.bundles.defaultStartLevel=4 -Declipse.product=org.eclipse.jdt.ls.core.product -Dlog.protocol=true -Dlog.level=ALL -noverify -Xmx1G -javaagent:\$DIR/lombok.jar -Xbootclasspath/a:\$DIR/lombok.jar -jar \$LAUNCHER -configuration \$DIR/$configDir -data \$DIR/data

--- a/installer/install-efm-langserver.sh
+++ b/installer/install-efm-langserver.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-elixir-ls.sh
+++ b/installer/install-elixir-ls.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -9,7 +9,7 @@ unzip elixir-ls.zip
 rm elixir-ls.zip
 
 cat <<EOF >elixir-ls
-#!/usr/bin/env bash
+#!/bin/sh
 
 DIR=\$(cd \$(dirname \$0); pwd)
 \$DIR/language_server.sh \$*

--- a/installer/install-elm-language-server.sh
+++ b/installer/install-elm-language-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-emmylua-ls.sh
+++ b/installer/install-emmylua-ls.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -6,7 +6,7 @@ version="0.3.6"
 curl -L -o EmmyLua-LS-all.jar "https://github.com/EmmyLua/EmmyLua-LanguageServer/releases/download/$version/EmmyLua-LS-all.jar"
 
 cat <<EOF >emmylua-ls
-#!/usr/bin/env bash
+#!/bin/sh
 
 DIR=\$(cd \$(dirname \$0); pwd)
 java -cp \$DIR/EmmyLua-LS-all.jar com.tang.vscode.MainKt

--- a/installer/install-erlang-ls.sh
+++ b/installer/install-erlang-ls.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-esbonio.sh
+++ b/installer/install-esbonio.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -7,7 +7,7 @@ python3 -m venv ./venv
 ./venv/bin/pip3 install "esbonio[lsp]"
 
 cat <<EOF >esbonio
-#!/usr/bin/env bash
+#!/bin/sh
 
 DIR=\$(cd \$(dirname \$0); pwd)
 \$DIR/venv/bin/python3 -m esbonio

--- a/installer/install-eslint-language-server.sh
+++ b/installer/install-eslint-language-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -10,7 +10,7 @@ unzip "$asset"
 rm "$asset"
 
 cat <<EOF >eslint-language-server
-#!/usr/bin/env bash
+#!/bin/sh
 
 DIR=\$(cd \$(dirname \$0); pwd)
 node \$DIR/extension/server/out/eslintServer.js \$*

--- a/installer/install-flow.sh
+++ b/installer/install-flow.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-fortls.sh
+++ b/installer/install-fortls.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 "$(dirname "$0")/pip_install.sh" fortls fortran-language-server

--- a/installer/install-fsautocomplete.sh
+++ b/installer/install-fsautocomplete.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-fsharp-language-server.sh
+++ b/installer/install-fsharp-language-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -7,7 +7,7 @@ npm install
 dotnet build -c Release
 
 cat <<EOF >fsharp-language-server
-#!/usr/bin/env bash
+#!/bin/sh
 
 DIR=\$(cd \$(dirname \$0); pwd)
 \$DIR/src/FSharpLanguageServer/bin/Release/netcoreapp2.0/FSharpLanguageServer.dll \$*

--- a/installer/install-golangci-lint-langserver.sh
+++ b/installer/install-golangci-lint-langserver.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-gopls.sh
+++ b/installer/install-gopls.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-gql-language-server.sh
+++ b/installer/install-gql-language-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-graphql-language-server.sh
+++ b/installer/install-graphql-language-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-groovy-language-server.sh
+++ b/installer/install-groovy-language-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -6,7 +6,7 @@ git clone --depth=1 https://github.com/prominic/groovy-language-server .
 ./gradlew build
 
 cat <<EOF >groovy-language-server
-#!/usr/bin/env bash
+#!/bin/sh
 
 DIR=\$(cd \$(dirname \$0); pwd)
 java -jar \$DIR/build/libs/groovy-language-server-all.jar \$*

--- a/installer/install-html-languageserver.sh
+++ b/installer/install-html-languageserver.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-intelephense.sh
+++ b/installer/install-intelephense.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-javascript-typescript-stdio.sh
+++ b/installer/install-javascript-typescript-stdio.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-jedi-language-server.sh
+++ b/installer/install-jedi-language-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-json-languageserver.sh
+++ b/installer/install-json-languageserver.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-julia-language-server.sh
+++ b/installer/install-julia-language-server.sh
@@ -1,11 +1,11 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
 julia -e 'using Pkg; Pkg.add("LanguageServer")'
 
 cat <<EOF >julia-language-server
-#!/usr/bin/env bash
+#!/bin/sh
 
 julia -e "using LanguageServer, LanguageServer.SymbolServer; runserver()"
 EOF

--- a/installer/install-kotlin-language-server.sh
+++ b/installer/install-kotlin-language-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-lemminx.sh
+++ b/installer/install-lemminx.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -9,7 +9,7 @@ lemminx_jar="org.eclipse.lemminx-${version}-uber.jar"
 curl -L "$url" -o "${lemminx_jar}"
 
 cat <<EOF >lemminx
-#!/usr/bin/env bash
+#!/bin/sh
 
 DIR=\$(cd \$(dirname \$0); pwd)
 java -jar \$DIR/${lemminx_jar}

--- a/installer/install-marksman.sh
+++ b/installer/install-marksman.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-metals.sh
+++ b/installer/install-metals.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -6,22 +6,22 @@ curl -Lo ./coursier https://git.io/coursier-cli
 chmod +x ./coursier
 
 version=$(curl -LsS "https://scalameta.org/metals/latests.json" | grep -o '"release": "[^"]*"' | grep -o '[\.0-9]*')
-java_flags=()
+java_flags=
 
-if [[ -n "${https_proxy}" ]]; then
+if [ -n "${https_proxy}" ]; then
   readonly https_proxy_without_protocol="${https_proxy#http://}"
-  java_flags+=("-Dhttps.proxyHost=${https_proxy_without_protocol%:*}")
-  java_flags+=("-Dhttps.proxyPort=${https_proxy_without_protocol##*:}")
+  java_flags="$java_flags -Dhttps.proxyHost=${https_proxy_without_protocol%:*}"
+  java_flags="$java_flags -Dhttps.proxyPort=${https_proxy_without_protocol##*:}"
 fi
 
-if [[ -n "${http_proxy}" ]]; then
+if [ -n "${http_proxy}" ]; then
   http_proxy_without_protocol="${http_proxy#http://}"
-  java_flags+=("-Dhttp.proxyHost=${http_proxy_without_protocol%:*}")
-  java_flags+=("-Dhttp.proxyPort=${http_proxy_without_protocol##*:}")
+  java_flags="$java_flags -Dhttp.proxyHost=${http_proxy_without_protocol%:*}"
+  java_flags="$java_flags -Dhttp.proxyPort=${http_proxy_without_protocol##*:}"
 fi
 
-if [[ -n "${no_proxy}" ]]; then
-  java_flags+=("-Dhttp.nonProxyHosts=${no_proxy}")
+if [ -n "${no_proxy}" ]; then
+  java_flags="$java_flags -Dhttp.nonProxyHosts=${no_proxy}"
 fi
 
-java "${java_flags[@]}" -jar ./coursier bootstrap --ttl Inf "org.scalameta:metals_2.13:${version}" -r "bintray:scalacenter/releases" -r "sonatype:public" -r "sonatype:snapshots" -o ./metals
+java "$java_flags" -jar ./coursier bootstrap --ttl Inf "org.scalameta:metals_2.13:${version}" -r "bintray:scalacenter/releases" -r "sonatype:public" -r "sonatype:snapshots" -o ./metals

--- a/installer/install-nimlsp.sh
+++ b/installer/install-nimlsp.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-ntt.sh
+++ b/installer/install-ntt.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
-set -o pipefail
+#set -o pipefail
 
 os="$(uname -s | tr "[:upper:]" "[:lower:]")"
 

--- a/installer/install-ocaml-lsp.sh
+++ b/installer/install-ocaml-lsp.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-omnisharp-lsp.sh
+++ b/installer/install-omnisharp-lsp.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -32,7 +32,7 @@ if [ "$mainVersion" -ge "6" ]; then
   net6="-net6.0"
 
 cat <<EOF >run
-#!/usr/bin/env bash
+#!/bin/sh
 
 base_dir="\$(cd "\$(dirname "\$0")" && pwd -P)"
 omnisharp_cmd=\${base_dir}/OmniSharp
@@ -47,7 +47,7 @@ curl -L "$url" | tar xz
 chmod +x run
 
 cat <<EOF >omnisharp-lsp
-#!/usr/bin/env bash
+#!/bin/sh
 
 DIR=\$(cd \$(dirname \$0); pwd)
 \$DIR/run \$*

--- a/installer/install-perlnavigator.sh
+++ b/installer/install-perlnavigator.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-plpgsql-lsp.sh
+++ b/installer/install-plpgsql-lsp.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -7,7 +7,7 @@ npm install
 npm run build
 
 cat <<EOF >plpgsql-lsp
-#!/usr/bin/env bash
+#!/bin/sh
 
 DIR=\$(cd \$(dirname \$0); pwd)
 node \$DIR/server/out/server.js \$*

--- a/installer/install-powershell-languageserver.sh
+++ b/installer/install-powershell-languageserver.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -8,7 +8,7 @@ rm PowerShellEditorServices.zip
 mkdir session
 
 cat <<EOF >powershell-languageserver
-#!/usr/bin/env bash
+#!/bin/sh
 
 DIR=\$(cd \$(dirname \$0); pwd)
 PSES_BUNDLE_PATH=\$DIR/PowerShellEditorServices

--- a/installer/install-prisma-language-server.sh
+++ b/installer/install-prisma-language-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -10,10 +10,11 @@ if [ ! -f package.json ]; then
 fi
 
 npm install "@prisma/engines"
-pushd "node_modules/@prisma/engines"
+_DIR="$PWD"
+cd "node_modules/@prisma/engines"
 PRISMA_FMT_BASENAME="$(find . -name "prisma-fmt*")"
 test -x "$PRISMA_FMT_BASENAME"
-popd
+cd "$_DIR"
 
 ln -s "./node_modules/@prisma/engines/${PRISMA_FMT_BASENAME}" ./prisma-fmt
 "$(dirname "$0")/npm_install.sh" prisma-language-server @prisma/language-server

--- a/installer/install-psalm-language-server.sh
+++ b/installer/install-psalm-language-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-puppet-ls.sh
+++ b/installer/install-puppet-ls.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 set -o errexit
 
 git clone --depth=1 https://github.com/puppetlabs/puppet-editor-services.git .
@@ -7,7 +7,7 @@ bundle install
 bundle exec rake gem_revendor
 
 cat <<'EOF' >puppet-ls
-#!/usr/bin/env bash
+#!/bin/sh
 set -o errexit
 cd "$(dirname "$0")"
 exec bundle exec ruby ./puppet-languageserver "$@"

--- a/installer/install-pyls-all.sh
+++ b/installer/install-pyls-all.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-pyls-ms.sh
+++ b/installer/install-pyls-ms.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -25,7 +25,7 @@ curl -L "$url" -o "$nupkg"
 unzip "$nupkg"
 
 cat <<EOF >pyls-ms
-#!/usr/bin/env bash
+#!/bin/sh
 
 DIR=\$(cd \$(dirname \$0); pwd)
 \$DIR/.dotnet/dotnet \$DIR/Microsoft.Python.LanguageServer.dll

--- a/installer/install-pyls.sh
+++ b/installer/install-pyls.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-pylsp-all.sh
+++ b/installer/install-pylsp-all.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-pylsp.sh
+++ b/installer/install-pylsp.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-pyright-langserver.sh
+++ b/installer/install-pyright-langserver.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-r-languageserver.sh
+++ b/installer/install-r-languageserver.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -6,7 +6,7 @@ echo 'install.packages("languageserver", repos = "https://cran.r-project.org")' 
 Rscript install.r
 
 cat <<EOF >r-languageserver
-#!/usr/bin/env bash
+#!/bin/sh
 
 R --slave -e 'languageserver::run()'
 EOF

--- a/installer/install-racket-lsp.sh
+++ b/installer/install-racket-lsp.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 raco pkg install racket-langserver
 cat <<EOF >racket-lsp

--- a/installer/install-reason-language-server.sh
+++ b/installer/install-reason-language-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-remark-language-server.sh
+++ b/installer/install-remark-language-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-rome.sh
+++ b/installer/install-rome.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-ruby-lsp.sh
+++ b/installer/install-ruby-lsp.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -8,7 +8,7 @@ bundle config set --local without development
 bundle install
 
 cat <<EOF >ruby-lsp
-#!/usr/bin/env bash
+#!/bin/sh
 
 DIR=\$(cd \$(dirname \$0); pwd)
 BUNDLE_GEMFILE=\$DIR/Gemfile bundle exec ruby \$DIR/exe/ruby-lsp \$*

--- a/installer/install-ruby_language_server.sh
+++ b/installer/install-ruby_language_server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -8,7 +8,7 @@ bundle config set --local without development
 bundle install
 
 cat <<EOF >ruby_language_server
-#!/usr/bin/env bash
+#!/bin/sh
 
 DIR=\$(cd \$(dirname \$0); pwd)
 BUNDLE_GEMFILE=\$DIR/Gemfile bundle exec ruby \$DIR/exe/ruby_language_server \$*

--- a/installer/install-rust-analyzer.sh
+++ b/installer/install-rust-analyzer.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -7,9 +7,9 @@ arch="$(uname -m)"
 
 case $os in
 linux)
-  if [[ $arch == "x86_64" ]]; then
+  if [ "$arch" = "x86_64" ]; then
     platform="x86_64-unknown-linux-gnu"
-  elif [[ $arch == "aarch64" ]]; then
+  elif [ "$arch" = "aarch64" ]; then
     platform="aarch64-unknown-linux-gnu"
   else
     echo "unknown architecture: $arch"
@@ -17,9 +17,9 @@ linux)
   fi
   ;;
 darwin)
-  if [[ $arch == "x86_64" ]]; then
+  if [ "$arch" = "x86_64" ]; then
     platform="x86_64-apple-darwin"
-  elif [[ $arch == "aarch64" || $arch == "arm64" ]]; then
+  elif [ "$arch" = "aarch64" ] || [ "$arch" = "arm64" ]; then
     platform="aarch64-apple-darwin"
   else
     echo "unknown architecture: $arch"
@@ -27,9 +27,9 @@ darwin)
   fi
   ;;
 mingw64_nt*)
-  if [[ $arch == "x86_64" ]]; then
+  if [ "$arch" = "x86_64" ]; then
   	platform="x86_64-pc-windows-msvc"
-  elif [[ $arch == "aarch64" || $arch == "arm64" ]]; then
+  elif [ "$arch" = "aarch64" ] || [ "$arch" = "arm64" ]; then
     platform="aarch64-pc-windows-msvc"
   else
     echo "unknown architecture: $arch"

--- a/installer/install-serve-d.sh
+++ b/installer/install-serve-d.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-solargraph.sh
+++ b/installer/install-solargraph.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -8,7 +8,7 @@ bundle config set --local without development
 bundle install
 
 cat <<EOF >solargraph
-#!/usr/bin/env bash
+#!/bin/sh
 
 DIR=\$(cd \$(dirname \$0); pwd)
 BUNDLE_GEMFILE=\$DIR/Gemfile bundle exec ruby \$DIR/bin/solargraph \$*

--- a/installer/install-sql-language-server.sh
+++ b/installer/install-sql-language-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-sqls.sh
+++ b/installer/install-sqls.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-steep.sh
+++ b/installer/install-steep.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -8,7 +8,7 @@ bundle config set --local without development
 bundle install
 
 cat <<EOF >steep
-#!/usr/bin/env bash
+#!/bin/sh
 
 DIR=\$(cd \$(dirname \$0); pwd)
 BUNDLE_GEMFILE=\$DIR/Gemfile bundle exec steep \$*

--- a/installer/install-sumneko-lua-language-server.sh
+++ b/installer/install-sumneko-lua-language-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -7,9 +7,9 @@ arch="$(uname -m)"
 
 case $os in
 linux)
-  if [[ $arch == "x86_64" ]]; then
+  if [ "$arch" = "x86_64" ]; then
     platform="linux-x64"
-  elif [[ $arch == "aarch64" || $arch == "arm64" ]]; then
+  elif [ "$arch" = "aarch64" ] || [ "$arch" = "arm64" ]; then
     platform="linux-arm64"
   else
     echo "unknown architecture: $arch"
@@ -17,9 +17,9 @@ linux)
   fi
   ;;
 darwin)
-  if [[ $arch == "x86_64" ]]; then
+  if [ "$arch" = "x86_64" ]; then
     platform="darwin-x64"
-  elif [[ $arch == "aarch64" || $arch == "arm64" ]]; then
+  elif [ "$arch" = "aarch64" ] || [ "$arch" = "arm64" ]; then
     platform="darwin-arm64"
   else
     echo "unknown architecture: $arch"
@@ -27,7 +27,7 @@ darwin)
   fi
   ;;
 mingw64_nt*)
-  if [[ $arch == "x86_64" ]]; then
+  if [ "$arch" = "x86_64" ]; then
     platform="win32-x64"
   else
     echo "unknown architecture: $arch"
@@ -51,7 +51,7 @@ rm "$asset"
 chmod +x extension/server/bin/lua-language-server
 
 cat <<EOF >sumneko-lua-language-server
-#!/usr/bin/env bash
+#!/bin/sh
 
 DIR=\$(cd \$(dirname \$0); pwd)/extension/server
 \$DIR/bin/lua-language-server -E -e LANG=en \$DIR/main.lua \$*

--- a/installer/install-svelte-language-server.sh
+++ b/installer/install-svelte-language-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-svls.sh
+++ b/installer/install-svls.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-tailwindcss-intellisense.sh
+++ b/installer/install-tailwindcss-intellisense.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -13,7 +13,7 @@ rm "$asset" \[Content_Types\].xml extension.vsixmanifest
 chmod +x extension/dist/server/index.js
 
 cat <<EOF >tailwindcss-intellisense
-#!/usr/bin/env bash
+#!/bin/sh
 
 DIR=\$(cd \$(dirname \$0); pwd)
 node \$DIR/extension/dist/server/index.js \$*

--- a/installer/install-taplo-lsp.sh
+++ b/installer/install-taplo-lsp.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-terraform-ls.sh
+++ b/installer/install-terraform-ls.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-terraform-lsp.sh
+++ b/installer/install-terraform-lsp.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-texlab.sh
+++ b/installer/install-texlab.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-typeprof.sh
+++ b/installer/install-typeprof.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
@@ -8,7 +8,7 @@ bundle config set --local without development
 bundle install
 
 cat <<EOF >typeprof
-#!/usr/bin/env bash
+#!/bin/sh
 
 DIR=\$(cd \$(dirname \$0); pwd)
 BUNDLE_GEMFILE=\$DIR/Gemfile bundle exec ruby \$DIR/exe/typeprof \$*

--- a/installer/install-typescript-language-server.sh
+++ b/installer/install-typescript-language-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-vim-language-server.sh
+++ b/installer/install-vim-language-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-vlang-vls.sh
+++ b/installer/install-vlang-vls.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 git clone --depth=1 https://github.com/vlang/vls .
 
 echo 'Compiling vlang/vls...'

--- a/installer/install-vls.sh
+++ b/installer/install-vls.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-volar-server.sh
+++ b/installer/install-volar-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-vscode-css-language-server.sh
+++ b/installer/install-vscode-css-language-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-vscode-html-language-server.sh
+++ b/installer/install-vscode-html-language-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-vscode-json-language-server.sh
+++ b/installer/install-vscode-json-language-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-yaml-language-server.sh
+++ b/installer/install-yaml-language-server.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 

--- a/installer/install-zls.sh
+++ b/installer/install-zls.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 git clone --recurse-submodules https://github.com/zigtools/zls .
 git checkout "refs/tags/$(git tag | grep "^$(zig version | sed -r 's/\.[0-9]+$//')")"

--- a/installer/npm_install.sh
+++ b/installer/npm_install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Usage
 # $ npm_install [EXECUTABLE_NAME] [NPM_NAME]

--- a/installer/pip_install.sh
+++ b/installer/pip_install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Usage
 # $ pip_install [EXECUTABLE_NAME] [PYPI_NAME]

--- a/installer/yarn_install.sh
+++ b/installer/yarn_install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Usage
 # $ yarn_install [EXECUTABLE_NAME] [NPM_NAME]


### PR DESCRIPTION
this PR
- changes `#!/usr/bin/env bash` || `#!/bin/bash` to `#!/bin/sh` for installer shebangs
- makes installer scripts POSIX compatible (by replacing bashisms)

```sh
$ shellcheck *.sh
```
returns nothing, so all the scripts should work as before

why?

i wanted to install `go` tools on my openbsd laptop without bash ;)