### PR TITLE
elixir is not needed for installing elixir-ls

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -256,9 +256,7 @@
       "command": "elixir-ls",
       "url": "https://github.com/elixir-lsp/elixir-ls",
       "description": "A frontend-independent IDE \"smartness\" server for Elixir.",
-      "requires": [
-        "elixir"
-      ],
+      "requires": [],
       "root_uri_patterns": [
         "mix.exs"
       ],


### PR DESCRIPTION
`elixir` is not needed for installing `elixir-ls`
link:
- https://github.com/mattn/vim-lsp-settings/blob/master/installer/install-elixir-ls.sh
- https://github.com/mattn/vim-lsp-settings/blob/master/installer/install-elixir-ls.cmd