### PR TITLE
Add nixd alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ You can change the directory to install servers by set `g:lsp_settings_servers_d
 | Markdown (remark) | remark-language-server              |    Yes    |      Yes      |
 | Markdown          | Marksman                            |    Yes    |      Yes      |
 | Nim               | nimls                               |    No     |      No       |
+| Nix               | nixd                                |    Yes    |      Yes      |
 | Nix               | rnix-lsp                            |    Yes    |      Yes      |
 | PHP               | intelephense                        |    Yes    |      Yes      |
 | PHP               | psalm-language-server               |    Yes    |      Yes      |

--- a/installer/install-nixd-lsp.cmd
+++ b/installer/install-nixd-lsp.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+call nix-env -i -f "https://github.com/nix-community/nixd/archive/master.tar.gz"

--- a/installer/install-nixd-lsp.sh
+++ b/installer/install-nixd-lsp.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+nix-env -i -f "https://github.com/nix-community/nixd/archive/master.tar.gz"

--- a/settings.json
+++ b/settings.json
@@ -890,6 +890,14 @@
       "requires": [
         "nix"
       ]
+    },
+    {
+      "command": "nixd",
+      "url": "https://github.com/nix-community/nixd",
+      "description": "Nix language server, based on nix libraries",
+      "requires": [
+        "nix"
+      ]
     }
   ],
   "objc": [

--- a/settings/nixd.vim
+++ b/settings/nixd.vim
@@ -1,0 +1,14 @@
+augroup vim_lsp_settings_nixd
+  au!
+  LspRegisterServer {
+      \ 'name': 'nixd',
+      \ 'cmd': {server_info->lsp_settings#get('nixd', 'cmd', lsp_settings#exec_path('nixd'))},
+      \ 'root_uri':{server_info->lsp_settings#get('nid', 'root_uri', lsp_settings#root_uri('nixd'))},
+      \ 'initialization_options': lsp_settings#get('nixd', 'initialization_options', {}),
+      \ 'allowlist': lsp_settings#get('nixd', 'allowlist', ['nix']),
+      \ 'blocklist': lsp_settings#get('nixd', 'blocklist', []),
+      \ 'config': lsp_settings#get('nixd', 'config', lsp_settings#server_config('nixd')),
+      \ 'workspace_config': lsp_settings#get('nixd', 'workspace_config', {}),
+      \ 'semantic_highlight': lsp_settings#get('nixd', 'semantic_highlight', {}),
+      \ }
+augroup END


### PR DESCRIPTION
[nixd](https://github.com/nix-community/nixd) is a brand new LSP alternative for nix supporting official nix libs.