### PR TITLE
Fix analysis-server-dart-snapshot installer

### DIFF
--- a/installer/install-analysis-server-dart-snapshot.sh
+++ b/installer/install-analysis-server-dart-snapshot.sh
@@ -13,9 +13,21 @@ darwin)
   ;;
 esac
 
-filename="dartsdk-$platform-x64-release.zip"
+case $(uname -m) in
+  arm64)
+    arch=arm64
+    ;;
+  aarch64)
+    arch=arm64
+    ;;
+  *)
+    arch=x64
+    ;;
+esac
 
-curl -o "$filename" "https://storage.googleapis.com/dart-archive/channels/dev/release/latest/sdk/dartsdk-$platform-x64-release.zip"
+filename="dartsdk-$platform-$arch-release.zip"
+
+curl -o "$filename" "https://storage.googleapis.com/dart-archive/channels/dev/release/latest/sdk/dartsdk-$platform-$arch-release.zip"
 unzip "$filename"
 rm "$filename"
 


### PR DESCRIPTION
## Changed
- Supported Apple Silicon(arm64)

## Note
Dart's LSP-Server Path: `OS(macos|linux|windows)-ARCH(x64|arm64)-release.zip`
https://dart.dev/get-dart/archive
```
e.g.
https://storage.googleapis.com/dart-archive/channels/stable/release/2.18.4/sdk/dartsdk-linux-x64-release.zip
https://storage.googleapis.com/dart-archive/channels/stable/release/2.18.4/sdk/dartsdk-linux-arm64-release.zip
https://storage.googleapis.com/dart-archive/channels/stable/release/2.18.4/sdk/dartsdk-macos-x64-release.zip
https://storage.googleapis.com/dart-archive/channels/stable/release/2.18.4/sdk/dartsdk-macos-arm64-release.zip
```