### PR TITLE
Update submodules after checkout

### DIFF
--- a/installer/install-zls.sh
+++ b/installer/install-zls.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-git clone --recurse-submodules https://github.com/zigtools/zls .
+git clone https://github.com/zigtools/zls .
 git checkout "refs/tags/$(git tag | grep "^$(zig version | sed -r 's/\.[0-9]+$//')")"
+git submodule update --init --recursive
 zig build
 mv zig-out/bin/zls .
 rm -rf zig-cache zig-out src tests


### PR DESCRIPTION
Fail to install zls

```
Cloning into '.'...
  ... SNIP ...
Submodule path 'src/known-folders': checked out '9db1b99219c767d5e24994b1525273fe4031e464'
Submodule path 'src/tracy': checked out '2d8723b69b39721eadcc296451012828899c0f17'
warning: unable to rmdir 'src/tracy': Directory not empty
Note: switching to 'refs/tags/0.9.0'.
  ... SNIP ...
error: Failed to add package at path /tmp/xmosh/zzzz/fail/src/zinput/src/main.zig: FileNotFound
zls...The following command exited with error code 1:
/usr/bin/zig build-exe /tmp/xmosh/zzzz/fail/src/main.zig --cache-dir /tmp/xmosh/zzzz/fail/zig-cache --global-cache-dir /home/anekos/.cache/zig --name zls --pkg-begin build_options /tmp/xmosh/zzzz/fail/zig-cache/options/L9eqxgIAE4PmL1q7z-R9mddPxCA1hxdCO2SbWbMoIU3gyy2e0E0-nMjqqyAeR5Ke --pkg-end --pkg-begin known-folders /tmp/xmosh/zzzz/fail/src/known-folders/known-folders.zig --pkg-end --pkg-begin zinput /tmp/xmosh/zzzz/fail/src/zinput/src/main.zig --pkg-end --enable-cache 
error: the following build command failed with exit code 1:
/tmp/xmosh/zzzz/fail/zig-cache/o/02252f86f825d116fc0493e4b58d6e05/build /usr/bin/zig /tmp/xmosh/zzzz/fail /tmp/xmosh/zzzz/fail/zig-cache /home/anekos/.cache/zig
mv: cannot stat 'zig-out/bin/zls': No such file or directory
```