### PR TITLE
fix clojure-lsp installer: DL latest standalone binary

### DIFF
--- a/installer/install-clojure-lsp.cmd
+++ b/installer/install-clojure-lsp.cmd
@@ -1,5 +1,22 @@
 @echo off
 
 setlocal
-set VERSION=2021.02.01-20.37.52
-curl -L -o clojure-lsp.cmd https://github.com/clojure-lsp/clojure-lsp/releases/download/%VERSION%/clojure-lsp
+
+set VERSION=latest
+
+rem FIXME: Windows shell always sets %PROCESSOR_ARCHITECTURE% ["AMD64" || "x86"] even if uses ARM64.
+echo Your Architecture is: %PROCESSOR_ARCHITECTURE%
+if %PROCESSOR_ARCHITECTURE% == AMD64 (
+  set ARCH=amd64
+) else (
+  echo Unknown architecture: %PROCESSOR_ARCHITECTURE%
+  exit /B 1
+)
+
+rem FIXME: clojure-lsp releases only AMD64 binary.
+set FILENAME=clojure-lsp-native-windows-%ARCH%.zip
+
+set URL=https://github.com/clojure-lsp/clojure-lsp/releases/%VERSION%/download/%FILENAME%
+echo Downloading: %URL%
+curl -L -O %URL%
+call "%~dp0\run_unzip.cmd" %FILENAME%

--- a/installer/install-clojure-lsp.sh
+++ b/installer/install-clojure-lsp.sh
@@ -2,6 +2,50 @@
 
 set -e
 
-version="2021.02.01-20.37.52"
-curl -L -o clojure-lsp "https://github.com/clojure-lsp/clojure-lsp/releases/download/$version/clojure-lsp"
+os="$(uname -s | tr "[:upper:]" "[:lower:]")"
+arch="$(uname -m)"
+
+case $os in
+linux)
+  os_fixed="linux"
+  if [ "$arch" = "x86_64" ]; then
+    platform="amd64"
+  elif [ "$arch" = "aarch64" ] || [ "$arch" = "arm64" ]; then
+    platform="aarch64"
+  else
+    echo "unknown architecture: $arch"
+    exit 1
+  fi
+  ;;
+darwin)
+  os_fixed="macos"
+  if [ "$arch" = "x86_64" ]; then
+    platform="amd64"
+  elif [ "$arch" = "aarch64" ] || [ "$arch" = "arm64" ]; then
+    platform="aarch64"
+  else
+    echo "unknown architecture: $arch"
+    exit 1
+  fi
+  ;;
+mingw64_nt*)
+  os_fixed="windows"
+  if [ "$arch" = "x86_64" ]; then
+    platform="amd64"
+  else
+    echo "unknown architecture: $arch"
+    exit 1
+  fi
+  ;;
+*)
+  echo "unknow platform: $os"
+  exit 1
+  ;;
+esac
+
+version="latest"
+filename="clojure-lsp-native-${os_fixed}-${platform}.zip"
+url="https://github.com/clojure-lsp/clojure-lsp/releases/${version}/download/${filename}"
+curl -L -O ${url}
+unzip ${filename}
 chmod +x clojure-lsp


### PR DESCRIPTION
Found at: https://github.com/shun/ddc-vim-lsp/pull/16#issuecomment-1212962805

Currently `clojure-lsp` installer downloads `2021.02.01-20.37.52`.
It's too old to use new features, and users need to install JRE.
This makes more steps to use LSP.

Now we can use native standalone binary in latest version, so I create this PR.