### PR TITLE
add -e switch at install-zls.sh

### DIFF
--- a/installer/install-apex-jorje-lsp.sh
+++ b/installer/install-apex-jorje-lsp.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 curl -o apex-jorje-lsp.jar -L "https://github.com/forcedotcom/salesforcedx-vscode/blob/develop/packages/salesforcedx-vscode-apex/out/apex-jorje-lsp.jar?raw=true"
 
 cat <<EOF >apex-jorje-lsp

--- a/installer/install-cl-lsp.sh
+++ b/installer/install-cl-lsp.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 
+set -e
+
 ros install cxxxr/lem cxxxr/cl-lsp

--- a/installer/install-clj-kondo-lsp.sh
+++ b/installer/install-clj-kondo-lsp.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
+
+set -e
+
 VERSION="2020.05.09"
 curl -L -o clj-kondo-lsp https://github.com/borkdude/clj-kondo/releases/download/v$VERSION/clj-kondo-lsp-server-$VERSION-standalone.jar

--- a/installer/install-fortls.sh
+++ b/installer/install-fortls.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 
+set -e
+
 "$(dirname "$0")/pip_install.sh" fortls fortran-language-server

--- a/installer/install-puppet-ls.sh
+++ b/installer/install-puppet-ls.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+
+set -e
 set -o errexit
 
 git clone --depth=1 https://github.com/puppetlabs/puppet-editor-services.git .

--- a/installer/install-racket-lsp.sh
+++ b/installer/install-racket-lsp.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 raco pkg install racket-langserver
 cat <<EOF >racket-lsp
 #!/bin/sh

--- a/installer/install-v-analyzer.sh
+++ b/installer/install-v-analyzer.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 url="https://raw.githubusercontent.com/v-analyzer/v-analyzer/master/install.vsh"
 
 # Replace hard-coded installation path "~/.config/v-analyzer" with "."

--- a/installer/install-vlang-vls.sh
+++ b/installer/install-vlang-vls.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+set -e
+
 git clone --depth=1 https://github.com/vlang/vls .
 
 echo 'Compiling vlang/vls...'

--- a/installer/install-zls.sh
+++ b/installer/install-zls.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 git clone https://github.com/zigtools/zls .
 git checkout "refs/tags/$(git tag | grep "^$(zig version | sed -r 's/\.[0-9]+$//')")"
 git submodule update --init --recursive


### PR DESCRIPTION
I don't know why `set -e` is not set, but other installer have this switch and I think it is better to set.