### PR TITLE
Fix wrong omnisharp server download url for osx

### DIFF
--- a/installer/install-omnisharp-lsp.sh
+++ b/installer/install-omnisharp-lsp.sh
@@ -32,7 +32,11 @@ if [ "$mainVersion" -ge "6" ]; then
   net6="-net6.0"
 
   if [ "$os" = "osx" ]; then
-    arch="-$(uname -m)"
+    if [ "$(uname -m)" = "x86_64" ]; then
+      arch="-x64"
+    else
+      arch="-$(uname -m)"
+    fi
   fi
 
 cat <<EOF >run


### PR DESCRIPTION
In Intel macOS (Version 12.6), the `uname -m` returns `x86_64`, which doesn't match the name in the release URLs (suffixed `-x64`) in [omnisharp-roslyn](https://github.com/OmniSharp/omnisharp-roslyn/releases). This PR is to fix the wrong URL. 