### PR TITLE
fix: command-line completion of LspInstallServer

### DIFF
--- a/autoload/lsp_settings.vim
+++ b/autoload/lsp_settings.vim
@@ -328,7 +328,8 @@ endfunction
 function! lsp_settings#complete_install(arglead, cmdline, cursorpos) abort
   let l:installers = []
 
-  for l:ft in split(&filetype . '.', '\.', 1)
+  let l:filetype = getcmdwintype() !=# '' && getcmdtype() ==# '' ? getbufvar('#', '&filetype') : &filetype
+  for l:ft in split(l:filetype . '.', '\.', 1)
     let l:ft = tolower(empty(l:ft) ? '_' : l:ft)
     if !has_key(s:settings, l:ft)
       continue


### PR DESCRIPTION
In cmdwin, LspInstallServer's completion always returns LSP(s) for Vim script regardless of the current buffer's filetype.  This PR fixes this.

**Reproduce steps**

- Prepare this `vimrc.vim`

```vim
set nocompatible
set runtimepath^=~/.cache/vim/pack/minpac/opt/vim-lsp
set runtimepath^=~/.cache/vim/pack/minpac/opt/vim-lsp-settings
```

- Run Vim with: `vim -u vimrc.vim`
- Open dummy Go file: `:e test.go`
- Check completion candidates in command-line: `:LspInstallServer<Space><C-d>`
    - Language servers for Go, such as gopls, will be presented.
    - In my environment, efm-langserver, golangci-lint-langserver, and gopls are shown.
- Cancel completion and open cmdwin with `<C-f>` (Type `<C-f>` without leaving command-line.)
- Trigger completion with `i<Tab>`
- `efm-langserver` and `vim-language-server` are shown as completion candidates.
    -  This is different from the completion on command-line.

**Environment**

- Vim 9.1.923
- vim-lsp: https://github.com/prabirshrestha/vim-lsp/commit/04428c920002ac7cfacbecacb070a8af57b455d0
- vim-lsp-settings: 9cf5846

(Both vim-lsp and vim-lsp-settings are the latest at the present time.)