### PR TITLE
Change godot port to 6005

### DIFF
--- a/settings/godot.vim
+++ b/settings/godot.vim
@@ -2,7 +2,7 @@ augroup vim_lsp_settings_godot
   au!
   LspRegisterServer {
       \ 'name': 'godot',
-      \ 'tcp': {server_info->lsp_settings#get('godot', 'tcp', '127.0.0.1:6008')},
+      \ 'tcp': {server_info->lsp_settings#get('godot', 'tcp', '127.0.0.1:6005')},
       \ 'root_uri':{server_info->lsp_settings#get('godot', 'root_uri', lsp_settings#root_uri('godot'))},
       \ 'initialization_options': lsp_settings#get('godot', 'initialization_options', v:null),
       \ 'allowlist': lsp_settings#get('godot', 'allowlist', ['gdscript3', 'gdscript']),


### PR DESCRIPTION
Godot changed the LSP port for Godot 4:
https://github.com/godotengine/godot/blob/master/modules/gdscript/language_server/gdscript_language_server.h#L47-L48

The change was in this commit:

https://github.com/godotengine/godot/commit/de7873c2d87c3ee8af8c27e35f49767fcc384e75

Godot 3 users can change to use this port in editor -> editor settings -> network -> language server -> remote port. Or they can use `let g:lsp_settings.godot = { 'tcp': '127.0.0.1:6008'}` to use the old port instead.