### PR TITLE
Add deno package.json support

### DIFF
--- a/settings/deno.vim
+++ b/settings/deno.vim
@@ -1,4 +1,5 @@
 function! Vim_lsp_settings_deno_get_blocklist() abort
+    " Deno project
     if !empty(lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'deno.json'))
         return []
     endif
@@ -6,6 +7,12 @@ function! Vim_lsp_settings_deno_get_blocklist() abort
         return []
     endif
 
+    " Deno with package.json, create directory 'node_modules/.deno/' and some module under it.
+    if !empty(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), 'node_modules/.deno/'))
+        return []
+    endif
+
+    " Is not non-Deno(=npm) project
     if empty(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), 'node_modules/'))
         return []
     endif


### PR DESCRIPTION
see https://deno.com/blog/v1.31#packagejson-support
Add deno with package.json support

After deno run(with package.json), generate `node_modules/.deno/` directory and some modules under it.

Add this check.

----

Tried deno with package.json, started server.

Other settings do not test, please review it.