### PR TITLE
Fix install-terraform-ls.sh

### DIFF
--- a/installer/install-terraform-ls.sh
+++ b/installer/install-terraform-ls.sh
@@ -24,10 +24,9 @@ arm64*) arch=arm64 ;;
   ;;
 esac
 
-version=$(basename $(curl -Ls -o /dev/null -w %\{url_effective\} https://github.com/hashicorp/terraform-ls/releases/latest))
-short_version=$(echo "$version" | cut -c2-)
-filename="terraform-ls_${short_version}"
-url="https://github.com/hashicorp/terraform-ls/releases/download/${version}/${filename}_${os}_${arch}.zip"
+version=$(basename $(curl -Ls -o /dev/null -w %\{url_effective\} https://github.com/hashicorp/terraform-ls/releases/latest) | tr -d v)
+filename="terraform-ls_${version}"
+url="https://releases.hashicorp.com/terraform-ls/${version}/${filename}_${os}_${arch}.zip"
 filename="${filename}.zip"
 
 curl -L --progress-bar "$url" -o "$filename"


### PR DESCRIPTION
Hashicorp is releasing binaries on releases.hashicorp.com instead of github releases. Update install-terraform-ls.sh to pull from the new location.

Fixes https://github.com/mattn/vim-lsp-settings/issues/708

## Testing

Before changes, `install-terraform-ls.sh` failed. The downloaded zip file was actually an ASCII file (not a zip) consisting of `Not found`.

After changes, confirmed working with:

```bash
$ ./install-terraform-ls.sh
################################################################################################ 100.0%
Archive:  terraform-ls_0.32.3.zip
replace terraform-ls? [y]es, [n]o, [A]ll, [N]one, [r]ename: y
  inflating: terraform-ls
$ echo $?
0
```