### PR TITLE
Add Ruby Sorbet

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ To use rubocop-lsp-mode, you need to install rubocop in your Ruby project using 
 ### [sorbet (Ruby)](https://sorbet.org/docs/vscode)
 
 To use sorbet, you need to install rubocop in your Ruby project using bundler.
+Also, [Watchman](https://facebook.github.io/watchman/) is required to watch file changes.
+For more details, please see [Sorbet](https://sorbet.org/docs/vscode#installing-and-enabling-the-sorbet-extension) and [Watchman](https://facebook.github.io/watchman/docs/install.html) documentations.
 
 ## Extra Configurations
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ You can change the directory to install servers by set `g:lsp_settings_servers_d
 | Ruby              | steep                               |    Yes    |      Yes      |
 | Ruby              | typeprof                            |    Yes    |      Yes      |
 | Ruby              | rubocop (lsp mode)                  |    Yes    |      No       |
+| Ruby              | sorbet                              |    Yes    |      No       |
 | Rust              | rls                                 |    Yes    |      No       |
 | Rust              | rust-analyzer                       |    Yes    |      Yes      |
 | Sphinx            | esbonio                             |    Yes    |      Yes      |
@@ -304,6 +305,10 @@ To use older version `golangci-lint`, please run `:LspSettingsGlobalEdit` and pu
 ### [rubocop lsp mode (Ruby)](https://docs.rubocop.org/rubocop/usage/lsp.html)
 
 To use rubocop-lsp-mode, you need to install rubocop in your Ruby project using bundler.
+
+### [sorbet (Ruby)](https://sorbet.org/docs/vscode)
+
+To use sorbet, you need to install rubocop in your Ruby project using bundler.
 
 ## Extra Configurations
 

--- a/installer/install-sorbet.cmd
+++ b/installer/install-sorbet.cmd
@@ -1,0 +1,18 @@
+@echo off
+
+echo @echo off ^
+
+setlocal ^
+
+set TARGET_DIR=%%1 ^
+
+shift ^
+
+cd %%TARGET_DIR%% ^
+
+bundle exec srb typecheck %%* ^
+
+> sorbet.cmd
+
+echo Install Done.
+echo **You need add sorbet dependencies in Gemfile.**

--- a/installer/install-sorbet.sh
+++ b/installer/install-sorbet.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -e
+
+cat <<EOF >sorbet
+#!/bin/sh
+
+TARGET_DIR=\$1
+shift
+cd \${TARGET_DIR}
+bundle exec srb typecheck \$*
+EOF
+
+chmod +x sorbet
+
+echo 'Install Done.'
+echo '**You need add sorbet dependencies in Gemfile.**'

--- a/settings.json
+++ b/settings.json
@@ -1346,6 +1346,17 @@
       "root_uri_patterns": [
         "Gemfile"
       ]
+    },
+    {
+      "command": "sorbet",
+      "url": "https://sorbet.org/",
+      "description": "Sorbet is a fast, powerful type checker designed for Ruby.",
+      "requires": [
+        "bundle"
+      ],
+      "root_uri_patterns": [
+        "Gemfile"
+      ]
     }
   ],
   "rust": [

--- a/settings/sorbet.vim
+++ b/settings/sorbet.vim
@@ -1,0 +1,14 @@
+augroup vim_lsp_settings_sorbet
+  au!
+  LspRegisterServer {
+      \ 'name': 'sorbet',
+      \ 'cmd': {server_info->lsp_settings#get('sorbet', 'cmd', [lsp_settings#exec_path('sorbet'), lsp#utils#uri_to_path(lsp_settings#root_uri('sorbet')), '--lsp'])+lsp_settings#get('sorbet', 'args', [])},
+      \ 'root_uri':{server_info->lsp_settings#get('sorbet', 'root_uri', lsp_settings#root_uri('sorbet'))},
+      \ 'initialization_options': lsp_settings#get('sorbet', 'initialization_options', v:null),
+      \ 'allowlist': lsp_settings#get('sorbet', 'allowlist', ['ruby']),
+      \ 'blocklist': lsp_settings#get('sorbet', 'blocklist', []),
+      \ 'config': lsp_settings#get('sorbet', 'config', lsp_settings#server_config('sorbet')),
+      \ 'workspace_config': lsp_settings#get('sorbet', 'workspace_config', {}),
+      \ 'semantic_highlight': lsp_settings#get('sorbet', 'semantic_highlight', {}),
+      \ }
+augroup END

--- a/settings/sorbet.vim
+++ b/settings/sorbet.vim
@@ -1,8 +1,18 @@
+function! Vim_lsp_get_watchman_flag()
+  if executable('watchman')
+    return ''
+  endif
+
+  " cf. https://sorbet.org/docs/vscode#installing-and-enabling-the-sorbet-extension
+  echo "To watch file changes, watchman is required for sorbet-lsp"
+  return '--disable-watchman'
+endfunction
+
 augroup vim_lsp_settings_sorbet
   au!
   LspRegisterServer {
       \ 'name': 'sorbet',
-      \ 'cmd': {server_info->lsp_settings#get('sorbet', 'cmd', [lsp_settings#exec_path('sorbet'), lsp#utils#uri_to_path(lsp_settings#root_uri('sorbet')), '--lsp'])+lsp_settings#get('sorbet', 'args', [])},
+      \ 'cmd': {server_info->lsp_settings#get('sorbet', 'cmd', [lsp_settings#exec_path('sorbet'), lsp#utils#uri_to_path(lsp_settings#root_uri('sorbet')), '--lsp', Vim_lsp_get_watchman_flag()])+lsp_settings#get('sorbet', 'args', [])},
       \ 'root_uri':{server_info->lsp_settings#get('sorbet', 'root_uri', lsp_settings#root_uri('sorbet'))},
       \ 'initialization_options': lsp_settings#get('sorbet', 'initialization_options', v:null),
       \ 'allowlist': lsp_settings#get('sorbet', 'allowlist', ['ruby']),


### PR DESCRIPTION
I add [Sorbet](https://sorbet.org/) settings for vim-lsp.

I adopt similar way to RuboCop (LSP mode) setting to create sorbet's one because sorbet executable (`srb` command) is expected to be installed by Bundle in the workspace according to the reference ( https://sorbet.org/docs/vscode#installing-and-enabling-the-sorbet-extension ).

Also, Sorbet needs watchman to watch file changes and if that is not installed `srb` command needs to have `--disable-watchman` flag.

NOTE: CodeAction is NOT worked correctly maybe due to Sorbet's issue or vim-lsp's issue. I'm trying to solve this now.

