### PR TITLE
Removed workaround for metals

### DIFF
--- a/installer/install-metals.sh
+++ b/installer/install-metals.sh
@@ -6,7 +6,6 @@ curl -Lo ./coursier https://git.io/coursier-cli
 chmod +x ./coursier
 
 version=$(curl -LsS "https://scalameta.org/metals/latests.json" | grep -o '"release": "[^"]*"' | grep -o '[\.0-9]*')
-version=0.11.6 # WORKAROUND
 
 java_flags=
 


### PR DESCRIPTION
https://github.com/prabirshrestha/vim-lsp/pull/1350 solved the issue that metals (>= 0.11.7) couldn't run, so that the workaround in metals installer is removed and now latest metals works correctly.