### PR TITLE
fix: do not enable steep if Steepfile is not exist to resolve #756

### DIFF
--- a/settings/steep.vim
+++ b/settings/steep.vim
@@ -5,7 +5,7 @@ augroup vim_lsp_settings_steep
       \ 'cmd': {server_info->lsp_settings#get('steep', 'cmd', [lsp_settings#exec_path('steep'), 'langserver', printf('--steepfile=%s', lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'Steepfile'))]+lsp_settings#get('steep', 'args', []))},
       \ 'root_uri': {server_info->lsp#utils#path_to_uri(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), 'Steepfile'))},
       \ 'initialization_options': lsp_settings#get('steep', 'initialization_options', {'diagnostics': 'true'}),
-      \ 'allowlist': lsp_settings#get('steep', 'allowlist', {x->empty(lsp_settings#root_path(['Steepfile'])) ? [] : ['ruby']}),
+      \ 'allowlist': lsp_settings#get('steep', 'allowlist', {x->empty(lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'Steepfile')) ? [] : ['ruby']}),
       \ 'blocklist': lsp_settings#get('steep', 'blocklist', []),
       \ 'config': lsp_settings#get('steep', 'config', lsp_settings#server_config('steep')),
       \ 'workspace_config': lsp_settings#get('steep', 'workspace_config', {}),


### PR DESCRIPTION
According to https://github.com/mattn/vim-lsp-settings/issues/756#issuecomment-2307006065 the `lsp_settings#root_path(['Steepfile'])` cannot detect `Steepfile` correctly.

I referenced the `typescript-language-server.vim` and changed it to `lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'Steepfile')`, and the issue was resolved.