### PR TITLE
Fix install-fsharp-language-server.sh, cf. issue #601

### DIFF
--- a/installer/install-fsharp-language-server.sh
+++ b/installer/install-fsharp-language-server.sh
@@ -10,7 +10,7 @@ cat <<EOF >fsharp-language-server
 #!/bin/sh
 
 DIR=\$(cd \$(dirname \$0); pwd)
-\$DIR/Publish/FSharpLanguageServer.dll \$*
+dotnet \$DIR/Publish/FSharpLanguageServer.dll \$*
 EOF
 
 chmod +x fsharp-language-server

--- a/installer/install-fsharp-language-server.sh
+++ b/installer/install-fsharp-language-server.sh
@@ -4,13 +4,13 @@ set -e
 
 git clone --depth=1 https://github.com/fsprojects/fsharp-language-server .
 npm install
-dotnet build -c Release
+dotnet publish --configuration Release --output Publish
 
 cat <<EOF >fsharp-language-server
 #!/bin/sh
 
 DIR=\$(cd \$(dirname \$0); pwd)
-\$DIR/src/FSharpLanguageServer/bin/Release/netcoreapp2.0/FSharpLanguageServer.dll \$*
+\$DIR/Publish/FSharpLanguageServer.dll \$*
 EOF
 
 chmod +x fsharp-language-server

--- a/installer/install-fsharp-language-server.sh
+++ b/installer/install-fsharp-language-server.sh
@@ -4,7 +4,9 @@ set -e
 
 git clone --depth=1 https://github.com/fsprojects/fsharp-language-server .
 npm install
-dotnet publish --configuration Release --output Publish
+dotnet tool install --global paket
+dotnet tool restore
+dotnet publish src/FSharpLanguageServer --configuration Release --output Publish 
 
 cat <<EOF >fsharp-language-server
 #!/bin/sh


### PR DESCRIPTION
The purpose of this PR is to fix the issues described in #601:

* We make the install and launch scripts agnostic to the .NET version by publishing the built application to a Publish folder (in other words, the target folder name is not dependent on the .NET version number). 
* We make sure the `paket` tool is installed and available.
* We only build the `FSharpLanguageServer` project, ignoring any other projects like test projects.
* We launch the built application using dotnet `FSharpLanguageServer.dll`

