### PR TITLE
Fix build error for ocaml-lsp on macOS Sonoma

### DIFF
--- a/installer/install-ocaml-lsp.sh
+++ b/installer/install-ocaml-lsp.sh
@@ -4,23 +4,18 @@ set -e
 
 DEFAULT_DIR="$(pwd)"
 
-# We should not download GitHub's zip file here, because it doesn't include some submodules.
-git clone --recurse-submodules http://github.com/ocaml/ocaml-lsp.git ocaml-lsp-files --depth=1
+mkdir -p ocaml-lsp-files
 cd ocaml-lsp-files
 
-rm -r lsp/test
 OPAMROOT="$(pwd)/.opam"
 export OPAMROOT
 
 export OPAMYES=true
 opam init -a -n
-opam switch create . ocaml-base-compiler.4.14.0
+opam switch create . ocaml-base-compiler.4.14.1
 eval "$(opam env)" 2>/dev/null
-opam exec make install-test-deps
-opam exec make all
-
-rm -rf .git
+opam install ocaml-lsp-server
 
 cd "$DEFAULT_DIR"
-ln -snf "./ocaml-lsp-files/_build/default/ocaml-lsp-server/bin/main.exe" ocaml-lsp
+ln -snf "./ocaml-lsp-files/_opam/bin/ocamllsp" ocaml-lsp
 chmod +x ocaml-lsp


### PR DESCRIPTION
I have confirmed that ocaml-lsp-server build fails when executing LspInstallServer on macOS Sonoma. Below is the message:

```
Cloning into 'ocaml-lsp-files'...
warning: redirecting to https://github.com/ocaml/ocaml-lsp.git/
remote: Enumerating objects: 475, done.
remote: Counting objects: 100% (475/475), done.
remote: Compressing objects: 100% (423/423), done.
remote: Total 475 (delta 34), reused 253 (delta 19), pack-reused 0
Receiving objects: 100% (475/475), 906.05 KiB | 3.09 MiB/s, done.
Resolving deltas: 100% (34/34), done.
No configuration file found, using built-in defaults.
Checking for available remotes: rsync and local, git.
  - you won't be able to use mercurial repositories unless you install the hg command on your system.
  - you won't be able to use darcs repositories unless you install the darcs command on your system.


<><> Fetching repository information ><><><><><><><><><><><><><><><><><><><>  🐫 
[default] Initialised

<><> Creating initial switch 'default' (invariant ["ocaml" {>= "4.05.0"}] - initially with ocaml-system) 

<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><>  🐫 
Switch invariant: ["ocaml" {>= "4.05.0"}]

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><>  🐫 
∗ installed base-bigarray.base
∗ installed base-threads.base
∗ installed base-unix.base
∗ installed ocaml-system.4.14.1
∗ installed ocaml-config.2
∗ installed ocaml.4.14.1
Done.
# Run eval $(opam env --switch=default) to update the current shell environment
ocaml-lsp-server is now pinned to git+file:///Users/msfukui/.local/share/vim-lsp-settings/servers/ocaml-lsp/ocaml-lsp-files#master (version 1.16.2)
lsp is now pinned to git+file:///Users/msfukui/.local/share/vim-lsp-settings/servers/ocaml-lsp/ocaml-lsp-files#master (version 1.16.2)
jsonrpc is now pinned to git+file:///Users/msfukui/.local/share/vim-lsp-settings/servers/ocaml-lsp/ocaml-lsp-files#master (version 1.16.2)

<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><>  🐫 
Switch invariant: ["ocaml-base-compiler" {= "4.14.0"}]
The following actions will be performed:
  ∗ install ocaml-options-vanilla 1
  ∗ install ocaml-base-compiler   4.14.0
  ∗ install base-unix             base     [required by dune]
  ∗ install base-bigarray         base
  ∗ install base-threads          base     [required by dune]
  ∗ install ocaml-config          2        [required by ocaml]
  ∗ install ocaml                 4.14.0   [required by lsp, jsonrpc, ocaml-lsp-server]
  ∗ install seq                   base     [required by re]
  ∗ install ocamlfind             1.9.6    [required by uutf]
  ∗ install ocamlbuild            0.14.2   [required by uutf]
  ∗ install dune                  3.11.1   [required by lsp, jsonrpc, ocaml-lsp-server]
  ∗ install topkg                 1.0.7    [required by uutf]
  ∗ install xdg                   3.11.1   [required by ocaml-lsp-server]
  ∗ install spawn                 v0.15.1  [required by ocaml-lsp-server]
  ∗ install result                1.5      [required by odoc-parser]
  ∗ install re                    1.11.0   [required by ocaml-lsp-server]
  ∗ install pp                    1.2.0    [required by ocaml-lsp-server]
  ∗ install ordering              3.11.1   [required by ocaml-lsp-server]
  ∗ install jsonrpc               1.16.2*
  ∗ install dune-build-info       3.11.1   [required by ocaml-lsp-server]
  ∗ install csexp                 1.5.2    [required by ocaml-lsp-server]
  ∗ install cppo                  1.6.9    [required by yojson]
  ∗ install chrome-trace          3.11.1   [required by ocaml-lsp-server]
  ∗ install camlp-streams         5.0.1    [required by odoc-parser]
  ∗ install uutf                  1.0.3    [required by lsp, ocaml-lsp-server]
  ∗ install astring               0.8.5    [required by odoc-parser]
  ∗ install dyn                   3.11.1   [required by ocaml-lsp-server]
  ∗ install ocamlformat-rpc-lib   0.26.1   [required by ocaml-lsp-server]
  ∗ install merlin-lib            4.12-414 [required by ocaml-lsp-server]
  ∗ install yojson                2.1.1    [required by lsp, ocaml-lsp-server]
  ∗ install odoc-parser           2.3.0    [required by ocaml-lsp-server]
  ∗ install stdune                3.11.1   [required by ocaml-lsp-server]
  ∗ install ocamlc-loc            3.11.1   [required by ocaml-lsp-server]
  ∗ install ppx_yojson_conv_lib   v0.16.0  [required by lsp, ocaml-lsp-server]
  ∗ install fiber                 3.7.0    [required by ocaml-lsp-server]
  ∗ install dune-rpc              3.11.1   [required by ocaml-lsp-server]
  ∗ install lsp                   1.16.2*
  ∗ install ocaml-lsp-server      1.16.2*
===== ∗ 38 =====

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><>  🐫 
∗ installed base-bigarray.base
∗ installed base-threads.base
∗ installed base-unix.base
⬇ retrieved camlp-streams.5.0.1  (https://opam.ocaml.org/cache)
⬇ retrieved astring.0.8.5  (https://opam.ocaml.org/cache)
⬇ retrieved csexp.1.5.2  (https://opam.ocaml.org/cache)
⬇ retrieved cppo.1.6.9  (https://opam.ocaml.org/cache)
⬇ retrieved chrome-trace.3.11.1  (https://opam.ocaml.org/cache)
⬇ retrieved dune-build-info.3.11.1  (cached)
⬇ retrieved dune.3.11.1  (cached)
⬇ retrieved dune-rpc.3.11.1  (cached)
⬇ retrieved dyn.3.11.1  (cached)
⬇ retrieved fiber.3.7.0  (https://opam.ocaml.org/cache)
⬇ retrieved jsonrpc.1.16.2  (git+file:///Users/msfukui/.local/share/vim-lsp-settings/servers/ocaml-lsp/ocaml-lsp-files#master)
⬇ retrieved lsp.1.16.2  (git+file:///Users/msfukui/.local/share/vim-lsp-settings/servers/ocaml-lsp/ocaml-lsp-files#master)
⬇ retrieved ocaml-lsp-server.1.16.2  (git+file:///Users/msfukui/.local/share/vim-lsp-settings/servers/ocaml-lsp/ocaml-lsp-files#master)
∗ installed ocaml-options-vanilla.1
⬇ retrieved ocamlbuild.0.14.2  (https://opam.ocaml.org/cache)
⬇ retrieved merlin-lib.4.12-414  (https://opam.ocaml.org/cache)
⬇ retrieved ocamlc-loc.3.11.1  (cached)
⬇ retrieved ocaml-base-compiler.4.14.0  (https://opam.ocaml.org/cache)
⬇ retrieved ocamlfind.1.9.6  (https://opam.ocaml.org/cache)
⬇ retrieved ocamlformat-rpc-lib.0.26.1  (https://opam.ocaml.org/cache)
⬇ retrieved ordering.3.11.1  (cached)
⬇ retrieved pp.1.2.0  (https://opam.ocaml.org/cache)
⬇ retrieved odoc-parser.2.3.0  (https://opam.ocaml.org/cache)
⬇ retrieved ppx_yojson_conv_lib.v0.16.0  (https://opam.ocaml.org/cache)
⬇ retrieved re.1.11.0  (https://opam.ocaml.org/cache)
⬇ retrieved result.1.5  (https://opam.ocaml.org/cache)
⬇ retrieved spawn.v0.15.1  (https://opam.ocaml.org/cache)
⬇ retrieved uutf.1.0.3  (https://opam.ocaml.org/cache)
⬇ retrieved topkg.1.0.7  (https://opam.ocaml.org/cache)
⬇ retrieved stdune.3.11.1  (cached)
⬇ retrieved yojson.2.1.1  (https://opam.ocaml.org/cache)
⬇ retrieved xdg.3.11.1  (cached)
∗ installed ocaml-base-compiler.4.14.0
∗ installed ocaml-config.2
∗ installed ocaml.4.14.0
∗ installed seq.base
∗ installed ocamlfind.1.9.6
∗ installed ocamlbuild.0.14.2
∗ installed topkg.1.0.7
∗ installed uutf.1.0.3
∗ installed astring.0.8.5
∗ installed dune.3.11.1
∗ installed csexp.1.5.2
∗ installed cppo.1.6.9
∗ installed camlp-streams.5.0.1
∗ installed pp.1.2.0
∗ installed jsonrpc.1.16.2
∗ installed ocamlformat-rpc-lib.0.26.1
∗ installed result.1.5
∗ installed spawn.v0.15.1
∗ installed re.1.11.0
∗ installed chrome-trace.3.11.1
∗ installed ordering.3.11.1
∗ installed xdg.3.11.1
∗ installed yojson.2.1.1
∗ installed odoc-parser.2.3.0
∗ installed dune-build-info.3.11.1
∗ installed ppx_yojson_conv_lib.v0.16.0
∗ installed dyn.3.11.1
∗ installed ocamlc-loc.3.11.1
∗ installed stdune.3.11.1
∗ installed lsp.1.16.2
∗ installed fiber.3.7.0
∗ installed merlin-lib.4.12-414
∗ installed dune-rpc.3.11.1
[ERROR] The compilation of ocaml-lsp-server.1.16.2 failed at "dune build -j 7 ocaml-lsp-server.install --release".

#=== ERROR while compiling ocaml-lsp-server.1.16.2 ============================#
# context     2.1.5 | macos/x86_64 | ocaml-base-compiler.4.14.0 | pinned(git+file:///Users/msfukui/.local/share/vim-lsp-settings/servers/ocaml-lsp/ocaml-lsp-files#master#672ca1bfbb816ff6b5f07a3f3a
bdecb66f982d8c)
# path        ~/.local/share/vim-lsp-settings/servers/ocaml-lsp/ocaml-lsp-files/_opam/.opam-switch/build/ocaml-lsp-server.1.16.2
# command     ~/.local/share/vim-lsp-settings/servers/ocaml-lsp/ocaml-lsp-files/.opam/opam-init/hooks/sandbox.sh build dune build -j 7 ocaml-lsp-server.install --release
# exit-code   1
# env-file    ~/.local/share/vim-lsp-settings/servers/ocaml-lsp/ocaml-lsp-files/.opam/log/ocaml-lsp-server-72519-e8507d.env
# output-file ~/.local/share/vim-lsp-settings/servers/ocaml-lsp/ocaml-lsp-files/.opam/log/ocaml-lsp-server-72519-e8507d.out
### output ###
# /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/assert.h:99:25: note: expanded from macro 'assert'
# [...]
# 32 warnings generated.
# (cd _build/default && /Users/msfukui/.local/share/vim-lsp-settings/servers/ocaml-lsp/ocaml-lsp-files/_opam/bin/ocamlmklib.opt -g -o vendor/lev/lev_stubs vendor/lev/lev_stubs.o vendor/lev/ev.o)
# ld: warning: -undefined suppress is deprecated
# ld: warning: -undefined suppress is deprecated
# (cd _build/default && /Users/msfukui/.local/share/vim-lsp-settings/servers/ocaml-lsp/ocaml-lsp-files/_opam/bin/ocamlopt.opt -w -40 -alert -unstable -g -I ocaml-lsp-server/src/.ocaml_lsp_server.o
bjs/byte -I ocaml-lsp-server/src/.ocaml_lsp_server.objs/native -I /Users/msfukui/.local/share/vim-lsp-settings/servers/ocaml-lsp/ocaml-lsp-files/_opam/lib/chrome-trace -I /Users/msfukui/.local/sha
re/vi[...]
# File "ocaml-lsp-server/src/doc_to_md.ml", line 143, characters 26-75:
# 143 |   | { value = `Code_block (metadata, { value = code; location = code_loc })
#                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: This pattern matches values of type 'a * 'b
#        but a pattern was expected which matches values of type
#          Odoc_parser.Ast.code_block



<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><>  🐫 
┌─ The following actions failed
│ λ build ocaml-lsp-server 1.16.2
└─ 
┌─ The following changes have been performed
│ ∗ install astring               0.8.5
│ ∗ install base-bigarray         base
│ ∗ install base-threads          base
│ ∗ install base-unix             base
│ ∗ install camlp-streams         5.0.1
│ ∗ install chrome-trace          3.11.1
│ ∗ install cppo                  1.6.9
│ ∗ install csexp                 1.5.2
│ ∗ install dune                  3.11.1
│ ∗ install dune-build-info       3.11.1
│ ∗ install dune-rpc              3.11.1
│ ∗ install dyn                   3.11.1
│ ∗ install fiber                 3.7.0
│ ∗ install jsonrpc               1.16.2
│ ∗ install lsp                   1.16.2
│ ∗ install merlin-lib            4.12-414
│ ∗ install ocaml                 4.14.0
│ ∗ install ocaml-base-compiler   4.14.0
│ ∗ install ocaml-config          2
│ ∗ install ocaml-options-vanilla 1
│ ∗ install ocamlbuild            0.14.2
│ ∗ install ocamlc-loc            3.11.1
│ ∗ install ocamlfind             1.9.6
│ ∗ install ocamlformat-rpc-lib   0.26.1
│ ∗ install odoc-parser           2.3.0
│ ∗ install ordering              3.11.1
│ ∗ install pp                    1.2.0
│ ∗ install ppx_yojson_conv_lib   v0.16.0
│ ∗ install re                    1.11.0
│ ∗ install result                1.5
│ ∗ install seq                   base
│ ∗ install spawn                 v0.15.1
│ ∗ install stdune                3.11.1
│ ∗ install topkg                 1.0.7
│ ∗ install uutf                  1.0.3
│ ∗ install xdg                   3.11.1
│ ∗ install yojson                2.1.1
└─ 
# Run eval $(opam env) to update the current shell environment
Switch initialisation failed: clean up? ('n' will leave the switch partially installed) [Y/n] y
```

Although I was not able to investigate the cause of this problem, I confirmed that the problem could be resolved by simply changing the installation method of ocaml-lsp-server to use a package manager. Below is the message:

```
No configuration file found, using built-in defaults.
Checking for available remotes: rsync and local, git.
  - you won't be able to use mercurial repositories unless you install the hg command on your system.
  - you won't be able to use darcs repositories unless you install the darcs command on your system.


<><> Fetching repository information ><><><><><><><><><><><><><><><><><><><>  🐫
[default] Initialised

<><> Creating initial switch 'default' (invariant ["ocaml" {>= "4.05.0"}] - initially with ocaml-system)

<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><>  🐫
Switch invariant: ["ocaml" {>= "4.05.0"}]

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><>  🐫
∗ installed base-bigarray.base
∗ installed base-threads.base
∗ installed base-unix.base
∗ installed ocaml-system.4.14.1
∗ installed ocaml-config.2
∗ installed ocaml.4.14.1
Done.
# Run eval $(opam env --switch=default) to update the current shell environment

<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><>  🐫
Switch invariant: ["ocaml-base-compiler" {= "4.14.1"}]

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><>  🐫
∗ installed base-bigarray.base
∗ installed base-threads.base
∗ installed base-unix.base
∗ installed ocaml-options-vanilla.1
⬇ retrieved ocaml-base-compiler.4.14.1  (https://opam.ocaml.org/cache)
∗ installed ocaml-base-compiler.4.14.1
∗ installed ocaml-config.2
∗ installed ocaml.4.14.1
Done.
# Run eval $(opam env) to update the current shell environment
The following actions will be performed:
  ∗ install ocamlfind           1.9.6    [required by uutf]
  ∗ install seq                 base     [required by re]
  ∗ install ocamlbuild          0.14.2   [required by uutf]
  ∗ install dune                3.11.1   [required by ocaml-lsp-server]
  ∗ install topkg               1.0.7    [required by uutf]
  ∗ install xdg                 3.11.1   [required by ocaml-lsp-server]
  ∗ install spawn               v0.15.1  [required by ocaml-lsp-server]
  ∗ install result              1.5      [required by odoc-parser]
  ∗ install re                  1.11.0   [required by ocaml-lsp-server]
  ∗ install pp                  1.2.0    [required by ocaml-lsp-server]
  ∗ install ordering            3.11.1   [required by ocaml-lsp-server]
  ∗ install dune-build-info     3.11.1   [required by ocaml-lsp-server]
  ∗ install csexp               1.5.2    [required by ocaml-lsp-server]
  ∗ install cppo                1.6.9    [required by yojson]
  ∗ install chrome-trace        3.11.1   [required by ocaml-lsp-server]
  ∗ install camlp-streams       5.0.1    [required by odoc-parser]
  ∗ install uutf                1.0.3    [required by ocaml-lsp-server]
  ∗ install astring             0.8.5    [required by odoc-parser]
  ∗ install dyn                 3.11.1   [required by ocaml-lsp-server]
  ∗ install ocamlformat-rpc-lib 0.26.1   [required by ocaml-lsp-server]
  ∗ install merlin-lib          4.12-414 [required by ocaml-lsp-server]
  ∗ install yojson              2.1.1    [required by ocaml-lsp-server]
  ∗ install odoc-parser         2.0.0    [required by ocaml-lsp-server]
  ∗ install stdune              3.11.1   [required by ocaml-lsp-server]
  ∗ install ocamlc-loc          3.11.1   [required by ocaml-lsp-server]
  ∗ install ppx_yojson_conv_lib v0.16.0  [required by ocaml-lsp-server]
  ∗ install fiber               3.7.0    [required by ocaml-lsp-server]
  ∗ install dune-rpc            3.11.1   [required by ocaml-lsp-server]
  ∗ install ocaml-lsp-server    1.16.2
===== ∗ 29 =====

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><>  🐫
⬇ retrieved camlp-streams.5.0.1  (https://opam.ocaml.org/cache)
⬇ retrieved astring.0.8.5  (https://opam.ocaml.org/cache)
⬇ retrieved csexp.1.5.2  (https://opam.ocaml.org/cache)
⬇ retrieved cppo.1.6.9  (https://opam.ocaml.org/cache)
⬇ retrieved chrome-trace.3.11.1  (https://opam.ocaml.org/cache)
⬇ retrieved dune-rpc.3.11.1  (cached)
⬇ retrieved dune.3.11.1  (https://opam.ocaml.org/cache)
⬇ retrieved dyn.3.11.1  (cached)
⬇ retrieved fiber.3.7.0  (https://opam.ocaml.org/cache)
⬇ retrieved dune-build-info.3.11.1  (https://opam.ocaml.org/cache)
⬇ retrieved merlin-lib.4.12-414  (https://opam.ocaml.org/cache)
⬇ retrieved ocaml-lsp-server.1.16.2  (https://opam.ocaml.org/cache)
⬇ retrieved ocamlbuild.0.14.2  (https://opam.ocaml.org/cache)
⬇ retrieved ocamlfind.1.9.6  (https://opam.ocaml.org/cache)
⬇ retrieved odoc-parser.2.0.0  (https://opam.ocaml.org/cache)
⬇ retrieved ocamlc-loc.3.11.1  (cached)
⬇ retrieved ocamlformat-rpc-lib.0.26.1  (https://opam.ocaml.org/cache)
⬇ retrieved ordering.3.11.1  (cached)
⬇ retrieved ppx_yojson_conv_lib.v0.16.0  (https://opam.ocaml.org/cache)
⬇ retrieved pp.1.2.0  (https://opam.ocaml.org/cache)
∗ installed seq.base
⬇ retrieved result.1.5  (https://opam.ocaml.org/cache)
⬇ retrieved spawn.v0.15.1  (https://opam.ocaml.org/cache)
⬇ retrieved re.1.11.0  (https://opam.ocaml.org/cache)
⬇ retrieved uutf.1.0.3  (https://opam.ocaml.org/cache)
∗ installed ocamlbuild.0.14.2
⬇ retrieved topkg.1.0.7  (https://opam.ocaml.org/cache)
⬇ retrieved yojson.2.1.1  (https://opam.ocaml.org/cache)
⬇ retrieved stdune.3.11.1  (cached)
∗ installed ocamlfind.1.9.6
⬇ retrieved xdg.3.11.1  (cached)
∗ installed topkg.1.0.7
∗ installed uutf.1.0.3
∗ installed astring.0.8.5
∗ installed dune.3.11.1
∗ installed csexp.1.5.2
∗ installed cppo.1.6.9
∗ installed camlp-streams.5.0.1
∗ installed pp.1.2.0
∗ installed result.1.5
∗ installed ocamlformat-rpc-lib.0.26.1
∗ installed re.1.11.0
∗ installed odoc-parser.2.0.0
∗ installed spawn.v0.15.1
∗ installed ordering.3.11.1
∗ installed xdg.3.11.1
∗ installed yojson.2.1.1
∗ installed chrome-trace.3.11.1
∗ installed dune-build-info.3.11.1
∗ installed ppx_yojson_conv_lib.v0.16.0
∗ installed dyn.3.11.1
∗ installed ocamlc-loc.3.11.1
∗ installed stdune.3.11.1
∗ installed fiber.3.7.0
∗ installed merlin-lib.4.12-414
∗ installed dune-rpc.3.11.1
∗ installed ocaml-lsp-server.1.16.2
Done.
```

If there is no particular concern, please merge the fix for this issue.

The environments in which operation has been confirmed are as follows:

```
$ sw_vers
ProductName:		macOS
ProductVersion:		14.0
BuildVersion:		23A344
$ uname -srvmo
Darwin 23.0.0 Darwin Kernel Version 23.0.0: Fri Sep 15 14:42:42 PDT 2023; root:xnu-10002.1.13~1/RELEASE_X86_64 x86_64 Darwin
```

I have not checked whether similar issues occur in other environments at this time.