### PR TITLE
feat: add typst-lsp

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ You can change the directory to install servers by set `g:lsp_settings_servers_d
 | TypeScript        | deno                                |    Yes    |      Yes      |
 | TypeScript        | rome                                |    Yes    |      Yes      |
 | TypeScript        | eslint-language-server              |    Yes    |      Yes      |
+| Typst             | typst-lsp                           |    Yes    |      Yes      |
 | Vim               | vim-language-server                 |    Yes    |      Yes      |
 | Vala              | vala-language-server                |    No     |      No       |
 | Veryl             | veryl-ls                            |    Yes    |      Yes      |

--- a/installer/install-typst-lsp.cmd
+++ b/installer/install-typst-lsp.cmd
@@ -1,0 +1,4 @@
+@echo off
+
+setlocal
+curl -L -o typst-lsp-x86_64-pc-windows-msvc.exe "https://github.com/nvarner/typst-lsp/releases/latest/download/typst-lsp-x86_64-pc-windows-msvc.exe"

--- a/installer/install-typst-lsp.sh
+++ b/installer/install-typst-lsp.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+set -e
+#set -o pipefail
+
+os="$(uname -s | tr "[:upper:]" "[:lower:]")"
+arch=$(uname -m)
+
+case $arch in
+x86_64) ;;
+arm64)
+  arch="aarch64"
+  ;;
+*)
+  printf "%s doesn't supported by bash installer" "$os"
+  exit 1
+  ;;
+esac
+
+case "${os}" in
+darwin)
+  url="https://github.com/nvarner/typst-lsp/releases/latest/download/typst-lsp-${arch}-apple-darwin"
+  ;;
+linux)
+  url="https://github.com/nvarner/typst-lsp/releases/latest/download/typst-lsp-${arch}-unknown-linux-gnu"
+  ;;
+*)
+  echo >&2 "$os is not supported"
+  exit 1
+  ;;
+esac
+
+curl -L -o typst-lsp "$url" 
+chmod +x typst-lsp

--- a/settings.json
+++ b/settings.json
@@ -1665,6 +1665,22 @@
       "requires": []
     }
   ],
+  "typ": [
+    {
+      "command": "typst-lsp",
+      "url": "https://github.com/nvarner/typst-lsp",
+      "description": "Language server for Typst",
+      "requires": []
+    },
+  ],
+  "typst": [
+    {
+      "command": "typst-lsp",
+      "url": "https://github.com/nvarner/typst-lsp",
+      "description": "Language server for Typst",
+      "requires": []
+    },
+  ],
   "vala": [
     {
       "command": "vala-language-server",

--- a/settings.json
+++ b/settings.json
@@ -1671,7 +1671,7 @@
       "url": "https://github.com/nvarner/typst-lsp",
       "description": "Language server for Typst",
       "requires": []
-    },
+    }
   ],
   "typst": [
     {
@@ -1679,7 +1679,7 @@
       "url": "https://github.com/nvarner/typst-lsp",
       "description": "Language server for Typst",
       "requires": []
-    },
+    }
   ],
   "vala": [
     {

--- a/settings/typst-lsp.vim
+++ b/settings/typst-lsp.vim
@@ -1,0 +1,14 @@
+augroup vim_lsp_settings_typst_lsp
+  au!
+  LspRegisterServer {
+      \ 'name': 'typst-lsp',
+      \ 'cmd': {server_info->lsp_settings#get('typst-lsp', 'cmd', [lsp_settings#exec_path('typst-lsp')]+lsp_settings#get('typst-lsp', 'args', []))},
+      \ 'root_uri':{server_info->lsp_settings#get('typst-lsp', 'root_uri', lsp_settings#root_uri('typst-lsp'))},
+      \ 'initialization_options': lsp_settings#get('typst-lsp', 'initialization_options', v:null),
+      \ 'allowlist': lsp_settings#get('typst-lsp', 'allowlist', ['typst', 'typ']),
+      \ 'blocklist': lsp_settings#get('typst-lsp', 'blocklist', []),
+      \ 'config': lsp_settings#get('typst-lsp', 'config', lsp_settings#server_config('typst-lsp')),
+      \ 'workspace_config': lsp_settings#get('typst-lsp', 'workspace_config', {}),
+      \ 'semantic_highlight': lsp_settings#get('typst-lsp', 'semantic_highlight', {}),
+      \ }
+augroup END


### PR DESCRIPTION
Adds [`typst-lsp`](https://github.com/nvarner/typst-lsp) for [Typst](https://typst.app).

The settings are in sync to what [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#typst_lsp) uses.

Here is a screenshot of how the [`typst-lsp` releases](https://github.com/nvarner/typst-lsp/releases) are:

<img width="952" alt="image" src="https://github.com/mattn/vim-lsp-settings/assets/43353831/a5dc527d-554f-4289-855b-988fb920242e">
