### PR TITLE
Replace rnix-lsp with nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ You can change the directory to install servers by set `g:lsp_settings_servers_d
 | Markdown          | Marksman                            |    Yes    |      Yes      |
 | Nim               | nimls                               |    No     |      No       |
 | Nix               | nixd                                |    Yes    |      Yes      |
-| Nix               | rnix-lsp                            |    Yes    |      Yes      |
+| Nix               | nil                                 |    Yes    |      Yes      |
 | PHP               | intelephense                        |    Yes    |      Yes      |
 | PHP               | psalm-language-server               |    Yes    |      Yes      |
 | OCaml             | ocaml-lsp                           | UNIX Only |      Yes      |

--- a/installer/install-nil-lsp.cmd
+++ b/installer/install-nil-lsp.cmd
@@ -1,0 +1,4 @@
+@echo off
+
+call nix-env -f -iA nixpkgs.nil
+

--- a/installer/install-nil-lsp.sh
+++ b/installer/install-nil-lsp.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+nix-env -f -iA nixpkgs.nil

--- a/settings.json
+++ b/settings.json
@@ -1039,6 +1039,14 @@
   ],
   "nix": [
     {
+      "command": "nil",
+      "url": "https://github.com/oxalica/nil",
+      "description": "Nix Language server, an incremental analysis assistant for writing in Nix",
+      "requires": [
+        "nix"
+      ]
+    },
+    {
       "command": "rnix-lsp",
       "url": "https://github.com/nix-community/rnix-lsp",
       "description": "Language server implementation for Nix",

--- a/settings/nil.vim
+++ b/settings/nil.vim
@@ -1,0 +1,14 @@
+augroup vim_lsp_settings_nil
+  au!
+  LspRegisterServer {
+      \ 'name': 'nil',
+      \ 'cmd': {server_info->lsp_settings#get('nil', 'cmd', lsp_settings#exec_path('nil'))},
+      \ 'root_uri':{server_info->lsp_settings#get('nil', 'root_uri', lsp_settings#root_uri('nil'))},
+      \ 'initialization_options': lsp_settings#get('nil', 'initialization_options', {}),
+      \ 'allowlist': lsp_settings#get('nil', 'allowlist', ['nix']),
+      \ 'blocklist': lsp_settings#get('nil', 'blocklist', []),
+      \ 'config': lsp_settings#get('nil', 'config', lsp_settings#server_config('nil')),
+      \ 'workspace_config': lsp_settings#get('nil', 'workspace_config', {}),
+      \ 'semantic_highlight': lsp_settings#get('nil', 'semantic_highlight', {}),
+      \ }
+augroup END

--- a/settings/rnix-lsp.vim
+++ b/settings/rnix-lsp.vim
@@ -10,5 +10,6 @@ augroup vim_lsp_settings_rnix_lsp
       \ 'config': lsp_settings#get('rnix-lsp', 'config', lsp_settings#server_config('rnix-lsp')),
       \ 'workspace_config': lsp_settings#get('rnix-lsp', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('rnix-lsp', 'semantic_highlight', {}),
+      \ 'deprecated': v:true,
       \ }
 augroup END


### PR DESCRIPTION
rnix is now unmaintained ( https://github.com/nix-community/rnix-lsp/commit/1e0afa406c1780e6fe74bb1cb6ddcec117df6597 ), deprecates rnix and add nil.