### PR TITLE
Java's eclipse-jdt-ls does not offer suggestions after a dot

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -601,7 +601,7 @@
         "java"
       ],
       "config": {
-        "refresh_pattern": "\\([.a-zA-Z0-9_-]\\+\\|/\\|\\k\\+\\)$"
+        "refresh_pattern": "\\([a-zA-Z0-9_-]\\+\\|/\\|\\k\\+\\)$"
       },
       "root_uri_patterns": [
         "pom.xml",


### PR DESCRIPTION
I believe that there is an error in the way `refresh_pattern` is set for eclipse-jdt-ls, that prevents complete suggestions to be shown after a dot has been typed (such as using the dot to access the methods of an instance variable).

The refresh pattern was originally set in https://github.com/mattn/vim-lsp-settings/pull/490. Other issues in vim-lsp and vim-lsp-settings seem to be pointing to this:

* https://github.com/prabirshrestha/vim-lsp/issues/1442#issuecomment-1445353234
* https://github.com/mattn/vim-lsp-settings/pull/550

As seen in the following case, while suggestions work after typing a dot in the import statement, typing a dot inside a method body does not present suggestions.

https://github.com/mattn/vim-lsp-settings/assets/1568690/3341b00b-9a09-44b2-b6c7-3bb0188f9f29

Patching the refresh_pattern for eclipse-jdt-ls and removing the dot as proposed in the patch causes dots to always trigger the completion menu, both on imports and on method bodies:

https://github.com/mattn/vim-lsp-settings/assets/1568690/66cf953e-5c6e-41f7-ba78-cea96cdebb68

I know little about Vim patterns and their differences in regard to normal PCRE patterns and while the fix seems to work and is aligned with the experience of other people in issues linked above, I'm scared about unexpected consequences of changing this.