### PR TITLE
Update clangd to 15

### DIFF
--- a/installer/install-clangd.cmd
+++ b/installer/install-clangd.cmd
@@ -1,7 +1,7 @@
 @echo off
 
 setlocal
-set VERSION=10.0.0
+set VERSION=15.0.0
 echo Downloading clang and LLVM...
 curl -L -o LLVM-%VERSION%-win64.exe "https://github.com/llvm/llvm-project/releases/download/llvmorg-%VERSION%/LLVM-%VERSION%-win64.exe"
 echo Running setup...

--- a/installer/install-clangd.sh
+++ b/installer/install-clangd.sh
@@ -98,7 +98,7 @@ filename() {
 
 
 # Search for an installable clang+llvm release.
-for llvm_version in 13 12 11 10 9; do
+for llvm_version in 15 14 13 12 11 10 9; do
   filename="$(filename "$distributor_id" "$llvm_version.0.0")"
   url="https://github.com/llvm/llvm-project/releases/download/llvmorg-$llvm_version.0.0/$filename.tar.xz"
   response_code=$(curl -sIL "${url}" -o /dev/null -w "%{response_code}")


### PR DESCRIPTION
I would like to use Clangd semantic highlighting on Windows.
The original code cannot be used on Windows because clangd 10.0.0 is installed.
This PR updates Windows installation scripts.
Scripts for linux and macOS have also been updated to use clangd 15.0.0 if the file is available.


https://github.com/llvm/llvm-project/releases/