### PR TITLE
Add ruff for python

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ You can change the directory to install servers by set `g:lsp_settings_servers_d
 | Python            | pylsp-all (pylsp with dependencies) |    Yes    |      Yes      |
 | Python            | pylsp (pylsp without dependencies)  |    Yes    |      Yes      |
 | Python            | pylyzer                             |    Yes    |      Yes      |
+| Python            | ruff                                |    Yes    |      Yes      |
 | Python            | ruff-lsp                            |    Yes    |      Yes      |
 | Prisma            | prisma-language-server              |    Yes    |      Yes      |
 | R                 | languageserver                      |    Yes    |      No       |

--- a/installer/install-ruff.cmd
+++ b/installer/install-ruff.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+call "%~dp0\pip_install.cmd" ruff ruff

--- a/installer/install-ruff.sh
+++ b/installer/install-ruff.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+"$(dirname "$0")/pip_install.sh" ruff ruff

--- a/settings.json
+++ b/settings.json
@@ -1387,6 +1387,22 @@
       ]
     },
     {
+      "command": "ruff",
+      "url": "https://github.com/astral-sh/ruff",
+      "description": "A language server written in Rust and built into Ruff.",
+      "requires": [
+        "py"
+      ]
+    },
+    {
+      "command": "ruff",
+      "url": "https://github.com/astral-sh/ruff",
+      "description": "A language server written in Rust and built into Ruff.",
+      "requires": [
+        "python3"
+      ]
+    },
+    {
       "command": "ruff-lsp",
       "url": "https://github.com/charliermarsh/ruff-lsp",
       "description": "A Language Server Protocol implementation for Ruff.",

--- a/settings/ruff.vim
+++ b/settings/ruff.vim
@@ -1,0 +1,14 @@
+augroup vim_lsp_settings_ruff
+  au!
+  LspRegisterServer {
+      \ 'name': 'ruff',
+      \ 'cmd': {server_info->lsp_settings#get('ruff', 'cmd', [lsp_settings#exec_path('ruff')]+lsp_settings#get('ruff', 'args', ['server']))},
+      \ 'root_uri':{server_info->lsp_settings#get('ruff', 'root_uri', lsp_settings#root_uri('ruff'))},
+      \ 'initialization_options': lsp_settings#get('ruff', 'initialization_options', v:null),
+      \ 'allowlist': lsp_settings#get('ruff', 'allowlist', ['python']),
+      \ 'blocklist': lsp_settings#get('ruff', 'blocklist', []),
+      \ 'config': lsp_settings#get('ruff', 'config', lsp_settings#server_config('ruff')),
+      \ 'workspace_config': lsp_settings#get('ruff', 'workspace_config', {}),
+      \ 'semantic_highlight': lsp_settings#get('ruff', 'semantic_highlight', {}),
+      \ }
+augroup END


### PR DESCRIPTION
Ruff had released a stabilized built-in lsp server in the [0.5.3](https://github.com/astral-sh/ruff/releases/tag/0.5.3) and [ruff-lsp is deprecating](https://astral.sh/blog/ruff-v0.4.5#whats-next)

The PR adds the ruff support according to the [official suggestion for vim-lsp](https://docs.astral.sh/ruff/editors/setup/#vim)