### PR TITLE
Fix diagnostic results with java eclipse.jdt.ls

### DIFF
--- a/installer/install-eclipse-jdt-ls.cmd
+++ b/installer/install-eclipse-jdt-ls.cmd
@@ -15,7 +15,7 @@ for %%%%F in (%%~dp0\plugins\org.eclipse.equinox.launcher_*.jar) do ( ^
 
 ) ^
 
-java -Declipse.application=org.eclipse.jdt.ls.core.id1 -Dosgi.bundles.defaultStartLevel=4 -Declipse.product=org.eclipse.jdt.ls.core.product -Dlog.protocol=true -Dlog.level=ALL -noverify -Xmx1G -javaagent:%%~dp0/lombok.jar -Xbootclasspath/a:%%~dp0/lombok.jar -jar !launcher! -configuration %%~dp0\config_win -data %%~dp0\data ^
+java -Declipse.application=org.eclipse.jdt.ls.core.id1 -Dosgi.bundles.defaultStartLevel=4 -Declipse.product=org.eclipse.jdt.ls.core.product -Dlog.protocol=true -Dlog.level=ALL -noverify -Xmx1G -javaagent:%%~dp0/lombok.jar -jar !launcher! -configuration %%~dp0\config_win -data %%~dp0\data ^
 
 > eclipse-jdt-ls.cmd
 

--- a/installer/install-eclipse-jdt-ls.sh
+++ b/installer/install-eclipse-jdt-ls.sh
@@ -19,7 +19,7 @@ cat <<EOF >eclipse-jdt-ls
 #!/bin/sh
 DIR=\$(cd \$(dirname \$0); pwd)
 LAUNCHER=\$(ls \$DIR/plugins/org.eclipse.equinox.launcher_*.jar)
-java -Declipse.application=org.eclipse.jdt.ls.core.id1 -Dosgi.bundles.defaultStartLevel=4 -Declipse.product=org.eclipse.jdt.ls.core.product -Dlog.protocol=true -Dlog.level=ALL -noverify -Xmx1G -javaagent:\$DIR/lombok.jar -Xbootclasspath/a:\$DIR/lombok.jar -jar \$LAUNCHER -configuration \$DIR/$configDir -data \$DIR/data
+java -Declipse.application=org.eclipse.jdt.ls.core.id1 -Dosgi.bundles.defaultStartLevel=4 -Declipse.product=org.eclipse.jdt.ls.core.product -Dlog.protocol=true -Dlog.level=ALL -noverify -Xmx1G -javaagent:\$DIR/lombok.jar -jar \$LAUNCHER -configuration \$DIR/$configDir -data \$DIR/data
 EOF
 
 chmod +x eclipse-jdt-ls


### PR DESCRIPTION
### Issue
 
Diagnostic restults are misssing for JAVA files with the latest version of eclipse.jdt.ls and lombok

In debug log i found:
```
Mon 13 May 2024 16:33:09 EEST:["<---",1,"eclipse-jdt-ls",{"response":{"method":"window/logMessage","jsonrpc":"2.0","params": {"message":"13 May 2024, 16:33:09 Problems occurred when invoking code from plug-in: \"org.eclipse.jdt.core\".\njavax/annotation/processing/AbstractProcessor\njava.lang.NoClassDefFoundError: javax/annotation/processing/AbstractProcessor
at java.base/java.lang.ClassLoader.findBootstrapClass(Native Method)
at java.base/java.lang.ClassLoader.findBootstrapClassOrNull(ClassLoader. java:1277)
at java.base/java.lang.System$2.findBootstrapClassOrNull(System.java:2393)
at java.base/jdk.internal.loader.ClassLoaders$BootClassLoader.loadClassOrNull(ClassLoaders.java:140)
at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:700)
at java.base/jdk.internal.loader.BuiltinClassLoader. loadClassOrNull(BuiltinClassLoader.java:676)
at java.base/jdk.internal.loader.BuiltinClassLoader. loadClassOrNull(BuiltinClassLoader.java:700)
at java.base/jdk.internal.loader.BuiltinClassLoader. loadClassOrNull(BuiltinClassLoader.java:676)
at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:639)
at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
at java.base/java. lang.ClassLoader.loadClass(ClassLoader.java:580)
at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:580)
at java. base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
at org.eclipse.jdt.apt.core.internal.AnnotationProcessorFactoryLoader.loadJava6FactoryClasses(AnnotationProcessorFactoryLoader.java:641)
at org.eclipse.jdt.apt. core.internal.AnnotationProcessorFactoryLoader.loadFactories(AnnotationProcessorFactoryLoader.java:580)
at org.eclipse.jdt.apt. core.internal.AnnotationProcessorFactoryLoader.getJava5FactoriesAndAttributesForProject(AnnotationProcessorFactoryLoader.java: 420)
at org.eclipse.jdt.apt.core.internal.AptCompilationParticipant.reconcile(AptCompilationParticipant.java:226)
at org.eclipse.jdt.internal.core.ReconcileWorkingCopyOperation$1.run(ReconcileWorkingCopyOperation.java:254)
at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:47)
at org.eclipse.jdt.internal.core.ReconcileWorkingCopyOperation.notifyParticipants(ReconcileWorkingCopyOperation.java:239)
at org.eclipse.jdt.internal.core.ReconcileWorkingCopyOperation.executeOperation(ReconcileWorkingCopyOperation.java:97)
at org.eclipse.jdt.internal.core.JavaModelOperation.run(JavaModelOperation.java:740)
at org.eclipse.jdt.internal.core.JavaModelOperation.runOperation(JavaModelOperation.java:805)
at org.eclipse.jdt.internal.core.CompilationUnit.reconcile(CompilationUnit.java:1311)
at org.eclipse.jdt.ls.core. internal.handlers.BaseDocumentLifeCycleHandler.publishDiagnostics(BaseDocumentLifeCycleHandler.java:332)
at org.eclipse.jdt.ls. core.internal.handlers.BaseDocumentLifeCycleHandler.publishDiagnostics(BaseDocumentLifeCycleHandler.java:295)
at org.eclipse. jdt.ls.core.internal.handlers.BaseDocumentLifeCycleHandler$PublishDiagnosticJob.run(BaseDocumentLifeCycleHandler.java:777)
at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)\n","type":1}}}]
```

### Reason

https://github.com/redhat-developer/vscode-java/issues/652#issuecomment-466906125
https://github.com/emacs-lsp/lsp-java/issues/54#issuecomment-553995773

`Xbootclasspath` is not required since `v1.16.0 "Candid Duck" (January 26th, 2015)`  https://projectlombok.org/changelog 