### PR TITLE
Use `uname -m` as `-p` doesn't always work

### DIFF
--- a/installer/install-marksman.sh
+++ b/installer/install-marksman.sh
@@ -3,7 +3,7 @@
 set -e
 
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
-if [ $(uname -p) = "x86_64" ];
+if [ $(uname -m) = "x86_64" ];
 then
   arch="x64"
 else


### PR DESCRIPTION
See https://unix.stackexchange.com/questions/307955/uname-p-i-are-unknown `uname -m` returns machine type, which is enough for this script, `uname -p` doesn't work on most Linux distros.

In my system (Arch), executing `uname -p` returns `unknown` therefore the script downloads ARM64 version of `marksman`.