### PR TITLE
fix: Change rust-analyzer binary download URL for Windows.

### DIFF
--- a/installer/install-rust-analyzer.cmd
+++ b/installer/install-rust-analyzer.cmd
@@ -1,7 +1,6 @@
 @echo off
 
 setlocal
-curl -L -o "rust-analyzer-windows.gz" "https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/rust-analyzer-x86_64-pc-windows-msvc.gz"
-call "%~dp0\run_gzip.cmd" rust-analyzer-windows.gz
-
-move rust-analyzer-windows rust-analyzer.exe
+curl -L -o "rust-analyzer-windows.zip" "https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/rust-analyzer-x86_64-pc-windows-msvc.zip"
+call "%~dp0\run_unzip.cmd" rust-analyzer-windows.zip
+del rust-analyzer-windows.zip rust_analyzer.pdb


### PR DESCRIPTION
In the latest [rust-analyzer releases](https://github.com/rust-lang/rust-analyzer/releases), gzip Windows binaries are no longer included. 
Therefore, I have updated the installer to download the zip archive instead.