### PR TITLE
Fix astro-ls server not starting

### DIFF
--- a/settings/astro-ls.vim
+++ b/settings/astro-ls.vim
@@ -1,5 +1,5 @@
 function! s:get_current_ts_path() abort
-  let ts_path = '/node_modules/typescript/lib/tsserverlibrary.js'
+  let ts_path = '/node_modules/typescript/lib'
 
   let project_dir = lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), 'package.json')
   let tsserverlibrary_path = project_dir . ts_path
@@ -9,8 +9,7 @@ function! s:get_current_ts_path() abort
 
   let path = filereadable(tsserverlibrary_path) ? tsserverlibrary_path : fallback_path
   return {
-        \   'serverPath': path,
-        \   'localizedPath': v:null,
+        \   'tsdk': path,
         \ }
 endfunction
 
@@ -22,8 +21,7 @@ endfunction
 
 let g:vim_lsp_settings_astro_options = {
       \   'typescript': {
-      \     'serverPath': '',
-      \     'localizedPath': v:null,
+      \     'tsdk': '',
       \   },
       \ }
 


### PR DESCRIPTION
In astro-ls server, I got the following error and `:LspStatus` failed.

error message:
```
Failed to initialize astro-ls with error -32603: Request initialize failed with message: The `typescript.tsdk` init option is required. It should point to a directory containing a `typescript.js` or `tsserverlibrary.js` file, such as `node_modules/typescript/lib`.
```

Volar, which astro-ls depends on, now uses `tsdk` instead of `serverPath` in `initializationOptions`, so I fixed it.