### PR TITLE
Fix: Python version check for pip (in Python 3.12 or later, removed distutils)

### DIFF
--- a/installer/pip_install.cmd
+++ b/installer/pip_install.cmd
@@ -17,7 +17,8 @@ goto :EOF
 
 :python
 rem python is 2 or 3 check(python3 version at python3 grammar)
-call python -c "import sys; from distutils.version import LooseVersion;sys.exit(0 if (LooseVersion(sys.version) > LooseVersion('3')) else 1)" 2>NUL
+rem Do a quick check as distutils has been removed in Python 3.12
+call python -c "import sys; sys.exit(0 if (sys.version_info[0] >= 3) else 1)" 2>NUL
 if errorlevel 1 goto :python_fail
 set PYTHON=python
 goto :create_venv


### PR DESCRIPTION
## Background

Python 3.12 or later, distutils has been removed.
See: https://docs.python.org/3/whatsnew/3.12.html

So the previous version check code will fail.

## Changes

Change this to a simple check and fix it.
(Currently, the use of Python 2 is declining, so I thought this was a good idea.)