### PR TITLE
Skip installation checks for clangd server if it has already been set up locally.

### DIFF
--- a/installer/install-clangd.sh
+++ b/installer/install-clangd.sh
@@ -98,6 +98,9 @@ filename() {
 }
 
 # Search for local clangd in PATH
+if which "clangd" >/dev/null; then
+    exit 0
+fi
 for llvm_version in $(seq 30 -1 9); do
   cmd="clangd-$llvm_version"
   if which "$cmd" >/dev/null; then

--- a/installer/install-clangd.sh
+++ b/installer/install-clangd.sh
@@ -99,6 +99,7 @@ filename() {
 
 # Search for local clangd in PATH
 if which "clangd" >/dev/null; then
+    clangd --version
     exit 0
 fi
 for llvm_version in $(seq 30 -1 9); do


### PR DESCRIPTION
In Arch Linux `clangd` comes as a part of the [clang](https://wiki.archlinux.org/title/Clang) package.

After successful installation the binaries are placed into `/usr/bin` like this:
```bash
lrwxrwxrwx 1 root root       8 Oct  3 19:11 clang -> clang-18
-rwxr-xr-x 1 root root    143K Oct  3 19:11 clang-18
-rwxr-xr-x 1 root root     25M Oct  3 19:11 clangd
-rwxr-xr-x 1 root root     99K Oct  3 19:11 clang-format
...
```
which makes `clangd` readily available:
```bash
$ clangd --version
clangd version 18.1.8
Features: linux
Platform: x86_64-pc-linux-gnu
```

Currently the `clangd` LSP server installation script [expects](https://github.com/mattn/vim-lsp-settings/blob/02cd145c223ddf1dfb3069303400946d1907ccec/installer/install-clangd.sh#L100-L109) local `clangd` binaries to be named like "clangd-X", which isn't always the case as shown above. This aborts LSP server installation with the following message "Could not find an installable clangd release!"

This PR bypasses the check when `clangd` is set up allowing LSP server installation to complete successfully.