### PR TITLE
improve installers to pass shellcheck checks

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,2 +1,0 @@
-disable=SC2002
-disable=SC2046

--- a/installer/install-clangd.sh
+++ b/installer/install-clangd.sh
@@ -18,7 +18,7 @@ if command -v lsb_release 2>/dev/null; then
 elif [ -e /etc/fedora-release ]; then
   distributor_id="Fedora"
 elif [ -e /etc/redhat-release ]; then
-  distributor_id=$(cat /etc/redhat-release | cut -d ' ' -f 1)
+  distributor_id=$(cut -d ' ' -f 1 /etc/redhat-release)
 elif [ -e /etc/arch-release ]; then
   distributor_id="Arch"
 elif [ -e /etc/SuSE-release ]; then
@@ -57,7 +57,8 @@ filename() {
       platform="linux-gnu-ubuntu-$ubuntu_version"
       ;;
     22.04)
-      local platform="linux-gnu-ubuntu-20.04"
+      platform="linux-gnu-ubuntu-20.04"
+      ;;
     esac
     ;;
   # Check LinuxMint version
@@ -95,7 +96,6 @@ filename() {
 
   echo "clang+llvm-$version-$arch-$platform"
 }
-
 
 # Search for an installable clang+llvm release.
 for llvm_version in 15 14 13 12 11 10 9; do

--- a/installer/install-deno.sh
+++ b/installer/install-deno.sh
@@ -9,7 +9,7 @@ linux)
   filename="deno-x86_64-unknown-linux-gnu.zip"
   ;;
 darwin)
-  if [ $(uname -m) = "x86_64" ]; then
+  if [ "$(uname -m)" = "x86_64" ]; then
     filename="deno-x86_64-apple-darwin.zip"
   else
     filename="deno-aarch64-apple-darwin.zip"

--- a/installer/install-eclipse-jdt-ls.sh
+++ b/installer/install-eclipse-jdt-ls.sh
@@ -10,12 +10,12 @@ rm jdt-language-server-latest.tar.gz
 osType="$(uname -s)"
 echo "$osType"
 case "$osType" in
-    Darwin*)    configDir=config_mac;;
-    Linux*)     configDir=config_linux;;
-    *)          configDir=config_linux
+Darwin*) configDir=config_mac ;;
+Linux*) configDir=config_linux ;;
+*) configDir=config_linux ;;
 esac
 
-cat <<EOF > eclipse-jdt-ls
+cat <<EOF >eclipse-jdt-ls
 #!/bin/sh
 DIR=\$(cd \$(dirname \$0); pwd)
 LAUNCHER=\$(ls \$DIR/plugins/org.eclipse.equinox.launcher_*.jar)

--- a/installer/install-fsharp-language-server.sh
+++ b/installer/install-fsharp-language-server.sh
@@ -6,7 +6,7 @@ git clone --depth=1 https://github.com/fsprojects/fsharp-language-server .
 npm install
 dotnet tool install --global paket
 dotnet tool restore
-dotnet publish src/FSharpLanguageServer --configuration Release --output Publish 
+dotnet publish src/FSharpLanguageServer --configuration Release --output Publish
 
 cat <<EOF >fsharp-language-server
 #!/bin/sh

--- a/installer/install-metals.sh
+++ b/installer/install-metals.sh
@@ -10,7 +10,7 @@ version=$(curl -LsS "https://scalameta.org/metals/latests.json" | grep -o '"rele
 java_flags=
 
 if [ -n "${https_proxy}" ]; then
-  readonly https_proxy_without_protocol="${https_proxy#http://}"
+  https_proxy_without_protocol="${https_proxy#http://}"
   java_flags="$java_flags -J-Dhttps.proxyHost=${https_proxy_without_protocol%:*}"
   java_flags="$java_flags -J-Dhttps.proxyPort=${https_proxy_without_protocol##*:}"
 fi
@@ -25,12 +25,12 @@ if [ -n "${no_proxy}" ]; then
   java_flags="$java_flags -J-Dhttp.nonProxyHosts=${no_proxy}"
 fi
 
-
+# shellcheck disable=SC2086
 ./coursier bootstrap \
   --java-opt -Xss4m \
   --java-opt -Xms100m \
   ${java_flags} \
-  org.scalameta:metals_2.13:${version} \
+  org.scalameta:metals_2.13:"${version}" \
   -r bintray:scalacenter/releases \
   -r sonatype:releases \
   -o metals -f

--- a/installer/install-nimlsp.sh
+++ b/installer/install-nimlsp.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-nimble -y --nimbledir=$(pwd) install nimlsp
-ln -s $(pwd)/bin/nimlsp .
+nimble -y --nimbledir="$(pwd)" install nimlsp
+ln -s "$(pwd)/bin/nimlsp" .

--- a/installer/install-omnisharp-lsp.sh
+++ b/installer/install-omnisharp-lsp.sh
@@ -20,12 +20,12 @@ darwin)
 esac
 
 case $version in
-  (*"."*)
-    mainVersion=${version%%"."*}
-    ;;
-  (*)
-    mainVersion=$version
-    ;;
+*.*)
+  mainVersion=${version%%.*}
+  ;;
+*)
+  mainVersion=$version
+  ;;
 esac
 
 if [ "$mainVersion" -ge "6" ]; then
@@ -39,7 +39,7 @@ if [ "$mainVersion" -ge "6" ]; then
     fi
   fi
 
-cat <<EOF >run
+  cat <<EOF >run
 #!/bin/sh
 
 base_dir="\$(cd "\$(dirname "\$0")" && pwd -P)"

--- a/installer/install-perlnavigator.sh
+++ b/installer/install-perlnavigator.sh
@@ -15,8 +15,7 @@ darwin)
   ;;
 esac
 
-curl -L -o perlnavigator-$os-x86_64.zip "https://github.com/bscan/PerlNavigator/releases/latest/download/perlnavigator-$os-x86_64.zip"
-unzip perlnavigator-$os-x86_64.zip
-mv perlnavigator-$os-x86_64/perlnavigator .
-rm -rf perlnavigator-$os-x86_64 perlnavigator-$os-x86_64.zip
-
+curl -L -o "perlnavigator-$os-x86_64.zip" "https://github.com/bscan/PerlNavigator/releases/latest/download/perlnavigator-$os-x86_64.zip"
+unzip "perlnavigator-$os-x86_64.zip"
+mv "perlnavigator-$os-x86_64/perlnavigator" .
+rm -rf "perlnavigator-$os-x86_64" "perlnavigator-$os-x86_64.zip"

--- a/installer/install-rust-analyzer.sh
+++ b/installer/install-rust-analyzer.sh
@@ -28,7 +28,7 @@ darwin)
   ;;
 mingw64_nt*)
   if [ "$arch" = "x86_64" ]; then
-  	platform="x86_64-pc-windows-msvc"
+    platform="x86_64-pc-windows-msvc"
   elif [ "$arch" = "aarch64" ] || [ "$arch" = "arm64" ]; then
     platform="aarch64-pc-windows-msvc"
   else

--- a/installer/install-taplo-lsp.sh
+++ b/installer/install-taplo-lsp.sh
@@ -4,9 +4,6 @@ set -e
 
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
 
-# Releases of taplo-lsp have the tag such as 'release-lsp-${version}'
-latest="0.2.6"
-
 case $os in
 linux)
   platform="linux-"$(uname -m)
@@ -16,6 +13,6 @@ darwin)
   ;;
 esac
 
-curl -L "https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-$platform.gz" | gzip -d > taplo-lsp
+curl -L "https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-$platform.gz" | gzip -d >taplo-lsp
 
 chmod +x taplo-lsp

--- a/installer/install-terraform-ls.sh
+++ b/installer/install-terraform-ls.sh
@@ -25,7 +25,7 @@ aarch64*) arch=arm64 ;;
   ;;
 esac
 
-version=$(basename $(curl -Ls -o /dev/null -w %\{url_effective\} https://github.com/hashicorp/terraform-ls/releases/latest))
+version=$(basename "$(curl -Ls -o /dev/null -w %\{url_effective\} https://github.com/hashicorp/terraform-ls/releases/latest)")
 short_version=$(echo "$version" | cut -c2-)
 filename="terraform-ls_${short_version}"
 url="https://github.com/hashicorp/terraform-ls/releases/download/${version}/${filename}_${os}_${arch}.zip"

--- a/installer/install-texlab.sh
+++ b/installer/install-texlab.sh
@@ -19,7 +19,7 @@ esac
 case $arch in
 x86_64) ;;
 arm64)
-  if [ "$os" == "linux" ]; then
+  if [ "$os" = "linux" ]; then
     printf "%s doesn't supported by bash installer" "$os"
     exit 1
   fi
@@ -30,7 +30,6 @@ arm64)
   exit 1
   ;;
 esac
-
 
 url="https://github.com/latex-lsp/texlab/releases/latest/download/texlab-$arch-$os.tar.gz"
 curl -L "$url" | tar xzv

--- a/installer/install-zls.sh
+++ b/installer/install-zls.sh
@@ -7,5 +7,5 @@ zig build
 mv zig-out/bin/zls .
 rm -rf zig-cache zig-out src tests
 cat <<EOF >zls.json
-{"zig_lib_path":"$(dirname $(which zig))/lib/zig","enable_snippets":true,"warn_style":true,"enable_semantic_tokens":true}
+{"zig_lib_path":"$(dirname "$(which zig)")/lib/zig","enable_snippets":true,"warn_style":true,"enable_semantic_tokens":true}
 EOF


### PR DESCRIPTION
The linter `shellcheck` checks are ignored in some merged PRs but I think we can fix most of the warnings. I removed the `.shellcheckrc` file to run `shellcheck` more strictly and fixed all of the warnings. I also run `make shfmt` to reformat all the installers. 