### PR TITLE
add blocklist for typescript-language-server

### DIFF
--- a/settings/typescript-language-server.vim
+++ b/settings/typescript-language-server.vim
@@ -1,4 +1,7 @@
 function! Vim_lsp_settings_typescript_language_server_get_blocklist() abort
+    if empty(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), 'node_modules/'))
+        return ['typescript', 'javascript', 'typescriptreact', 'javascriptreact', 'vue']
+    endif
     if !empty(lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'deno.json'))
         return lsp_settings#utils#warning('server "typescript-language-server" is disabled since "deno.json" is found', ['typescript', 'javascript', 'typescriptreact', 'javascriptreact', 'vue'])
     endif

--- a/settings/typescript-language-server.vim
+++ b/settings/typescript-language-server.vim
@@ -1,3 +1,10 @@
+function! Vim_lsp_settings_typescript_language_server_get_blocklist() abort
+    if !empty(lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'deno.json'))
+        return lsp_settings#utils#warning('server "typescript-language-server" is disabled since "deno.json" is found', ['typescript', 'javascript', 'typescriptreact', 'javascriptreact', 'vue'])
+    endif
+    return []
+endfunction
+
 function! s:find_vue_plugin() abort
   let plugin_location = lsp_settings#servers_dir() .. '/volar-server/node_modules/@vue/typescript-plugin'
   if !isdirectory(plugin_location)
@@ -41,7 +48,7 @@ augroup vim_lsp_settings_typescript_language_server
       \   'plugins': Vim_lsp_settings_typescript_language_server_setup_plugins(),
       \ }),
       \ 'allowlist': lsp_settings#get('typescript-language-server', 'allowlist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact', 'typescript.tsx', 'vue']),
-      \ 'blocklist': lsp_settings#get('typescript-language-server', 'blocklist', {c->empty(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), 'node_modules/')) ? ['typescript', 'javascript', 'typescriptreact', 'javascriptreact', 'vue'] : []}),
+      \ 'blocklist': lsp_settings#get('typescript-language-server', 'blocklist', Vim_lsp_settings_typescript_language_server_get_blocklist()),
       \ 'config': lsp_settings#get('typescript-language-server', 'config', lsp_settings#server_config('typescript-language-server')),
       \ 'workspace_config': lsp_settings#get('typescript-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('typescript-language-server', 'semantic_highlight', {}),


### PR DESCRIPTION
Now typescript-language-server will be disabled if deno.json exists.