### PR TITLE
fixbug: digestif init argument error

### DIFF
--- a/settings/digestif.vim
+++ b/settings/digestif.vim
@@ -4,7 +4,7 @@ augroup vim_lsp_settings_digestif
       \ 'name': 'digestif',
       \ 'cmd': {server_info->lsp_settings#get('digestif', 'cmd', [lsp_settings#exec_path('digestif')]+lsp_settings#get('digestif', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('digestif', 'root_uri', lsp_settings#root_uri('digestif'))},
-      \ 'initialization_options': lsp_settings#get('digestif', 'initialization_options', v:null),
+      \ 'initialization_options': lsp_settings#get('digestif', 'initialization_options', has('macunix') ? v:null : {'diagnostics': 'true'}),
       \ 'allowlist': lsp_settings#get('digestif', 'allowlist', ['plaintex', 'tex']),
       \ 'blocklist': lsp_settings#get('digestif', 'blocklist', []),
       \ 'config': lsp_settings#get('digestif', 'config', lsp_settings#server_config('digestif')),

--- a/settings/digestif.vim
+++ b/settings/digestif.vim
@@ -4,7 +4,7 @@ augroup vim_lsp_settings_digestif
       \ 'name': 'digestif',
       \ 'cmd': {server_info->lsp_settings#get('digestif', 'cmd', [lsp_settings#exec_path('digestif')]+lsp_settings#get('digestif', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('digestif', 'root_uri', lsp_settings#root_uri('digestif'))},
-      \ 'initialization_options': lsp_settings#get('digestif', 'initialization_options', {'diagnostics': 'true'}),
+      \ 'initialization_options': lsp_settings#get('digestif', 'initialization_options', v:null),
       \ 'allowlist': lsp_settings#get('digestif', 'allowlist', ['plaintex', 'tex']),
       \ 'blocklist': lsp_settings#get('digestif', 'blocklist', []),
       \ 'config': lsp_settings#get('digestif', 'config', lsp_settings#server_config('digestif')),


### PR DESCRIPTION
In Mac, digestif error with:"Failed to initialize digestif with error 1: /usr/local/texlive/2023/texmf-dist/scripts/digestif/digesti:110: Invalid configuration option: diagnostics = "true"