### PR TITLE
Fix metals installer

### DIFF
--- a/installer/install-metals.sh
+++ b/installer/install-metals.sh
@@ -6,6 +6,7 @@ curl -Lo ./coursier https://git.io/coursier-cli
 chmod +x ./coursier
 
 version=$(curl -LsS "https://scalameta.org/metals/latests.json" | grep -o '"release": "[^"]*"' | grep -o '[\.0-9]*')
+version=0.11.6 # WORKAROUND
 
 java_flags=
 

--- a/installer/install-metals.sh
+++ b/installer/install-metals.sh
@@ -6,22 +6,31 @@ curl -Lo ./coursier https://git.io/coursier-cli
 chmod +x ./coursier
 
 version=$(curl -LsS "https://scalameta.org/metals/latests.json" | grep -o '"release": "[^"]*"' | grep -o '[\.0-9]*')
+
 java_flags=
 
 if [ -n "${https_proxy}" ]; then
   readonly https_proxy_without_protocol="${https_proxy#http://}"
-  java_flags="$java_flags -Dhttps.proxyHost=${https_proxy_without_protocol%:*}"
-  java_flags="$java_flags -Dhttps.proxyPort=${https_proxy_without_protocol##*:}"
+  java_flags="$java_flags -J-Dhttps.proxyHost=${https_proxy_without_protocol%:*}"
+  java_flags="$java_flags -J-Dhttps.proxyPort=${https_proxy_without_protocol##*:}"
 fi
 
 if [ -n "${http_proxy}" ]; then
   http_proxy_without_protocol="${http_proxy#http://}"
-  java_flags="$java_flags -Dhttp.proxyHost=${http_proxy_without_protocol%:*}"
-  java_flags="$java_flags -Dhttp.proxyPort=${http_proxy_without_protocol##*:}"
+  java_flags="$java_flags -J-Dhttp.proxyHost=${http_proxy_without_protocol%:*}"
+  java_flags="$java_flags -J-Dhttp.proxyPort=${http_proxy_without_protocol##*:}"
 fi
 
 if [ -n "${no_proxy}" ]; then
-  java_flags="$java_flags -Dhttp.nonProxyHosts=${no_proxy}"
+  java_flags="$java_flags -J-Dhttp.nonProxyHosts=${no_proxy}"
 fi
 
-java "$java_flags" -jar ./coursier bootstrap --ttl Inf "org.scalameta:metals_2.13:${version}" -r "bintray:scalacenter/releases" -r "sonatype:public" -r "sonatype:snapshots" -o ./metals
+
+./coursier bootstrap \
+  --java-opt -Xss4m \
+  --java-opt -Xms100m \
+  ${java_flags} \
+  org.scalameta:metals_2.13:${version} \
+  -r bintray:scalacenter/releases \
+  -r sonatype:releases \
+  -o metals -f


### PR DESCRIPTION
The first commit fixed the installer for metals (#566). 
The second one is a workaround for an issue which the latest metals 0.11.7 seems not compatible with vim-lsp as before ([prabirshrestha/vim-lsp/#1331](https://github.com/prabirshrestha/vim-lsp/issues/1331)).