### PR TITLE
New url for terraform-ls downloads

### DIFF
--- a/installer/install-terraform-ls.cmd
+++ b/installer/install-terraform-ls.cmd
@@ -2,6 +2,6 @@
 
 setlocal
 for /f "usebackq" %%V in (`curl -Ls -o nul -w %%{url_effective} https://github.com/hashicorp/terraform-ls/releases/latest`) do set VERSION=%%~nxV
-curl -L -o terraform-ls_%VERSION%.windows.x86_64.zip "https://github.com/hashicorp/terraform-ls/releases/download/%VERSION%/terraform-ls_%VERSION:~1%_windows_amd64.zip"
+curl -L -o terraform-ls_%VERSION%.windows.x86_64.zip "https://releases.hashicorp.com/terraform-ls/%VERSION:~1%/terraform-ls_%VERSION:~1%_windows_amd64.zip"
 call "%~dp0\run_unzip.cmd" terraform-ls_%VERSION%.windows.x86_64.zip
 del terraform-ls_%VERSION%.windows.x86_64.zip

--- a/installer/install-terraform-ls.sh
+++ b/installer/install-terraform-ls.sh
@@ -28,7 +28,7 @@ esac
 version=$(basename "$(curl -Ls -o /dev/null -w %\{url_effective\} https://github.com/hashicorp/terraform-ls/releases/latest)")
 short_version=$(echo "$version" | cut -c2-)
 filename="terraform-ls_${short_version}"
-url="https://github.com/hashicorp/terraform-ls/releases/download/${version}/${filename}_${os}_${arch}.zip"
+url="https://releases.hashicorp.com/terraform-ls/${short_version}/${filename}_${os}_${arch}.zip"
 filename="${filename}.zip"
 
 curl -L --progress-bar "$url" -o "$filename"


### PR DESCRIPTION
terraform-ls doesn't publish binaries under github releases anymore. Update url to reference releases.hashicorp.com.

I don't have environment to test Windows changes, hopefully someone will be able to confirm it's working.