### PR TITLE
chore: use vscode-langservers-extracted instead of vscode-css-langageserver-bin

### DIFF
--- a/installer/install-css-languageserver.cmd
+++ b/installer/install-css-languageserver.cmd
@@ -1,3 +1,3 @@
 @echo off
 
-call "%~dp0\npm_install.cmd" css-languageserver vscode-css-languageserver-bin
+call "%~dp0\npm_install.cmd" css-languageserver

--- a/installer/install-css-languageserver.sh
+++ b/installer/install-css-languageserver.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-"$(dirname "$0")/npm_install.sh" css-languageserver vscode-css-languageserver-bin
+"$(dirname "$0")/npm_install.sh" css-languageserver

--- a/settings.json
+++ b/settings.json
@@ -177,17 +177,6 @@
       ]
     },
     {
-      "command": "css-languageserver",
-      "url": "https://github.com/vscode-langservers/vscode-css-languageserver-bin",
-      "description": "Binary version published on npm of vscode-css-languageserver extracted from VSCode tree",
-      "config": {
-        "refresh_pattern": "\\([a-zA-Z0-9_-]\\+\\)$"
-      },
-      "requires": [
-        "npm"
-      ]
-    },
-    {
       "command": "tailwindcss-intellisense",
       "url": "https://github.com/tailwindlabs/tailwindcss-intellisense",
       "description": "Intelligent Tailwind CSS tooling for Visual Studio Code",
@@ -928,9 +917,12 @@
   ],
   "less": [
     {
-      "command": "css-languageserver",
-      "url": "https://github.com/vscode-langservers/vscode-css-languageserver-bin",
-      "description": "Binary version published on npm of vscode-css-languageserver extracted from VSCode tree",
+      "command": "vscode-css-language-server",
+      "url": "https://github.com/hrsh7th/vscode-langservers-extracted",
+      "description": "HTML/CSS/JSON language servers extracted from vscode.",
+      "config": {
+        "refresh_pattern": "\\([a-zA-Z0-9_-]\\+\\)$"
+      },
       "requires": [
         "npm"
       ]
@@ -1483,9 +1475,12 @@
   ],
   "sass": [
     {
-      "command": "css-languageserver",
-      "url": "https://github.com/vscode-langservers/vscode-css-languageserver-bin",
-      "description": "Binary version published on npm of vscode-css-languageserver extracted from VSCode tree",
+      "command": "vscode-css-language-server",
+      "url": "https://github.com/hrsh7th/vscode-langservers-extracted",
+      "description": "HTML/CSS/JSON language servers extracted from vscode.",
+      "config": {
+        "refresh_pattern": "\\([a-zA-Z0-9_-]\\+\\)$"
+      },
       "requires": [
         "npm"
       ]
@@ -1493,9 +1488,12 @@
   ],
   "scss": [
     {
-      "command": "css-languageserver",
-      "url": "https://github.com/vscode-langservers/vscode-css-languageserver-bin",
-      "description": "Binary version published on npm of vscode-css-languageserver extracted from VSCode tree",
+      "command": "vscode-css-language-server",
+      "url": "https://github.com/hrsh7th/vscode-langservers-extracted",
+      "description": "HTML/CSS/JSON language servers extracted from vscode.",
+      "config": {
+        "refresh_pattern": "\\([a-zA-Z0-9_-]\\+\\)$"
+      },
       "requires": [
         "npm"
       ]

--- a/settings.json
+++ b/settings.json
@@ -177,6 +177,17 @@
       ]
     },
     {
+      "command": "css-languageserver",
+      "url": "https://github.com/vscode-langservers/vscode-css-languageserver-bin",
+      "description": "Binary version published on npm of vscode-css-languageserver extracted from VSCode tree",
+      "config": {
+        "refresh_pattern": "\\([a-zA-Z0-9_-]\\+\\)$"
+      },
+      "requires": [
+        "npm"
+      ]
+    },
+    {
       "command": "tailwindcss-intellisense",
       "url": "https://github.com/tailwindlabs/tailwindcss-intellisense",
       "description": "Intelligent Tailwind CSS tooling for Visual Studio Code",
@@ -926,6 +937,14 @@
       "requires": [
         "npm"
       ]
+    },
+    {
+      "command": "css-languageserver",
+      "url": "https://github.com/vscode-langservers/vscode-css-languageserver-bin",
+      "description": "Binary version published on npm of vscode-css-languageserver extracted from VSCode tree",
+      "requires": [
+        "npm"
+      ]
     }
   ],
   "lisp": [
@@ -1484,6 +1503,14 @@
       "requires": [
         "npm"
       ]
+    },
+    {
+      "command": "css-languageserver",
+      "url": "https://github.com/vscode-langservers/vscode-css-languageserver-bin",
+      "description": "Binary version published on npm of vscode-css-languageserver extracted from VSCode tree",
+      "requires": [
+        "npm"
+      ]
     }
   ],
   "scss": [
@@ -1494,6 +1521,14 @@
       "config": {
         "refresh_pattern": "\\([a-zA-Z0-9_-]\\+\\)$"
       },
+      "requires": [
+        "npm"
+      ]
+    },
+    {
+      "command": "css-languageserver",
+      "url": "https://github.com/vscode-langservers/vscode-css-languageserver-bin",
+      "description": "Binary version published on npm of vscode-css-languageserver extracted from VSCode tree",
       "requires": [
         "npm"
       ]


### PR DESCRIPTION
closed #740 .

- before:
  - ![20240501165227](https://github.com/mattn/vim-lsp-settings/assets/6778957/81fac1c3-5602-48a9-abe5-fb9d5f70cb9f)
- after:
  - ![20240501165200](https://github.com/mattn/vim-lsp-settings/assets/6778957/de02ebff-0724-494f-a429-fb396139489d)


---

`git grep vscode-css-languageserver-bin`して、関連していそうなコードを削除し、次のコードを該当箇所にコピーしました。

- https://github.com/ver-1000000/vim-lsp-settings/blob/8be483f98ebd6e1af1a3227be0540e5d360ee1cc/settings.json#L168-L178

他に考慮すべきところや問題点があればお知らせいただければと思います🙏