### PR TITLE
gopls: change capabilities to use documentSymbol

### DIFF
--- a/settings/gopls.vim
+++ b/settings/gopls.vim
@@ -22,6 +22,13 @@ augroup vim_lsp_settings_gopls
       \         'run_vulncheck_exp': v:true,
       \     },
       \ }),
+      \ 'capabilities': lsp_settings#get('gopls', 'capabilities', {
+      \     'textDocument': {
+      \         'documentSymbol': {
+      \             'hierarchicalDocumentSymbolSupport': v:true,
+      \         },
+      \     },
+      \ }),
       \ 'allowlist': lsp_settings#get('gopls', 'allowlist', ['go', 'gomod', 'gohtmltmpl', 'gotexttmpl']),
       \ 'blocklist': lsp_settings#get('gopls', 'blocklist', []),
       \ 'config': lsp_settings#get('gopls', 'config', lsp_settings#server_config('gopls')),


### PR DESCRIPTION
instead of deprecated symbolInformation.

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#symbolInformation

```
/**
 * Represents information about programming constructs like variables, classes,
 * interfaces etc.
 *
 * @deprecated use DocumentSymbol or WorkspaceSymbol instead.
 */
```