### PR TITLE
ci: update checkout actions to a non-deprecated node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,15 @@ jobs:
             neovim: true
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - id: vim
         uses: rhysd/action-setup-vim@v1
         with:
           version: ${{ matrix.version }}
           neovim: ${{ matrix.neovim }}
       - name: 'Setup vim-themis'
-        uses: actions/checkout@v2
-        with: 
+        uses: actions/checkout@v4
+        with:
           repository: thinca/vim-themis
           path: vim-themis
       - name: Run tests

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -13,7 +13,7 @@ jobs:
     name: runner / vint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: vint
         uses: reviewdog/action-vint@v1
         with:
@@ -24,7 +24,7 @@ jobs:
     name: runner / shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: shellcheck
         uses: reviewdog/action-shellcheck@v1
         with:


### PR DESCRIPTION
We are getting tons of warnings in CI:

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default

Example: https://github.com/mattn/vim-lsp-settings/actions/runs/7344860647