### PR TITLE
Add pom.xml to kotlin's root_uri patterns

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -948,6 +948,9 @@
       "requires": [
         "java"
       ],
+      "root_uri_patterns": [
+        "pom.xml"
+      ],
       "vim_plugin": {
         "extensions": [
           "kt"


### PR DESCRIPTION
Many Kotlin projects are defined with maven pom.xml's. A notable example is TeamCity's dynamic CI configuration [1].

Adding pom.xml to root_uri_patterns ensures that the workspace is initialized with the correct pom.xml for these project, including TeamCity.

[1]: https://www.jetbrains.com/help/teamcity/kotlin-dsl.html