### PR TITLE
Added `g:lsp_settings_use_install_file` config.

### DIFF
--- a/doc/vim-lsp-settings.txt
+++ b/doc/vim-lsp-settings.txt
@@ -172,6 +172,13 @@ g:lsp_settings_filetype_xxx
   one element and type of the element is |function|, vim-lsp-settings call it
   and the result is evaluated lazy.
 
+					  *g:lsp_settings_use_install_file*
+g:lsp_settings_use_install_file
+  Default: 0
+  Set 0 Look for the executable file in the PATH environment variable and
+  execute it first if found.
+  Set 1 vim-lsp-settings installed executable if available
+
 :LspSettingsLocalEdit [root]                           *:LspSettingsLocalEdit*
   Edit local settings. Accepts an optional explicit [root] directory that
   contains the .vim-lsp-settings config directory.


### PR DESCRIPTION
Added a configuration where the installer looks for the installed files first.
(See: https://github.com/mattn/vim-lsp-settings/issues/777#issuecomment-2407376356)