### PR TITLE
fix: add --issues-exit-code=1 flag to `golangci-lint-langserver`

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,20 @@ location. See 'Configurations' below.
 If you installed `hie` with stack, you can use hie without configurations.
 But if you have not installed `hie` yet, you can install it by following [these steps](https://github.com/haskell/haskell-ide-engine#installation).
 
+### [golangci-lint-langserver](https://github.com/nametake/golangci-lint-langserver) (Go)
+
+To use older version `golangci-lint-langserver`, please run `:LspSettingsGlobalEdit` and put bellow configuration.
+
+```json5
+"golangci-lint-langserver": {
+    "initialization_options": {
+        "command": [
+            "golangci-lint", "run", "--enable-all", "--disable", "lll", "--out-format", "json"
+        ]
+    }
+}
+```
+
 ## Extra Configurations
 
 Most of the configurations are not required.

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ But if you have not installed `hie` yet, you can install it by following [these 
 
 ### [golangci-lint-langserver](https://github.com/nametake/golangci-lint-langserver) (Go)
 
-To use older version `golangci-lint-langserver`, please run `:LspSettingsGlobalEdit` and put bellow configuration.
+To use older version `golangci-lint`, please run `:LspSettingsGlobalEdit` and put bellow configuration.
 
 ```json5
 "golangci-lint-langserver": {

--- a/settings/golangci-lint-langserver.vim
+++ b/settings/golangci-lint-langserver.vim
@@ -4,7 +4,7 @@ augroup vim_lsp_settings_golangci_lint_langserver
       \ 'name': 'golangci-lint-langserver',
       \ 'cmd': {server_info->lsp_settings#get('golangci-lint-langserver', 'cmd', [lsp_settings#exec_path('golangci-lint-langserver')]+lsp_settings#get('golangci-lint-langserver', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('golangci-lint-langserver', 'root_uri', lsp_settings#root_uri('golangci-lint-langserver'))},
-      \ 'initialization_options': lsp_settings#get('golangci-lint-langserver', 'initialization_options', {'command': ['golangci-lint', 'run', '--enable-all', '--disable', 'lll', '--out-format', 'json']}),
+      \ 'initialization_options': lsp_settings#get('golangci-lint-langserver', 'initialization_options', {'command': ['golangci-lint', 'run', '--enable-all', '--disable', 'lll', '--out-format', 'json', '--issues-exit-code=1']}),
       \ 'allowlist': lsp_settings#get('golangci-lint-langserver', 'allowlist', ['go']),
       \ 'blocklist': lsp_settings#get('golangci-lint-langserver', 'blocklist', []),
       \ 'config': lsp_settings#get('golangci-lint-langserver', 'config', lsp_settings#server_config('golangci-lint-langserver')),


### PR DESCRIPTION
I pull requested and merged add default option flag `--issues-exit-code=1 ` to golangci-lint-langserver .
https://github.com/nametake/golangci-lint-langserver/pull/23

This PR  add  `--issues-exit-code=1` to golangci-lint-langserver initialization_options.

