### PR TITLE
remove `to .vimrc` from vimrc example

### DIFF
--- a/doc/vim-lsp-settings.txt
+++ b/doc/vim-lsp-settings.txt
@@ -43,7 +43,7 @@ NeoBundle: add below to .vimrc
 
 vim-plug: add below to .vimrc
 >
- Plug 'mattn/vim-lsp-settings' to .vimrc
+ Plug 'mattn/vim-lsp-settings'
 <
  Run :PlugInstall
 


### PR DESCRIPTION
Just notice, ` to .vimrc` is unneeded in code block, so I just remove it.