### PR TITLE
add vscode-eslint-language-server

### DIFF
--- a/installer/install-vscode-eslint-language-server.cmd
+++ b/installer/install-vscode-eslint-language-server.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+call "%~dp0\npm_install.cmd" vscode-eslint-language-server vscode-langservers-extracted

--- a/installer/install-vscode-eslint-language-server.sh
+++ b/installer/install-vscode-eslint-language-server.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+"$(dirname "$0")/npm_install.sh" vscode-eslint-language-server vscode-langservers-extracted

--- a/settings.json
+++ b/settings.json
@@ -687,6 +687,17 @@
         "package.json",
         ".flowconfig"
       ]
+    },
+    {
+      "command": "vscode-eslint-language-server",
+      "url": "https://github.com/hrsh7th/vscode-langservers-extracted",
+      "description": "HTML/CSS/JSON/ESLint language servers extracted from vscode.",
+      "requires": [
+        "npm"
+      ],
+      "root_uri_patterns": [
+        "package.json"
+      ]
     }
   ],
   "javascriptreact": [
@@ -744,6 +755,17 @@
       "root_uri_patterns": [
         "package.json",
         ".flowconfig"
+      ]
+    },
+    {
+      "command": "vscode-eslint-language-server",
+      "url": "https://github.com/hrsh7th/vscode-langservers-extracted",
+      "description": "HTML/CSS/JSON/ESLint language servers extracted from vscode.",
+      "requires": [
+        "npm"
+      ],
+      "root_uri_patterns": [
+        "package.json"
       ]
     }
   ],
@@ -1636,6 +1658,17 @@
       "url": "https://deno.land/",
       "description": "A modern runtime for JavaScript and TypeScript.",
       "requires": []
+    },
+    {
+      "command": "vscode-eslint-language-server",
+      "url": "https://github.com/hrsh7th/vscode-langservers-extracted",
+      "description": "HTML/CSS/JSON/ESLint language servers extracted from vscode.",
+      "requires": [
+        "npm"
+      ],
+      "root_uri_patterns": [
+        "package.json"
+      ]
     }
   ],
   "typescriptreact": [
@@ -1676,6 +1709,17 @@
       "url": "https://deno.land/",
       "description": "A modern runtime for JavaScript and TypeScript.",
       "requires": []
+    },
+    {
+      "command": "vscode-eslint-language-server",
+      "url": "https://github.com/hrsh7th/vscode-langservers-extracted",
+      "description": "HTML/CSS/JSON/ESLint language servers extracted from vscode.",
+      "requires": [
+        "npm"
+      ],
+      "root_uri_patterns": [
+        "package.json"
+      ]
     }
   ],
   "typ": [

--- a/settings/vscode-eslint-language-server.vim
+++ b/settings/vscode-eslint-language-server.vim
@@ -1,0 +1,40 @@
+augroup vim_lsp_settings_eslint_language_server
+  au!
+  LspRegisterServer {
+      \ 'name': 'vscode-eslint-language-server',
+      \ 'cmd': {server_info->lsp_settings#get('vscode-eslint-language-server', 'cmd', [lsp_settings#exec_path('vscode-eslint-language-server')]+lsp_settings#get('vscode-eslint-language-server', 'args', ['--stdio']))},
+      \ 'root_uri':{server_info->lsp_settings#get('vscode-eslint-language-server', 'root_uri', lsp_settings#root_uri('vscode-eslint-language-server'))},
+      \ 'initialization_options': lsp_settings#get('vscode-eslint-language-server', 'initialization_options', {'diagnostics': 'true'}),
+      \ 'allowlist': lsp_settings#get('vscode-eslint-language-server', 'allowlist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact']),
+      \ 'blocklist': lsp_settings#get('vscode-eslint-language-server', 'blocklist', []),
+      \ 'config': lsp_settings#get('vscode-eslint-language-server', 'config', lsp_settings#server_config('vscode-eslint-language-server')),
+      \ 'workspace_config': lsp_settings#get('vscode-eslint-language-server', 'workspace_config', {
+      \   'validate': 'probe',
+      \   'packageManager': 'npm',
+      \   'useESLintClass': v:false,
+      \   'experimental': { 'useFlatConfig': v:false },
+      \   'codeAction': {
+      \     'disableRuleComment': {
+      \       'enable': v:true,
+      \       'location': 'separateLine',
+      \     },
+      \     'showDocumentation': {
+      \       'enable': v:true,
+      \     },
+      \   },
+      \   'codeActionOnSave': {
+      \     'enable': v:true,
+      \     'mode': 'all',
+      \   },
+      \   'format': v:false,
+      \   'quiet': v:false,
+      \   'onIgnoredFiles': 'off',
+      \   'options': {},
+      \   'rulesCustomizations': [],
+      \   'run': 'onType',
+      \   'problems': { 'shortenToSingleLine': v:true },
+      \   'nodePath': v:null,
+      \ }),
+      \ 'semantic_highlight': lsp_settings#get('vscode-eslint-language-server', 'semantic_highlight', {}),
+      \ }
+augroup END


### PR DESCRIPTION
Add vscode-eslint-language-server, which uses [vscode-langservers-extracted](https://github.com/hrsh7th/vscode-langservers-extracted) to install the newer vscode-eslint.

It seems that vscode-eslint no longer creates Release.
https://github.com/microsoft/vscode-eslint/releases
