### PR TITLE
fix installation of marksman on linux

### DIFF
--- a/installer/install-marksman.sh
+++ b/installer/install-marksman.sh
@@ -3,10 +3,15 @@
 set -e
 
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
-
+if [ $(uname -p) = "x86_64" ];
+then
+  arch="x64"
+else
+  arch="arm64"
+fi
 case $os in
 linux)
-  platform="linux"
+  platform="linux-"$arch
   ;;
 darwin)
   platform="macos"


### PR DESCRIPTION
The download URL for marksman has changed as of https://github.com/artempyanykh/marksman/releases/tag/2023-06-01 and now for Linux the arch needs to be specified as well. Updated the marksman install script to switch between x86_64 and arm64. 
*NOTE*: I only had a x86 box readily available on which I tested the change. Didn't test for ARM, but since changes are minimal it should work. 