### PR TITLE
feat: Add tinymist for Typst

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ You can change the directory to install servers by set `g:lsp_settings_servers_d
 | TypeScript        | eslint-language-server              |    Yes    |      Yes      |
 | TypeScript        | biome                               |    Yes    |      Yes      |
 | Typst             | typst-lsp                           |    Yes    |      Yes      |
+| Typst             | tinymist                            |    Yes    |      Yes      |
 | Vim               | vim-language-server                 |    Yes    |      Yes      |
 | Vala              | vala-language-server                |    No     |      No       |
 | Verilog           | verible-verilog-ls                  | UNIX Only |      Yes      |

--- a/installer/install-tinymist.cmd
+++ b/installer/install-tinymist.cmd
@@ -1,0 +1,4 @@
+@echo off
+
+setlocal
+curl -L -o tinymist.exe "https://github.com/Myriad-Dreamin/tinymist/releases/latest/download/tinymist-win32-x64.exe"

--- a/installer/install-tinymist.sh
+++ b/installer/install-tinymist.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -e
+
+os="$(uname -s | tr "[:upper:]" "[:lower:]")"
+arch=$(uname -m)
+
+case $arch in
+x86_64)
+  arch="x64"
+  ;;
+arm64) ;;
+*)
+  printf "%s doesn't supported by bash installer" "$os"
+  exit 1
+  ;;
+esac
+
+case "${os}" in
+darwin) ;;
+linux) ;;
+*)
+  echo >&2 "$os is not supported"
+  exit 1
+  ;;
+esac
+
+curl -L -o tinymist "https://github.com/Myriad-Dreamin/tinymist/releases/latest/download/tinymist-${os}-${arch}"
+chmod +x tinymist

--- a/settings.json
+++ b/settings.json
@@ -1969,6 +1969,12 @@
       "url": "https://github.com/nvarner/typst-lsp",
       "description": "Language server for Typst",
       "requires": []
+    },
+    {
+      "command": "tinymist",
+      "url": "https://github.com/Myriad-Dreamin/tinymist",
+      "description": "An integrated language service for Typst",
+      "requires": []
     }
   ],
   "typst": [
@@ -1976,6 +1982,12 @@
       "command": "typst-lsp",
       "url": "https://github.com/nvarner/typst-lsp",
       "description": "Language server for Typst",
+      "requires": []
+    },
+    {
+      "command": "tinymist",
+      "url": "https://github.com/Myriad-Dreamin/tinymist",
+      "description": "An integrated language service for Typst",
       "requires": []
     }
   ],

--- a/settings/tinymist.vim
+++ b/settings/tinymist.vim
@@ -1,0 +1,14 @@
+augroup vim_lsp_settings_tinymist
+  au!
+  LspRegisterServer {
+      \ 'name': 'tinymist',
+      \ 'cmd': {server_info->lsp_settings#get('tinymist', 'cmd', [lsp_settings#exec_path('tinymist')]+lsp_settings#get('tinymist', 'args', ['lsp']))},
+      \ 'root_uri':{server_info->lsp_settings#get('tinymist', 'root_uri', lsp_settings#root_uri('tinymist'))},
+      \ 'initialization_options': lsp_settings#get('tinymist', 'initialization_options', v:null),
+      \ 'allowlist': lsp_settings#get('tinymist', 'allowlist', ['typst', 'typ']),
+      \ 'blocklist': lsp_settings#get('tinymist', 'blocklist', []),
+      \ 'config': lsp_settings#get('tinymist', 'config', lsp_settings#server_config('tinymist')),
+      \ 'workspace_config': lsp_settings#get('tinymist', 'workspace_config', {}),
+      \ 'semantic_highlight': lsp_settings#get('tinymist', 'semantic_highlight', {}),
+      \ }
+augroup END


### PR DESCRIPTION
Add tinymist language server for Typst.

- tinymist: https://github.com/Myriad-Dreamin/tinymist
    - tinymist releases: https://github.com/Myriad-Dreamin/tinymist/releases
- Typst: https://github.com/typst/typst

The command-line argument is from this instruction: https://github.com/Myriad-Dreamin/tinymist/tree/main/crates/tinymist/README.md

Anyway, currently typst-lsp is available for Typst with vim-lsp-settings, but now it's deprecated.  So if you would like to do, I'll remove configurations of typst-lsp.  How do you think, @mattn ?
- typst-lsp: https://github.com/nvarner/typst-lsp