### PR TITLE
Remove parameters for vala language server

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1671,11 +1671,7 @@
       "url": "https://github.com/Prince781/vala-language-server",
       "description": "Code Intelligence for Vala & Genie",
       "requires": [
-        "meson",
         "valac"
-      ],
-      "root_uri_patterns": [
-        "meson.build"
       ]
     }
   ],

--- a/settings/vala-language-server.vim
+++ b/settings/vala-language-server.vim
@@ -2,7 +2,7 @@ augroup vim_lsp_settings_vala_language_server
   au!
   LspRegisterServer {
       \ 'name': 'vala-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('vala-language-server', 'cmd', [lsp_settings#exec_path('vala-language-server')]+lsp_settings#get('vala-language-server', 'args', ['--stdio']))},
+      \ 'cmd': {server_info->lsp_settings#get('vala-language-server', 'cmd', [lsp_settings#exec_path('vala-language-server')]+lsp_settings#get('vala-language-server', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('vala-language-server', 'root_uri', lsp_settings#root_uri('vala-language-server'))},
       \ 'initialization_options': lsp_settings#get('vala-language-server', 'initialization_options', v:null),
       \ 'allowlist': lsp_settings#get('vala-language-server', 'allowlist', ['vala']),


### PR DESCRIPTION
Seems there was a massive addition of this parameter `--stdio`.

I'm unsure if that is something ls should support but in vala-language-server is not supported (I can report if that should be supported)

fixes #675