### PR TITLE
Update Volar to v1.0.0

### DIFF
--- a/installer/install-volar-server.cmd
+++ b/installer/install-volar-server.cmd
@@ -1,5 +1,5 @@
 @echo off
 
-call "%~dp0\npm_install.cmd" vue-language-server @volar/vue-language-server@0.40.13
+call "%~dp0\npm_install.cmd" vue-language-server @volar/vue-language-server@~1.0.0
 ren vue-language-server.cmd volar-server.cmd
 call npm install typescript@4.8

--- a/installer/install-volar-server.sh
+++ b/installer/install-volar-server.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-"$(dirname "$0")/npm_install.sh" vue-language-server @volar/vue-language-server@0.40.13
+"$(dirname "$0")/npm_install.sh" vue-language-server @volar/vue-language-server@~1.0.0
 mv vue-language-server volar-server
 npm install typescript@4.8

--- a/settings/volar-server.vim
+++ b/settings/volar-server.vim
@@ -1,5 +1,5 @@
 function! s:get_current_ts_path() abort
-  let ts_path = '/node_modules/typescript/lib/tsserverlibrary.js'
+  let ts_path = '/node_modules/typescript/lib'
 
   let project_dir = lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), 'package.json')
   let tsserverlibrary_path = project_dir . ts_path
@@ -9,8 +9,7 @@ function! s:get_current_ts_path() abort
 
   let path = filereadable(tsserverlibrary_path) ? tsserverlibrary_path : fallback_path
   return {
-  \   'serverPath': path,
-  \   'localizedPath': v:null,
+  \   'tsdk': path,
   \ }
 endfunction
 
@@ -20,145 +19,23 @@ function! Vim_lsp_settings_volar_setup_ts_path(options) abort
   return initialization_options
 endfunction
 
-" cf. https://github.com/johnsoncodehk/volar/blob/master/packages/shared/src/types.ts
+" cf. https://github.com/johnsoncodehk/volar/blob/master/packages/language-server/src/types.ts#L102
 let g:vim_lsp_settings_volar_options = {
 \   'textDocumentSync': 2,
 \   'typescript': {
-\     'serverPath': '',
-\     'localizedPath': v:null,
+\     'tsdk': '',
 \   },
-\   'languageFeatures': {
-\     'references': v:true,
-\     'implementation': v:true,
-\     'definition': v:true,
-\     'typeDefinition': v:true,
-\     'callHierarchy': v:true,
-\     'hover': v:true,
-\     'rename': v:true,
-\     'renameFileRefactoring': v:true,
-\     'signatureHelp': v:true,
-\     'completion': {
-\       'getDocumentSelectionRequest': v:true,
-\     },
-\     'documentHighlight': v:true,
-\     'documentLink': v:true,
-\     'workspaceSymbol': v:true,
-\     'codeLens': { 'showReferencesNotification': v:true },
-\     'semanticTokens': v:true,
-\     'codeAction': v:true,
-\     'inlayHints': v:true,
-\     'diagnostics': v:true,
-\     'schemaRequestService': { 'getDocumentContentRequest': v:true },
-\   },
-\   'documentFeatures': {
-\     'selectionRange': v:true,
-\     'foldingRange': v:true,
-\     'linkedEditingRange': v:true,
-\     'documentSymbol': v:true,
-\     'documentColor': v:true,
-\     'documentFormatting': v:true,
-\   }
-\ }
-
-let g:vim_lsp_settings_volar_main_options = {
-\   'textDocumentSync': 2,
-\   'typescript': {
-\     'serverPath': '',
-\     'localizedPath': v:null,
-\   },
-\   'languageFeatures': {
-\     'references': v:true,
-\     'implementation': v:true,
-\     'definition': v:true,
-\     'typeDefinition': v:true,
-\     'callHierarchy': v:true,
-\     'hover': v:true,
-\     'rename': v:true,
-\     'renameFileRefactoring': v:true,
-\     'signatureHelp': v:true,
-\     'codeAction': v:true,
-\     'workspaceSymbol': v:true,
-\     'completion': {
-\       'getDocumentSelectionRequest': v:true,
-\     },
-\     'schemaRequestService': { 'getDocumentContentRequest': v:true },
-\   }
-\}
-
-let g:vim_lsp_settings_volar_second_options = {
-\   'textDocumentSync': 2,
-\   'typescript': {
-\     'serverPath': '',
-\     'localizedPath': v:null,
-\   },
-\   'languageFeatures': {
-\     'documentHighlight': v:true,
-\     'documentLink': v:true,
-\     'codeLens': { 'showReferencesNotification': v:true },
-\     'semanticTokens': v:true,
-\     'inlayHints': v:true,
-\     'diagnostics': v:true,
-\     'schemaRequestService': { 'getDocumentContentRequest': v:true },
-\   }
-\}
-
-let g:vim_lsp_settings_volar_document_options = {
-\   'textDocumentSync': 2,
-\   'typescript': {
-\     'serverPath': '',
-\     'localizedPath': v:null,
-\   },
-\   'documentFeatures': {
-\     'selectionRange': v:true,
-\     'foldingRange': v:true,
-\     'linkedEditingRange': v:true,
-\     'documentSymbol': v:true,
-\     'documentColor': v:true,
-\     'documentFormatting': v:true
-\   }
 \ }
 
 augroup vim_lsp_settings_volar_server
   au!
-  if get(g:, 'vim_lsp_settings_volar_experimental_multiple_servers')
-    LspRegisterServer {
-    \ 'name': 'volar-server-main',
-    \ 'cmd': {server_info->lsp_settings#get('volar-server', 'cmd', [lsp_settings#exec_path('volar-server')]+lsp_settings#get('volar-server', 'args', ['--stdio']))},
-    \ 'root_uri':{server_info->lsp_settings#get('volar-server', 'root_uri', lsp_settings#root_uri('volar-server'))},
-    \ 'initialization_options': lsp_settings#get('volar-server', 'initialization_options', Vim_lsp_settings_volar_setup_ts_path(g:vim_lsp_settings_volar_main_options)),
-    \ 'allowlist': lsp_settings#get('volar-server', 'allowlist', ['vue']),
-    \ 'blocklist': lsp_settings#get('volar-server', 'blocklist', []),
-    \ 'config': lsp_settings#get('volar-server', 'config', lsp_settings#server_config('volar-server')),
-    \ }
-
-    LspRegisterServer {
-    \ 'name': 'volar-server-second',
-    \ 'cmd': {server_info->lsp_settings#get('volar-server', 'cmd', [lsp_settings#exec_path('volar-server')]+lsp_settings#get('volar-server', 'args', ['--stdio']))},
-    \ 'root_uri':{server_info->lsp_settings#get('volar-server', 'root_uri', lsp_settings#root_uri('volar-server'))},
-    \ 'initialization_options': lsp_settings#get('volar-server', 'initialization_options', Vim_lsp_settings_volar_setup_ts_path(g:vim_lsp_settings_volar_second_options)),
-    \ 'allowlist': lsp_settings#get('volar-server', 'allowlist', ['vue']),
-    \ 'blocklist': lsp_settings#get('volar-server', 'blocklist', []),
-    \ 'config': lsp_settings#get('volar-server', 'config', lsp_settings#server_config('volar-server')),
-    \ }
-
-    LspRegisterServer {
-    \ 'name': 'volar-server-document',
-    \ 'cmd': {server_info->lsp_settings#get('volar-server', 'cmd', [lsp_settings#exec_path('volar-server')]+lsp_settings#get('volar-server', 'args', ['--stdio']))},
-    \ 'root_uri':{server_info->lsp_settings#get('volar-server', 'root_uri', lsp_settings#root_uri('volar-server'))},
-    \ 'initialization_options': lsp_settings#get('volar-server', 'initialization_options', Vim_lsp_settings_volar_setup_ts_path(g:vim_lsp_settings_volar_document_options)),
-    \ 'allowlist': lsp_settings#get('volar-server', 'allowlist', ['vue']),
-    \ 'blocklist': lsp_settings#get('volar-server', 'blocklist', []),
-    \ 'config': lsp_settings#get('volar-server', 'config', lsp_settings#server_config('volar-server')),
-    \ }
-  else
-    LspRegisterServer {
-    \ 'name': 'volar-server',
-    \ 'cmd': {server_info->lsp_settings#get('volar-server', 'cmd', [lsp_settings#exec_path('volar-server')]+lsp_settings#get('volar-server', 'args', ['--stdio']))},
-    \ 'root_uri':{server_info->lsp_settings#get('volar-server', 'root_uri', lsp_settings#root_uri('volar-server'))},
-    \ 'initialization_options': lsp_settings#get('volar-server', 'initialization_options', Vim_lsp_settings_volar_setup_ts_path(g:vim_lsp_settings_volar_options)),
-    \ 'allowlist': lsp_settings#get('volar-server', 'allowlist', ['vue']),
-    \ 'blocklist': lsp_settings#get('volar-server', 'blocklist', []),
-    \ 'config': lsp_settings#get('volar-server', 'config', lsp_settings#server_config('volar-server')),
-    \ }
-  endif
+  LspRegisterServer {
+  \ 'name': 'volar-server',
+  \ 'cmd': {server_info->lsp_settings#get('volar-server', 'cmd', [lsp_settings#exec_path('volar-server')]+lsp_settings#get('volar-server', 'args', ['--stdio']))},
+  \ 'root_uri':{server_info->lsp_settings#get('volar-server', 'root_uri', lsp_settings#root_uri('volar-server'))},
+  \ 'initialization_options': lsp_settings#get('volar-server', 'initialization_options', Vim_lsp_settings_volar_setup_ts_path(g:vim_lsp_settings_volar_options)),
+  \ 'allowlist': lsp_settings#get('volar-server', 'allowlist', ['vue']),
+  \ 'blocklist': lsp_settings#get('volar-server', 'blocklist', []),
+  \ 'config': lsp_settings#get('volar-server', 'config', lsp_settings#server_config('volar-server')),
+  \ }
 augroup END

--- a/settings/volar-server.vim
+++ b/settings/volar-server.vim
@@ -39,3 +39,22 @@ augroup vim_lsp_settings_volar_server
   \ 'config': lsp_settings#get('volar-server', 'config', lsp_settings#server_config('volar-server')),
   \ }
 augroup END
+
+function! s:on_lsp_buffer_enabled() abort
+  " Force some capabilities to be enabled.
+  " These capabilities are expected to be registered by dynamic registration
+  " by vim-lsp, but are registered statically by volar.
+  " cf. https://github.com/prabirshrestha/vim-lsp/pull/1379
+  let l:capabilities = lsp#get_server_capabilities('volar-server')
+  if !empty(l:capabilities)
+    let l:capabilities.callHierarcyProvider = v:true
+    let l:capabilities.renameProvider = {'prepareProvider': v:true}
+    let l:capabilities.signatureHelpProvider = v:true
+    let l:capabilities.workspaceSymbolProvider = v:true
+  endif
+endfunction
+
+augroup lsp_install_volar_server
+  au!
+  autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled()
+augroup END


### PR DESCRIPTION
Update Volar to v1.0.0 (actually v1.0.X). Since Volar is now stable, its version is specified by `~1.0.0`.

Also, `initializationOptions` becomes very simple because Volar now recognizes client capabilities.
But, now some hacks are needed because of https://github.com/prabirshrestha/vim-lsp/pull/1379 .

In addition, I deleted experimental multiple servers feature because Volar's architecture is changed.
I will try it again later...