### PR TITLE
Add bacon-ls

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ You can change the directory to install servers by set `g:lsp_settings_servers_d
 | Ruby              | sorbet                              |    Yes    |      No       |
 | Rust              | rls                                 |    Yes    |      No       |
 | Rust              | rust-analyzer                       |    Yes    |      Yes      |
+| Rust              | bacon-ls                            |    Yes    |      Yes      |
 | Sphinx            | esbonio                             |    Yes    |      Yes      |
 | SQL               | sql-language-server                 |    Yes    |      Yes      |
 | SQL               | sqls                                |    Yes    |      Yes      |
@@ -284,6 +285,25 @@ subdictionaries (`cargo`, `completion`, `procMacro`, etc.) in your
 | Colored Diagnostic Output       | ❌     |
 | Dependency Tree                 | ❌     |
 | View Recursive Memory Layout    | ❌     |
+
+### [bacon-ls](https://github.com/crisidev/bacon-ls) (Rust)
+
+The `bacon` command is required. If not exists, it will be installed globally.
+
+`bacon-ls` is not a replacement for `rust-analyzer`, they can be used together. The workspace folders feature is required. Therefore, the following configuration is necessary:
+```vim
+let g:lsp_experimental_workspace_folders = 1
+let g:lsp_settings_filetype_rust = ['rust-analyzer', 'bacon-ls']
+let g:lsp_settings = {
+\ 'rust-analyzer': {
+\   'initialization_options': {
+\     'checkOnSave': v:false,
+\     'diagnostics': v:false,
+\   },
+\}
+```
+
+For detailed configuration options, please refer to the [`bacon-ls` configuration documentation](https://github.com/crisidev/bacon-ls/blob/main/README.md#configuration).
 
 ### deno (TypeScript)
 

--- a/installer/install-bacon-ls.cmd
+++ b/installer/install-bacon-ls.cmd
@@ -1,0 +1,26 @@
+@echo off
+
+setlocal
+
+set PLATFORM=x86_64-pc-windows-msvc
+
+rem Get latest release version
+for /f "tokens=7 delims=/" %%i in ('curl -si "https://github.com/crisidev/bacon-ls/releases/latest" ^| findstr /i "location:"') do (
+    set "VERSION=%%i"
+)
+
+rem Install bacon-ls
+curl -L -o "bacon-ls.zip" "https://github.com/crisidev/bacon-ls/releases/download/%VERSION%/bacon-ls-%VERSION%-%PLATFORM%.zip"
+call "%~dp0\run_unzip.cmd" bacon-ls.zip
+move /Y "target\%PLATFORM%\release\bacon-ls.exe" .
+del /F bacon-ls.zip
+rd /S /Q target
+echo bacon-ls
+.\bacon-ls.exe --version
+
+rem Install bacon
+where bacon >/dev/null 2>&1
+if errorlevel 1 (
+    cargo install --locked bacon
+)
+bacon --version

--- a/installer/install-bacon-ls.sh
+++ b/installer/install-bacon-ls.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+
+set -e
+
+os=$(uname -s | tr "[:upper:]" "[:lower:]")
+arch="$(uname -m)"
+ext="tar.gz"
+
+case $os in
+linux)
+  if [ "$arch" = "x86_64" ]; then
+    platform="x86_64-unknown-linux-gnu"
+  elif [ "$arch" = "aarch64" ]; then
+    platform="aarch64-unknown-linux-gnu"
+  else
+    echo "unknown architecture: $arch"
+    exit 1
+  fi
+  ;;
+darwin)
+  if [ "$arch" = "x86_64" ]; then
+    platform="x86_64-apple-darwin"
+  elif [ "$arch" = "aarch64" ] || [ "$arch" = "arm64" ]; then
+    platform="aarch64-apple-darwin"
+  else
+    echo "unknown architecture: $arch"
+    exit 1
+  fi
+  ;;
+mingw64_nt*)
+  if [ "$arch" = "x86_64" ]; then
+    platform="x86_64-pc-windows-msvc"
+  elif [ "$arch" = "aarch64" ] || [ "$arch" = "arm64" ]; then
+    platform="aarch64-pc-windows-msvc"
+  else
+    echo "unknown architecture: $arch"
+    exit 1
+  fi
+  ext="zip"
+  ;;
+*)
+  echo "unknow platform: $os"
+  exit 1
+  ;;
+esac
+
+# Get latest release version
+version=$(curl -si 'https://github.com/crisidev/bacon-ls/releases/latest' | grep -ioE '^location: \S+')
+version=${version##*/}
+
+# Install bacon-ls
+curl -L -o "bacon-ls.$ext" "https://github.com/crisidev/bacon-ls/releases/download/$version/bacon-ls-$version-$platform.$ext"
+if [ "$ext" = "zip" ]; then
+  unzip "bacon-ls.$ext"
+  mv "target/$platform/release/bacon-ls.exe" .
+  rm -rf "target"
+else
+  tar -xf "bacon-ls.$ext"
+fi
+rm -rf "bacon-ls.$ext"
+echo "bacon-ls"
+./bacon-ls --version
+
+# Install bacon
+if ! which bacon >/dev/null 2>&1; then
+  cargo install --locked bacon
+fi
+bacon --version

--- a/settings.json
+++ b/settings.json
@@ -1589,6 +1589,18 @@
       "root_uri_patterns": [
         "Cargo.toml"
       ]
+    },
+    {
+      "command": "bacon-ls",
+      "url": "https://github.com/crisidev/bacon-ls",
+      "description": "A Language Server for Rust using Bacon diagnostics",
+      "requires": [
+        "cargo"
+      ],
+      "root_uri_patterns": [
+        "bacon.toml",
+        "Cargo.lock"
+      ]
     }
   ],
   "sass": [

--- a/settings/bacon-ls.vim
+++ b/settings/bacon-ls.vim
@@ -1,0 +1,14 @@
+augroup vim_lsp_settings_bacon_ls
+  au!
+  LspRegisterServer {
+      \ 'name': 'bacon-ls',
+      \ 'cmd': {server_info->lsp_settings#get('bacon-ls', 'cmd', [lsp_settings#exec_path('bacon-ls')]+lsp_settings#get('bacon-ls', 'args', []))},
+      \ 'root_uri':{server_info->lsp_settings#get('bacon-ls', 'root_uri', lsp_settings#root_uri('bacon-ls'))},
+      \ 'initialization_options': lsp_settings#get('bacon-ls', 'initialization_options', {}),
+      \ 'allowlist': lsp_settings#get('bacon-ls', 'allowlist', ['rust']),
+      \ 'blocklist': lsp_settings#get('bacon-ls', 'blocklist', []),
+      \ 'config': lsp_settings#get('bacon-ls', 'config', lsp_settings#server_config('bacon-ls')),
+      \ 'workspace_config': lsp_settings#get('bacon-ls', 'workspace_config', {}),
+      \ 'semantic_highlight': lsp_settings#get('bacon-ls', 'semantic_highlight', {}),
+      \ }
+augroup END


### PR DESCRIPTION
[`bacon-ls`](https://github.com/crisidev/bacon-ls) is a Language Server for Rust using [`bacon`](https://dystroy.org/bacon/) diagnostics.