### PR TITLE
Escape the buffer path for whitespace in path

### DIFF
--- a/settings/typescript-language-server.vim
+++ b/settings/typescript-language-server.vim
@@ -16,7 +16,7 @@ augroup vim_lsp_settings_typescript_language_server
       \   },
       \ }),
       \ 'allowlist': lsp_settings#get('typescript-language-server', 'allowlist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact', 'typescript.tsx']),
-      \ 'blocklist': lsp_settings#get('typescript-language-server', 'blocklist', {c->empty(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), 'node_modules/')) ? ['typescript', 'javascript', 'typescriptreact', 'javascriptreact'] : []}),
+      \ 'blocklist': lsp_settings#get('typescript-language-server', 'blocklist', {c->empty(lsp#utils#find_nearest_parent_file_directory(fnameescape(lsp#utils#get_buffer_path()), 'node_modules/')) ? ['typescript', 'javascript', 'typescriptreact', 'javascriptreact'] : []}),
       \ 'config': lsp_settings#get('typescript-language-server', 'config', lsp_settings#server_config('typescript-language-server')),
       \ 'workspace_config': lsp_settings#get('typescript-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('typescript-language-server', 'semantic_highlight', {}),


### PR DESCRIPTION
When my project path includes whitespace (/home/kb/Hello World/), the blocklist works unexpectedly. 