### PR TITLE
Add fennel-ls installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ You can change the directory to install servers by set `g:lsp_settings_servers_d
 | Erlang            | erlang-ls                           |    Yes    |      Yes      |
 | F#                | fsautocomplete                      |    Yes    |      Yes      |
 | F#                | fsharp-language-server              |    Yes    |      Yes      |
+| Fennel            | fennel-ls                           |    Yes    |      Yes      |
 | Fortran           | fortls                              |    Yes    |      Yes      |
 | Go                | gopls                               |    Yes    |      Yes      |
 | Go                | golangci-lint-langserver            |    Yes    |      Yes      |

--- a/installer/install-fennel-ls.cmd
+++ b/installer/install-fennel-ls.cmd
@@ -1,0 +1,31 @@
+@echo off
+
+:check_bash
+IF EXIST "C:\Program Files\Git\bin\bash.exe" (
+  echo Detected: Git Bash x64
+  set BASH="C:\Program Files\Git\bin\bash.exe"
+) ELSE IF EXIST "C:\Program Files (x86)\Git\bin\bash.exe" (
+  echo Detected: Git Bash x86
+  set BASH="C:\Program Files (x86)\Git\bin\bash.exe"
+) ELSE (
+  echo Git Bash not found. Please install Git for Windows.
+  echo example:
+  echo  winget install Git.Git
+  goto :exit
+)
+
+echo BASH=%BASH%
+
+:make
+copy "%~dp0install-fennel-ls.sh" "%cd%\install-fennel-ls.sh"
+%BASH% -c "./install-fennel-ls.sh"
+
+:makebat
+echo FIXME: Workaround - need to create a dummy .bat file since vim-lsp-settings verifies the executable's existence.
+echo Creating dummy file: fennel-ls.bat
+echo "" > fennel-ls.bat
+
+:clean
+del "%cd%\install-fennel-ls.sh"
+
+:exit

--- a/installer/install-fennel-ls.sh
+++ b/installer/install-fennel-ls.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+git clone https://git.sr.ht/~xerool/fennel-ls src
+cd src/
+make
+cp fennel-ls ../
+cd ../
+rm -rf src/

--- a/settings.json
+++ b/settings.json
@@ -323,6 +323,17 @@
       }
     }
   ],
+  "fennel": [
+    {
+      "command": "fennel-ls",
+      "url": "https://git.sr.ht/~xerool/fennel-ls",
+      "description": "Provides intelligent editing features for fennel files.",
+      "requires": [
+        "lua",
+        "make"
+      ]
+    }
+  ],
   "fortran": [
     {
       "command": "fortls",

--- a/settings/fennel-ls.vim
+++ b/settings/fennel-ls.vim
@@ -1,0 +1,19 @@
+augroup vim_lsp_settings_fennel_ls
+  au!
+  if has('win32') || has('win64')
+    let Fennel_ls_cmd = {server_info->lsp_settings#get('fennel-ls', 'cmd', ['lua.exe', lsp_settings#servers_dir().'\fennel-ls\fennel-ls']+lsp_settings#get('fennel-ls', 'args', []))}
+  else
+    let Fennel_ls_cmd = {server_info->lsp_settings#get('fennel-ls', 'cmd', [lsp_settings#exec_path('fennel-ls')]+lsp_settings#get('fennel-ls', 'args', []))}
+  endif
+  LspRegisterServer {
+        \ 'name': 'fennel-ls',
+        \ 'cmd': Fennel_ls_cmd,
+        \ 'root_uri':{server_info->lsp_settings#get('fennel-ls', 'root_uri', lsp_settings#root_uri('fennel-ls'))},
+        \ 'initialization_options': lsp_settings#get('fennel-ls', 'initialization_options', v:null),
+        \ 'allowlist': lsp_settings#get('fennel-ls', 'allowlist', ['fennel']),
+        \ 'blocklist': lsp_settings#get('fennel-ls', 'blocklist', []),
+        \ 'config': lsp_settings#get('fennel-ls', 'config', lsp_settings#server_config('fennel-ls')),
+        \ 'workspace_config': lsp_settings#get('fennel-ls', 'workspace_config', {}),
+        \ 'semantic_highlight': lsp_settings#get('fennel-ls', 'semantic_highlight', {}),
+        \ }
+augroup END


### PR DESCRIPTION
Fennel - a Lisp-like language for Lua - is effective for developing Neovim configurations and plugins.

This pull request is a re-submission of #804.

Changes:
– The implementation now references the official fennel-ls repository, rather than my fork.