### PR TITLE
fix sqls path

### DIFF
--- a/installer/install-sqls.cmd
+++ b/installer/install-sqls.cmd
@@ -1,3 +1,3 @@
 @echo off
 
-call "%~dp0\go_install.cmd" github.com/lighttiger2505/sqls@latest
+call "%~dp0\go_install.cmd" github.com/sqls-server/sqls@latest

--- a/installer/install-sqls.sh
+++ b/installer/install-sqls.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-"$(dirname "$0")/go_install.sh" github.com/lighttiger2505/sqls@latest
+"$(dirname "$0")/go_install.sh" github.com/sqls-server/sqls@latest


### PR DESCRIPTION
I tried `:LspInstallServer sqls` (in Linux NOT Windows) and got below message.

```
go: downloading github.com/lighttiger2505/sqls v0.2.28
go: github.com/lighttiger2505/sqls@latest: version constraints conflict:
        github.com/lighttiger2505/sqls@v0.2.28: parsing go.mod:
        module declares its path as: github.com/sqls-server/sqls
                but was required as: github.com/lighttiger2505/sqls
```

So I modified path and retried installation.


```
go: downloading github.com/sqls-server/sqls v0.2.28
go: downloading github.com/sourcegraph/jsonrpc2 v0.2.0
...
```