### PR TITLE
feat: add support for Dagger CUE LSP

### DIFF
--- a/installer/install-dagger-cue-lsp.sh
+++ b/installer/install-dagger-cue-lsp.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -e
+
+# check if dagger is present
+dagger_path=$(which dagger)
+if [ -f $dagger_path ]; then
+	echo "Dagger CLI already installed, using it…"
+	exit 0
+fi
+
+os=$(uname -s | tr "[:upper:]" "[:lower:]")
+
+url="http://can.not.find.cue.lsp.version"
+
+arch=$(uname -i)
+if [ "$arch" = "x86_64" ]; then
+  arch="amd64"
+elif [ "$arch" = "aarch64" ]; then
+  arch="arm64"
+fi
+
+url=$(curl -H "Accept: application/vnd.github+json"   https://api.github.com/repos/dagger/cuelsp/releases/latest | grep $os | grep $arch | grep "browser_download_url" | awk '{ print $2; }' | sed 's/"//g' )
+
+curl -L "$url" | tar -xz

--- a/settings.json
+++ b/settings.json
@@ -340,6 +340,19 @@
       }
     }
   ],
+  "dagger_cue_lsp": [
+    {
+      "command": "dagger",
+      "url": "https://github.com/dagger/dagger/blob/main/README.md",
+      "description": "Dagger CUE LSP",
+      "requires": [
+        "dagger"
+      ],
+      "root_uri_patterns": [
+        "cue.mod"
+      ]
+    }
+  ],
   "go": [
     {
       "command": "gopls",

--- a/settings.json
+++ b/settings.json
@@ -343,7 +343,7 @@
   "dagger_cue_lsp": [
     {
       "command": "dagger",
-      "url": "https://github.com/dagger/dagger/blob/main/README.md",
+      "url": "https://github.com/dagger/dagger/",
       "description": "Dagger CUE LSP",
       "requires": [
         "dagger"

--- a/settings/dagger-cue-lsp.vim
+++ b/settings/dagger-cue-lsp.vim
@@ -1,0 +1,32 @@
+" NOTE: For compatibility, this looks up not only
+" dagger lsp's user config but also
+" cuelsp's one.
+augroup vim_lsp_settings_dagger_cue_lsp
+  au!
+  LspRegisterServer {
+      \ 'name': 'dagger_cue_lsp',
+      \ 'cmd': {server_info->
+      \     lsp_settings#get('dagger_cue_lsp', 'cmd',
+      \     [lsp_settings#exec_path('dagger')]+
+      \         lsp_settings#get('dagger_cue_lsp', 'args', ['cuelsp'],
+      \         ))},
+      \ 'root_uri': {server_info->
+      \     lsp_settings#get('dagger_cue_lsp', 'root_uri',
+      \     lsp_settings#root_uri('dagger_cue_lsp'))},
+      \ 'allowlist':
+      \     lsp_settings#get('dagger_cue_lsp', 'allowlist',
+      \     ['cue']),
+      \ 'blocklist':
+      \     lsp_settings#get('dagger_cue_lsp', 'blocklist',
+      \     []),
+      \ 'config':
+      \     lsp_settings#get('dagger_cue_lsp', 'config',
+      \     lsp_settings#server_config('dagger_cue_lsp')),
+      \ 'workspace_config':
+      \     lsp_settings#get('dagger_cue_lsp', 'workspace_config',
+      \     {}),
+      \ 'semantic_highlight':
+      \     lsp_settings#get('dagger_cue_lsp', 'semantic_highlight',
+      \     {}),
+      \ }
+augroup END


### PR DESCRIPTION
Hi,
we recently released a CUE LSP, and I followed `vim-lsp` documentation to configure it, and it works pretty well. But I wanted to make it even simpler to use it and started creating this PR.
But somehow, I can't make it work.
The configuration that works with bare `vim-lsp` is:

```vim
if executable('dagger')
    au User lsp_setup call lsp#register_server({
        \ 'name': 'dagger_cue_lsp',
        \ 'cmd': {server_info->['dagger', 'cuelsp']},
        \ 'allowlist': ['cue'],
        \ })
endif

function! s:on_lsp_buffer_enabled() abort
    setlocal omnifunc=lsp#complete
    setlocal signcolumn=yes
    if exists('+tagfunc') | setlocal tagfunc=lsp#tagfunc | endif
    nmap <buffer> gd <plug>(lsp-definition)
    nmap <buffer> gs <plug>(lsp-document-symbol-search)
    nmap <buffer> gS <plug>(lsp-workspace-symbol-search)
    nmap <buffer> gr <plug>(lsp-references)
    nmap <buffer> gi <plug>(lsp-implementation)
    "nmap <buffer> gt <plug>(lsp-type-definition)
    nmap <buffer> ,rn <plug>(lsp-rename)
    nmap <buffer> [g <plug>(lsp-previous-diagnostic)
    nmap <buffer> ]g <plug>(lsp-next-diagnostic)
    nmap <buffer> K <plug>(lsp-hover)

    let g:lsp_format_sync_timeout = 1000
    autocmd! BufWritePre *.cue call execute('LspDocumentFormatSync')

    " refer to doc to add more commands
endfunction

let g:lsp_log_file = expand('/tmp/vim-lsp.log')
let g:lsp_log_verbose = 1

let g:lsp_experimental_workspace_folders = get(g:, 'lsp_experimental_workspace_folders', 1)

augroup lsp_install
    au!
    " call s:on_lsp_buffer_enabled only for languages that has the server registered.
    autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled()
augroup END
```
On a second improvement, I'd like to be able to use either the cuelsp server embedded in the dagger binary, but I want user who just want to use CUE not to have to download dagger. We have a standalone cuelsp binary as well. I think somehow haskell has 2 binaries as well, but I couldn't get the configuration right, so I reduced to just 1 case.