### PR TITLE
Fixed failed installers for windows.

### DIFF
--- a/installer/install-eclipse-jdt-ls.cmd
+++ b/installer/install-eclipse-jdt-ls.cmd
@@ -1,7 +1,9 @@
 @echo off
 
-curl -L "http://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz" | tar zx
+curl -LO "https://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz"
 curl -o lombok.jar "https://projectlombok.org/downloads/lombok.jar"
+tar xvf jdt-language-server-latest.tar.gz
+rm jdt-language-server-latest.tar.gz
 
 echo @echo off ^
 

--- a/installer/install-ntt.cmd
+++ b/installer/install-ntt.cmd
@@ -1,4 +1,6 @@
 @echo off
 
 setlocal
-curl -L "https://github.com/nokia/ntt/releases/latest/download/ntt_windows_x86_64.tar.gz" | tar xz ntt.exe
+curl -LO "https://github.com/nokia/ntt/releases/latest/download/ntt_windows_x86_64.tar.gz"
+tar xvf ntt_windows_x86_64.tar.gz
+rm ntt_windows_x86_64.tar.gz

--- a/installer/install-terraform-lsp.cmd
+++ b/installer/install-terraform-lsp.cmd
@@ -2,4 +2,6 @@
 
 setlocal
 set VERSION=0.0.12
-curl -L "https://github.com/juliosueiras/terraform-lsp/releases/download/v%VERSION%/terraform-lsp_%VERSION%_windows_amd64.tar.gz" | tar xz
+curl -LO "https://github.com/juliosueiras/terraform-lsp/releases/download/v%VERSION%/terraform-lsp_%VERSION%_windows_amd64.tar.gz"
+tar xvf terraform-lsp_%VERSION%_windows_amd64.tar.gz
+rm terraform-lsp_%VERSION%_windows_amd64.tar.gz


### PR DESCRIPTION
These installer process is failed on windows.

- eclipse-jdt-ls
- terraform-lsp
- ntt

Failed log:

```sh
tar: Error opening archive: Failed to open '\\.\ tape0'
% Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   162  100   162    0     0    401      0 --:--:-- --:--:-- --:--:--   401
  0 39.5M    0 15921    0     0   5585      0  2:03:43  0:00:02  2:03:41 12686
curl: (23) Failure writing output to destination
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1925k  100 1925k    0     0  8472k      0 --:--:-- --:--:-- --:--:-- 8484k
```

`curl` and `tar` used then.

- `curl`: `C:\Windows\System32\curl.exe`.
- `tar`: `C:\Windows\System32\tar.exe`.

```sh
C:\Users\mikoto>where curl
C:\Windows\System32\curl.exe
C:\Program Files\Git\mingw64\bin\curl.exe

C:\Users\mikoto>where tar
C:\Windows\System32\tar.exe
C:\Program Files\Git\usr\bin\tar.exe
```

git's `curl` and `tar` is successed.

```sh
>"C:\Program Files\Git\mingw64\bin\curl.exe" -L "http://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz" | "C:\Program Files\Git\usr\bin\tar.exe" zx
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   162  100   162    0     0    423      0 --:--:-- --:--:-- --:--:--   424
100 39.5M  100 39.5M    0     0  1391k      0  0:00:29  0:00:29 --:--:-- 6149k
```

I changed the download and extraction process.
This way the Windows `curl` and `tar` commands will also succeed.