### PR TITLE
Add vtsls globalPlugins for vue/typescript-plugin

### DIFF
--- a/settings/vtsls.vim
+++ b/settings/vtsls.vim
@@ -8,6 +8,30 @@ function! Vim_lsp_settings_vtsls_get_blocklist() abort
     return []
 endfunction
 
+function! s:find_vue_plugin() abort
+  let plugin_location = lsp_settings#servers_dir() .. '/volar-server/node_modules/@vue/typescript-plugin'
+  if !isdirectory(plugin_location)
+    return v:null
+  endif
+
+  return {
+  \ 'name': '@vue/typescript-plugin',
+  \ 'location': plugin_location,
+  \ 'languages': ['vue'],
+  \ }
+endfunction
+
+function! Vim_lsp_settings_vtsls_setup_plugins() abort
+  let plugins = []
+
+  let vue_plugin = s:find_vue_plugin()
+  if !empty(vue_plugin)
+    call add(plugins, vue_plugin)
+  endif
+
+  return plugins
+endfunction
+
 augroup vim_lsp_settings_vtsls
   au!
   LspRegisterServer {
@@ -61,6 +85,11 @@ augroup vim_lsp_settings_vtsls
       \       'enumMemberValues': {
       \         'enabled': v:true,
       \       },
+      \     },
+      \   },
+      \   'vtsls': {
+      \     'tsserver': {
+      \       'globalPlugins': Vim_lsp_settings_vtsls_setup_plugins(),
       \     },
       \   },
       \ }),


### PR DESCRIPTION
Add `@vue/typescript-plugin` to globalPlugin.

ref https://github.com/yioneko/vtsls/blob/bd2df5a2d45cbc087e4fe285ec7c7396fd96e9cf/packages/service/configuration.schema.json#L1115C6-L1144

@tsukkee 
It would be very grateful if you could confirm this PR can use with `@vue/typescript-plugin` 🙏 

ref: https://github.com/mattn/vim-lsp-settings/pull/728

