### PR TITLE
update taplo only for Mac and Linux

### DIFF
--- a/installer/install-taplo-lsp.sh
+++ b/installer/install-taplo-lsp.sh
@@ -16,6 +16,7 @@ darwin)
   ;;
 esac
 
-curl -L "https://github.com/tamasfe/taplo/releases/download/release-lsp-$latest/taplo-lsp-$platform.tar.gz" | tar xz
+curl -L "https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-$platform.tar.gz" | tar xz
 
+mv taplo taplo-lsp
 chmod +x taplo-lsp

--- a/settings/taplo-lsp.vim
+++ b/settings/taplo-lsp.vim
@@ -39,31 +39,17 @@ let g:vim_lsp_settings_taplo_lsp_options = {
 
 augroup vim_lsp_settings_taplo_lsp
   au!
-  if has('win32') || has('win64')
-    LspRegisterServer {
-        \ 'name': 'taplo-lsp',
-        \ 'cmd': {server_info->lsp_settings#get('taplo-lsp', 'cmd', [lsp_settings#exec_path('taplo-lsp')]+lsp_settings#get('taplo-lsp', 'args', ['run']))},
-        \ 'root_uri':{server_info->lsp_settings#get('taplo-lsp', 'root_uri', lsp_settings#root_uri('taplo-lsp'))},
-        \ 'initialization_options': lsp_settings#get('taplo-lsp', 'initialization_options', g:vim_lsp_settings_taplo_lsp_options),
-        \ 'allowlist': lsp_settings#get('taplo-lsp', 'allowlist', ['toml']),
-        \ 'blocklist': lsp_settings#get('taplo-lsp', 'blocklist', []),
-        \ 'config': lsp_settings#get('taplo-lsp', 'config', lsp_settings#server_config('taplo-lsp')),
-        \ 'workspace_config': lsp_settings#get('taplo-lsp', 'workspace_config', {'evenBetterToml': g:vim_lsp_settings_taplo_lsp_options}),
-        \ 'semantic_highlight': lsp_settings#get('taplo-lsp', 'semantic_highlight', {}),
-        \ }
-  else
-    LspRegisterServer {
-        \ 'name': 'taplo-lsp',
-        \ 'cmd': {server_info->lsp_settings#get('taplo-lsp', 'cmd', [lsp_settings#exec_path('taplo-lsp')]+lsp_settings#get('taplo-lsp', 'args', ['lsp', 'stdio']))},
-        \ 'root_uri':{server_info->lsp_settings#get('taplo-lsp', 'root_uri', lsp_settings#root_uri('taplo-lsp'))},
-        \ 'initialization_options': lsp_settings#get('taplo-lsp', 'initialization_options', g:vim_lsp_settings_taplo_lsp_options),
-        \ 'allowlist': lsp_settings#get('taplo-lsp', 'allowlist', ['toml']),
-        \ 'blocklist': lsp_settings#get('taplo-lsp', 'blocklist', []),
-        \ 'config': lsp_settings#get('taplo-lsp', 'config', lsp_settings#server_config('taplo-lsp')),
-        \ 'workspace_config': lsp_settings#get('taplo-lsp', 'workspace_config', {'evenBetterToml': g:vim_lsp_settings_taplo_lsp_options}),
-        \ 'semantic_highlight': lsp_settings#get('taplo-lsp', 'semantic_highlight', {}),
-        \ }
-  endif
+  LspRegisterServer {
+      \ 'name': 'taplo-lsp',
+      \ 'cmd': {server_info->lsp_settings#get('taplo-lsp', 'cmd', [lsp_settings#exec_path('taplo-lsp')]+lsp_settings#get('taplo-lsp', 'args', has('win32') || has('win64') ? ['run'] : ['lsp','stdio']))},
+      \ 'root_uri':{server_info->lsp_settings#get('taplo-lsp', 'root_uri', lsp_settings#root_uri('taplo-lsp'))},
+      \ 'initialization_options': lsp_settings#get('taplo-lsp', 'initialization_options', g:vim_lsp_settings_taplo_lsp_options),
+      \ 'allowlist': lsp_settings#get('taplo-lsp', 'allowlist', ['toml']),
+      \ 'blocklist': lsp_settings#get('taplo-lsp', 'blocklist', []),
+      \ 'config': lsp_settings#get('taplo-lsp', 'config', lsp_settings#server_config('taplo-lsp')),
+      \ 'workspace_config': lsp_settings#get('taplo-lsp', 'workspace_config', {'evenBetterToml': g:vim_lsp_settings_taplo_lsp_options}),
+      \ 'semantic_highlight': lsp_settings#get('taplo-lsp', 'semantic_highlight', {}),
+      \ }
   autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled() 
 augroup END
 

--- a/settings/taplo-lsp.vim
+++ b/settings/taplo-lsp.vim
@@ -39,17 +39,31 @@ let g:vim_lsp_settings_taplo_lsp_options = {
 
 augroup vim_lsp_settings_taplo_lsp
   au!
-  LspRegisterServer {
-      \ 'name': 'taplo-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('taplo-lsp', 'cmd', [lsp_settings#exec_path('taplo-lsp')]+lsp_settings#get('taplo-lsp', 'args', ['run']))},
-      \ 'root_uri':{server_info->lsp_settings#get('taplo-lsp', 'root_uri', lsp_settings#root_uri('taplo-lsp'))},
-      \ 'initialization_options': lsp_settings#get('taplo-lsp', 'initialization_options', g:vim_lsp_settings_taplo_lsp_options),
-      \ 'allowlist': lsp_settings#get('taplo-lsp', 'allowlist', ['toml']),
-      \ 'blocklist': lsp_settings#get('taplo-lsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('taplo-lsp', 'config', lsp_settings#server_config('taplo-lsp')),
-      \ 'workspace_config': lsp_settings#get('taplo-lsp', 'workspace_config', {'evenBetterToml': g:vim_lsp_settings_taplo_lsp_options}),
-      \ 'semantic_highlight': lsp_settings#get('taplo-lsp', 'semantic_highlight', {}),
-      \ }
+  if has('win32') || has('win64')
+    LspRegisterServer {
+        \ 'name': 'taplo-lsp',
+        \ 'cmd': {server_info->lsp_settings#get('taplo-lsp', 'cmd', [lsp_settings#exec_path('taplo-lsp')]+lsp_settings#get('taplo-lsp', 'args', ['run']))},
+        \ 'root_uri':{server_info->lsp_settings#get('taplo-lsp', 'root_uri', lsp_settings#root_uri('taplo-lsp'))},
+        \ 'initialization_options': lsp_settings#get('taplo-lsp', 'initialization_options', g:vim_lsp_settings_taplo_lsp_options),
+        \ 'allowlist': lsp_settings#get('taplo-lsp', 'allowlist', ['toml']),
+        \ 'blocklist': lsp_settings#get('taplo-lsp', 'blocklist', []),
+        \ 'config': lsp_settings#get('taplo-lsp', 'config', lsp_settings#server_config('taplo-lsp')),
+        \ 'workspace_config': lsp_settings#get('taplo-lsp', 'workspace_config', {'evenBetterToml': g:vim_lsp_settings_taplo_lsp_options}),
+        \ 'semantic_highlight': lsp_settings#get('taplo-lsp', 'semantic_highlight', {}),
+        \ }
+  else
+    LspRegisterServer {
+        \ 'name': 'taplo-lsp',
+        \ 'cmd': {server_info->lsp_settings#get('taplo-lsp', 'cmd', [lsp_settings#exec_path('taplo-lsp')]+lsp_settings#get('taplo-lsp', 'args', ['lsp', 'stdio']))},
+        \ 'root_uri':{server_info->lsp_settings#get('taplo-lsp', 'root_uri', lsp_settings#root_uri('taplo-lsp'))},
+        \ 'initialization_options': lsp_settings#get('taplo-lsp', 'initialization_options', g:vim_lsp_settings_taplo_lsp_options),
+        \ 'allowlist': lsp_settings#get('taplo-lsp', 'allowlist', ['toml']),
+        \ 'blocklist': lsp_settings#get('taplo-lsp', 'blocklist', []),
+        \ 'config': lsp_settings#get('taplo-lsp', 'config', lsp_settings#server_config('taplo-lsp')),
+        \ 'workspace_config': lsp_settings#get('taplo-lsp', 'workspace_config', {'evenBetterToml': g:vim_lsp_settings_taplo_lsp_options}),
+        \ 'semantic_highlight': lsp_settings#get('taplo-lsp', 'semantic_highlight', {}),
+        \ }
+  endif
   autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled() 
 augroup END
 

--- a/settings/taplo-lsp.vim
+++ b/settings/taplo-lsp.vim
@@ -41,7 +41,7 @@ augroup vim_lsp_settings_taplo_lsp
   au!
   LspRegisterServer {
       \ 'name': 'taplo-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('taplo-lsp', 'cmd', [lsp_settings#exec_path('taplo-lsp')]+lsp_settings#get('taplo-lsp', 'args', has('win32') || has('win64') ? ['run'] : ['lsp','stdio']))},
+      \ 'cmd': {server_info->lsp_settings#get('taplo-lsp', 'cmd', [lsp_settings#exec_path('taplo-lsp')]+lsp_settings#get('taplo-lsp', 'args', has('win32') ? ['run'] : ['lsp','stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('taplo-lsp', 'root_uri', lsp_settings#root_uri('taplo-lsp'))},
       \ 'initialization_options': lsp_settings#get('taplo-lsp', 'initialization_options', g:vim_lsp_settings_taplo_lsp_options),
       \ 'allowlist': lsp_settings#get('taplo-lsp', 'allowlist', ['toml']),


### PR DESCRIPTION
A new version of taplo-lsp has been released, but there is currently no binary for Windows, and the way to call it from the CLI has changed, so you need to change the function you call depending on whether you are on Windows or not.

For further information, plz look [here](https://taplo.tamasfe.dev/cli/installation/binary.html).
