### PR TITLE
Omnisharp-LSP: Fix macOS .NET6 install

### DIFF
--- a/installer/install-omnisharp-lsp.sh
+++ b/installer/install-omnisharp-lsp.sh
@@ -31,6 +31,10 @@ esac
 if [ "$mainVersion" -ge "6" ]; then
   net6="-net6.0"
 
+  if [ "$os" = "osx" ]; then
+    arch="-$(uname -m)"
+  fi
+
 cat <<EOF >run
 #!/bin/sh
 


### PR DESCRIPTION
Currently, installing omnisharp-lsp on a macOS machine with .NET 6.0 fails due to a change in the naming scheme for the project's downloads. Starting with their .NET 6.0 builds, the osx builds are now provided for both arm64 and x64, which requires an additional specifier in the download filename. This change adds that specifier when installing the .NET 6.0 version of the LSP on a macOS machine.