### PR TITLE
Fix; Removed redundant line that caused exit 127

### DIFF
--- a/installer/install-clangd.sh
+++ b/installer/install-clangd.sh
@@ -51,7 +51,6 @@ filename() {
   case $distributor_id in
   # Check Ubuntu version
   Ubuntu)
-    ubuntu_version
     ubuntu_version=$(lsb_release -a 2>&1 | grep 'Release' | awk '{print $2}')
     case $ubuntu_version in
     14.04 | 16.04 | 18.04 | 20.04)


### PR DESCRIPTION
The variable 'ubuntu_version' does on ubuntu 18.04 caused error full exit with exit code
of 127, the removal of this fixes the error