### PR TITLE
Switch to pwsh

### DIFF
--- a/installer/install-powershell-languageserver.cmd
+++ b/installer/install-powershell-languageserver.cmd
@@ -7,14 +7,10 @@ call "%~dp0\run_unzip.cmd" PowerShellEditorServices.zip
 del PowerShellEditorServices.zip
 if not exist "%~dp0session" mkdir "%~dp0session"
 
-echo @echo off^
-
-setlocal^
-
-set PSES_BUNDLE_PATH=%%~dp0^
-
-set SESSION_TEMP_PATH=%%~dp0session^
-
-powershell -NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command ^"%%PSES_BUNDLE_PATH%%\PowerShellEditorServices\Start-EditorServices.ps1 -BundledModulesPath '%%PSES_BUNDLE_PATH%%' -LogPath '%%SESSION_TEMP_PATH%%\logs.log' -SessionDetailsPath '%%SESSION_TEMP_PATH%%\session.json' -FeatureFlags @() -AdditionalModules @() -HostName 'My Client' -HostProfileId 'myclient' -HostVersion 1.0.0 -Stdio -LogLevel Normal^"^
-
-> powershell-languageserver.cmd
+(
+ECHO @echo off
+ECHO setlocal
+ECHO set PSES_BUNDLE_PATH=%%~dp0
+ECHO set SESSION_TEMP_PATH=%%~dp0session
+ECHO pwsh -NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command "%%PSES_BUNDLE_PATH%%\PowerShellEditorServices\Start-EditorServices.ps1 -BundledModulesPath '%%PSES_BUNDLE_PATH%%' -LogPath '%%SESSION_TEMP_PATH%%\logs.log' -SessionDetailsPath '%%SESSION_TEMP_PATH%%\session.json' -FeatureFlags @() -AdditionalModules @() -HostName 'My Client' -HostProfileId 'myclient' -HostVersion 1.0.0 -Stdio -LogLevel Normal"
+) > powershell-languageserver.cmd


### PR DESCRIPTION
according to [Supported PowerShell Versions](https://github.com/PowerShell/PowerShellEditorServices?tab=readme-ov-file#supported-powershell-versions) and my tests, the powershell-language-server only work in pwsh core 7+.

I also modified the code to make the cmd file generated by the installer in CRLF format.