### PR TITLE
Fix deno's inlay hint settings

### DIFF
--- a/settings/deno.vim
+++ b/settings/deno.vim
@@ -42,35 +42,38 @@ augroup vim_lsp_settings_deno
       \       },
       \     },
       \   },
-      \   "inlayHints": {
-      \     "parameterNames": {
-      \       "enabled": "all",
-      \       "suppressWhenArgumentMatchesName": v:true,
-      \     },
-      \     "parameterTypes": {
-      \       "enabled": v:true,
-      \     },
-      \     "variableTypes": {
-      \       "enabled": v:true,
-      \       "suppressWhenTypeMatchesName": v:true,
-      \     },
-      \     "propertyDeclarationTypes": {
-      \       "enabled": v:true,
-      \     },
-      \     "functionLikeReturnTypes": {
-      \       "enabled": v:true,
-      \     },
-      \     "enumMemberValues": {
-      \       "enabled": v:true,
-      \     },
-      \   },
       \   'config': empty(lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'tsconfig.json')) ? v:null : lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'tsconfig.json'),
       \   'internalDebug': lsp_settings#get('deno', 'internalDebug', v:false),
       \ }),
       \ 'allowlist': lsp_settings#get('deno', 'allowlist', ['typescript', 'javascript', 'typescriptreact', 'javascriptreact']),
       \ 'blocklist': lsp_settings#get('deno', 'blocklist', Vim_lsp_settings_deno_get_blocklist()),
       \ 'config': lsp_settings#get('deno', 'config', lsp_settings#server_config('deno')),
-      \ 'workspace_config': lsp_settings#get('deno', 'workspace_config', {}),
+      \ 'workspace_config': lsp_settings#get('deno', 'workspace_config', {
+      \   'typescript': {
+      \     'inlayHints': {
+      \       'parameterNames': {
+      \         'enabled': 'all',
+      \         'suppressWhenArgumentMatchesName': v:true,
+      \       },
+      \       'parameterTypes': {
+      \         'enabled': v:true,
+      \       },
+      \       'variableTypes': {
+      \         'enabled': v:true,
+      \         'suppressWhenTypeMatchesName': v:true,
+      \       },
+      \       'propertyDeclarationTypes': {
+      \         'enabled': v:true,
+      \       },
+      \       'functionLikeReturnTypes': {
+      \         'enabled': v:true,
+      \       },
+      \       'enumMemberValues': {
+      \         'enabled': v:true,
+      \       },
+      \     },
+      \   },
+      \ }),
       \ 'semantic_highlight': lsp_settings#get('deno', 'semantic_highlight', {}),
       \ }
 augroup END


### PR DESCRIPTION
deno's inlay hint did not work since deno v1.38.0.

before:
<img width="731" alt="スクリーンショット 2023-11-16 1 04 33" src="https://github.com/mattn/vim-lsp-settings/assets/56591/1dbbd565-9981-48b2-8d09-1b9207bc90cd">

after:
<img width="731" alt="スクリーンショット 2023-11-16 1 03 40" src="https://github.com/mattn/vim-lsp-settings/assets/56591/0c4f7b2b-7563-40fe-8066-1a2ce3bef885">

Thanks to @yaegassy for suggested me to how to fix this problem.