### PR TITLE
Fix elixir-ls installer

### DIFF
--- a/installer/install-elixir-ls.cmd
+++ b/installer/install-elixir-ls.cmd
@@ -1,10 +1,11 @@
 @echo off
 
 setlocal
-set VERSION=0.15.1
-curl -L -o elixir-ls.zip "https://github.com/elixir-lsp/elixir-ls/releases/download/v%VERSION%/elixir-ls.zip"
-call "%~dp0\run_unzip.cmd" elixir-ls.zip
-del elixir-ls.zip
+set VERSION=v0.15.1
+set ZIP=elixir-ls-%VERSION%.zip
+curl -L -o "%ZIP%" "https://github.com/elixir-lsp/elixir-ls/releases/download/%VERSION%/%ZIP%"
+call "%~dp0\run_unzip.cmd" "%ZIP%"
+del "%ZIP%"
 
 echo @echo off ^
 

--- a/installer/install-elixir-ls.sh
+++ b/installer/install-elixir-ls.sh
@@ -3,10 +3,11 @@
 set -e
 
 version="v0.15.1"
-url="https://github.com/elixir-lsp/elixir-ls/releases/download/$version/elixir-ls.zip"
-curl -LO "$url"
-unzip elixir-ls.zip
-rm elixir-ls.zip
+zip="elixir-ls-$version.zip"
+url="https://github.com/elixir-lsp/elixir-ls/releases/download/$version/$zip"
+curl -L -o "$zip" "$url"
+unzip "$zip"
+rm "$zip"
 
 cat <<EOF >elixir-ls
 #!/bin/sh


### PR DESCRIPTION
From v0.15.0 [elixir-ls](https://github.com/elixir-lsp/elixir-ls) doesn't provide `elixir-ls.zip`.
Now provided by `elixir-ls-[VERSION].zip`.