### PR TITLE
new file format for ntt archive for windows

### DIFF
--- a/installer/install-ntt.cmd
+++ b/installer/install-ntt.cmd
@@ -1,6 +1,6 @@
 @echo off
 
 setlocal
-curl -LO "https://github.com/nokia/ntt/releases/latest/download/ntt_windows_x86_64.tar.gz"
-tar xvf ntt_windows_x86_64.tar.gz
-rm ntt_windows_x86_64.tar.gz
+curl -LO "https://github.com/nokia/ntt/releases/latest/download/ntt_windows_x86_64.zip"
+unzip ntt_windows_x86_64.zip
+rm ntt_windows_x86_64.zip


### PR DESCRIPTION
From `ntt v0.18.0` on the archive deployed for windows operating system will be in `. zip` format