### PR TITLE
add serve arg to helm-ls and fix file name typo

### DIFF
--- a/settings/helm-ls.vim
+++ b/settings/helm-ls.vim
@@ -2,7 +2,7 @@ augroup vim_lsp_settings_helm_ls
   au!
   LspRegisterServer {
       \ 'name': 'helm-ls',
-      \ 'cmd': {server_info->lsp_settings#get('helm-ls', 'cmd', [lsp_settings#exec_path('helm-ls')]+lsp_settings#get('helm-ls', 'args', []))},
+      \ 'cmd': {server_info->lsp_settings#get('helm-ls', 'cmd', [lsp_settings#exec_path('helm-ls')]+lsp_settings#get('helm-ls', 'args', ['serve']))},
       \ 'root_uri':{server_info->lsp_settings#get('helm-ls', 'root_uri', lsp_settings#root_uri('helm-ls'))},
       \ 'initialization_options': lsp_settings#get('helm-ls', 'initialization_options', {}),
       \ 'capabilities': lsp_settings#get('helm-ls', 'capabilities', {}),


### PR DESCRIPTION
helm-ls requires `serve` argument to start LSP

```
$ ~/.local/share/vim-lsp-settings/servers/helm-ls/helm-ls

  /\  /\___| |_ __ ___   / / ___
 / /_/ / _ \ | '_ ' _ \ / / / __|
/ __  /  __/ | | | | | / /__\__ \
\/ /_/ \___|_|_| |_| |_\____/___/

Usage:
  helm_ls [flags]
  helm_ls [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  lint        Lint a helm project
  serve       Start helm lint language server
  version     Print current version of helm_ls

Flags:
  -h, --help   help for helm_ls

Use "helm_ls [command] --help" for more information about a command.
```