### PR TITLE
Update Volar (currently called Vue Language Tools) to v2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ You can change the directory to install servers by set `g:lsp_settings_servers_d
 | Vim               | vim-language-server                 |    Yes    |      Yes      |
 | Vala              | vala-language-server                |    No     |      No       |
 | Veryl             | veryl-ls                            |    Yes    |      Yes      |
-| Vue               | volar-server                        |    Yes    |      Yes      |
+| Vue               | volar-server (Vue Language Tools)   |    Yes    |      Yes      |
 | Vue               | vls                                 |    Yes    |      Yes      |
 | V                 | v-analyzer                          |    Yes    |      Yes      |
 | V                 | vlang-vls                           |    Yes    |      Yes      |
@@ -314,6 +314,14 @@ To use rubocop-lsp-mode, you need to install rubocop in your Ruby project using 
 To use sorbet, you need to install rubocop in your Ruby project using bundler.
 Also, [Watchman](https://facebook.github.io/watchman/) is required to watch file changes.
 For more details, please see [Sorbet](https://sorbet.org/docs/vscode#installing-and-enabling-the-sorbet-extension) and [Watchman](https://facebook.github.io/watchman/docs/install.html) documentations.
+
+### [volar (Vue Language Tools)](https://github.com/vuejs/language-tools)
+
+To enable full Vue support, both `typescript-language-server` and `volar-server` should be installed and enabled in `vue` filetype.
+
+```vim
+let g:lsp_settings_filetype_vue = ['typescript-language-server', 'volar-server']
+```
 
 ## Extra Configurations
 

--- a/installer/install-volar-server.cmd
+++ b/installer/install-volar-server.cmd
@@ -1,5 +1,5 @@
 @echo off
 
-call "%~dp0\npm_install.cmd" vue-language-server @vue/language-server@~1.8.0
+call "%~dp0\npm_install.cmd" vue-language-server @vue/language-server@~2.0.0
 ren vue-language-server.cmd volar-server.cmd
-call npm install typescript@5.0.2
+call npm install typescript@5.4.2

--- a/installer/install-volar-server.sh
+++ b/installer/install-volar-server.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-"$(dirname "$0")/npm_install.sh" vue-language-server @vue/language-server@~1.8.0
+"$(dirname "$0")/npm_install.sh" vue-language-server @vue/language-server@~2.0.0
 mv vue-language-server volar-server
-npm install typescript@5.0.2
+npm install typescript@5.4.2

--- a/settings.json
+++ b/settings.json
@@ -1832,6 +1832,18 @@
       }
     },
     {
+      "command": "typescript-language-server",
+      "url": "https://github.com/typescript-language-server/typescript-language-server",
+      "description": "TypeScript & JavaScript Language Server",
+      "requires": [
+        "npm"
+      ],
+      "root_uri_patterns": [
+        "package.json",
+        "tsconfig.json"
+      ]
+    },
+    {
       "command": "vls",
       "url": "https://github.com/vuejs/vetur",
       "description": "Vue tooling for VS Code.",

--- a/settings/typescript-language-server.vim
+++ b/settings/typescript-language-server.vim
@@ -1,3 +1,38 @@
+function! s:find_vue_plugin() abort
+  let package_json_path = lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'package.json')
+  if empty(package_json_path)
+    return v:null
+  endif
+
+  let package_json = json_decode(join(readfile(package_json_path), ''))
+  if !(has_key(package_json, 'dependencies') && has_key(package_json['dependencies'], 'vue'))
+    return v:null
+  endif
+
+  let plugin_location = lsp_settings#servers_dir() .. '/volar-server/node_modules/@vue/typescript-plugin'
+  if !isdirectory(plugin_location)
+    call lsp_settings#utils#warning('Please install the latest volar-server to enable Vue support')
+    return v:null
+  endif
+
+  return {
+  \ 'name': '@vue/typescript-plugin',
+  \ 'location': plugin_location,
+  \ 'languages': ['vue'],
+  \ }
+endfunction
+
+function! Vim_lsp_settings_typescript_language_server_setup_plugins() abort
+  let plugins = []
+
+  let vue_plugin = s:find_vue_plugin()
+  if !empty(vue_plugin)
+    call add(plugins, vue_plugin)
+  endif
+
+  return plugins
+endfunction
+
 augroup vim_lsp_settings_typescript_language_server
   au!
   LspRegisterServer {
@@ -14,9 +49,10 @@ augroup vim_lsp_settings_typescript_language_server
       \     'includeInlayEnumMemberValueHints': v:true,
       \     'includeInlayFunctionLikeReturnTypeHints': v:true
       \   },
+      \   'plugins': Vim_lsp_settings_typescript_language_server_setup_plugins(),
       \ }),
-      \ 'allowlist': lsp_settings#get('typescript-language-server', 'allowlist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact', 'typescript.tsx']),
-      \ 'blocklist': lsp_settings#get('typescript-language-server', 'blocklist', {c->empty(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), 'node_modules/')) ? ['typescript', 'javascript', 'typescriptreact', 'javascriptreact'] : []}),
+      \ 'allowlist': lsp_settings#get('typescript-language-server', 'allowlist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact', 'typescript.tsx', 'vue']),
+      \ 'blocklist': lsp_settings#get('typescript-language-server', 'blocklist', {c->empty(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), 'node_modules/')) ? ['typescript', 'javascript', 'typescriptreact', 'javascriptreact', 'vue'] : []}),
       \ 'config': lsp_settings#get('typescript-language-server', 'config', lsp_settings#server_config('typescript-language-server')),
       \ 'workspace_config': lsp_settings#get('typescript-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('typescript-language-server', 'semantic_highlight', {}),

--- a/settings/typescript-language-server.vim
+++ b/settings/typescript-language-server.vim
@@ -1,17 +1,6 @@
 function! s:find_vue_plugin() abort
-  let package_json_path = lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'package.json')
-  if empty(package_json_path)
-    return v:null
-  endif
-
-  let package_json = json_decode(join(readfile(package_json_path), ''))
-  if !(has_key(package_json, 'dependencies') && has_key(package_json['dependencies'], 'vue'))
-    return v:null
-  endif
-
   let plugin_location = lsp_settings#servers_dir() .. '/volar-server/node_modules/@vue/typescript-plugin'
   if !isdirectory(plugin_location)
-    call lsp_settings#utils#warning('Please install the latest volar-server to enable Vue support')
     return v:null
   endif
 

--- a/settings/volar-server.vim
+++ b/settings/volar-server.vim
@@ -2,9 +2,9 @@ function! s:get_current_ts_path() abort
   let ts_path = '/node_modules/typescript/lib'
 
   let project_dir = lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), 'package.json')
-  let tsserverlibrary_path = project_dir . ts_path
+  let tsserverlibrary_path = project_dir .. ts_path
 
-  let server_dir = lsp_settings#servers_dir() . '/volar-server'
+  let server_dir = lsp_settings#servers_dir() .. '/volar-server'
   let fallback_path = server_dir . ts_path
 
   let path = filereadable(tsserverlibrary_path) ? tsserverlibrary_path : fallback_path
@@ -51,6 +51,18 @@ function! s:on_lsp_buffer_enabled() abort
     let l:capabilities.renameProvider = {'prepareProvider': v:true}
     let l:capabilities.signatureHelpProvider = v:true
     let l:capabilities.workspaceSymbolProvider = v:true
+  endif
+
+  " check typescript-language-server
+  let ts_server_dir = lsp_settings#servers_dir() .. '/typescript-language-server'
+  if !isdirectory(ts_server_dir)
+    call lsp_settings#utils#warning('Please install typescript-language-server to enable Vue support')
+  endif
+
+  if !exists('g:lsp_settings_filetype_vue') ||
+  \ index(g:lsp_settings_filetype_vue, 'volar-server') == -1 ||
+  \ index(g:lsp_settings_filetype_vue, 'typescript-language-server') == -1
+    call lsp_settings#utils#warning('Both ''volar-server'' and ''typescript-language-server'' should be included in g:lsp_settings_filetype_vue to enable Vue support')
   endif
 endfunction
 


### PR DESCRIPTION
Vue Language Tools v2.0 consists of the `@vue/language-server` and `@vue/typescript-plugin`.

* Add `g:lsp_settings_filetype_vue` setup instruction to enable both `volar-server` and `typescript-language-server` in `vue` filetype.
* Add `@vue/typescript-plugin` to `typescript-language-server` plugins only in Vue projects.
* Show warnings when the setup is incomplete.

I think this is the first case to utilize typescript language server's plugins in vue-lsp-setttings.
So, I would like to have advice if my approach to do that is not appropriate.
