### PR TITLE
Fixed installer to work with latest taplo release (0.8.0)

### DIFF
--- a/installer/install-taplo-lsp.sh
+++ b/installer/install-taplo-lsp.sh
@@ -9,14 +9,13 @@ latest="0.2.6"
 
 case $os in
 linux)
-  platform="x86_64-unknown-linux-gnu"
+    platform="linux-"$(uname -m)
   ;;
 darwin)
-  platform="x86_64-apple-darwin-gnu"
+    platform="darwin-"$(uname -m)
   ;;
 esac
 
-curl -L "https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-$platform.tar.gz" | tar xz
+curl -L "https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-$platform.gz" | gzip -d > taplo-lsp
 
-mv taplo taplo-lsp
 chmod +x taplo-lsp

--- a/installer/install-taplo-lsp.sh
+++ b/installer/install-taplo-lsp.sh
@@ -9,10 +9,10 @@ latest="0.2.6"
 
 case $os in
 linux)
-    platform="linux-"$(uname -m)
+  platform="linux-"$(uname -m)
   ;;
 darwin)
-    platform="darwin-"$(uname -m)
+  platform="darwin-"$(uname -m)
   ;;
 esac
 


### PR DESCRIPTION
This fixes the problem with the new format of the release files as discussed in #642
I didn't change the `install-taplo-lsp.cmd` installer because I have no way to test it