### PR TITLE
Fix install-powershell-languageserver.cmd caused pwsh server no start

### DIFF
--- a/installer/install-powershell-languageserver.cmd
+++ b/installer/install-powershell-languageserver.cmd
@@ -15,6 +15,6 @@ set PSES_BUNDLE_PATH=%%~dp0^
 
 set SESSION_TEMP_PATH=%%~dp0session^
 
-powershell -NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command ^"%%PSES_BUNDLE_PATH: =` %%\PowerShellEditorServices\Start-EditorServices.ps1^" -BundledModulesPath '%%PSES_BUNDLE_PATH%%' -LogPath '%%SESSION_TEMP_PATH%%\logs.log' -SessionDetailsPath '%%SESSION_TEMP_PATH%%\session.json' -FeatureFlags @() -AdditionalModules @() -HostName 'My Client' -HostProfileId 'myclient' -HostVersion 1.0.0 -Stdio -LogLevel Normal^
+powershell -NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command ^"%%PSES_BUNDLE_PATH%%\PowerShellEditorServices\Start-EditorServices.ps1 -BundledModulesPath '%%PSES_BUNDLE_PATH%%' -LogPath '%%SESSION_TEMP_PATH%%\logs.log' -SessionDetailsPath '%%SESSION_TEMP_PATH%%\session.json' -FeatureFlags @() -AdditionalModules @() -HostName 'My Client' -HostProfileId 'myclient' -HostVersion 1.0.0 -Stdio -LogLevel Normal^"^
 
 > powershell-languageserver.cmd


### PR DESCRIPTION
I'm not very familiar with the syntax in this cmd file, but I think ``%PSES_BUNDLE_PATH: =` %`` is not a standard cmd syntax. Also, moving the double quotes (which are ^" here) to the end caused PSES to remain in the "starting" state.