### PR TITLE
Update Volar (Vue Language Tools) to v3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,10 +429,10 @@ For more details, please see [Sorbet](https://sorbet.org/docs/vscode#installing-
 
 ### [volar (Vue Language Tools)](https://github.com/vuejs/language-tools)
 
-To enable full Vue support, both `typescript-language-server` and `volar-server` should be installed and enabled in `vue` filetype.
+To enable Vue support, both `vtsls` and `volar-server` should be installed and enabled in `vue` filetype.
 
 ```vim
-let g:lsp_settings_filetype_vue = ['typescript-language-server', 'volar-server']
+let g:lsp_settings_filetype_vue = ['vtsls', 'volar-server']
 ```
 
 ## Extra Configurations

--- a/installer/install-volar-server.cmd
+++ b/installer/install-volar-server.cmd
@@ -1,5 +1,5 @@
 @echo off
 
-call "%~dp0\npm_install.cmd" vue-language-server @vue/language-server@~2.1.0
+call "%~dp0\npm_install.cmd" vue-language-server @vue/language-server@^3.0.0
 ren vue-language-server.cmd volar-server.cmd
-call npm install typescript@5.5.4
+call npm install typescript@5.8.3

--- a/installer/install-volar-server.sh
+++ b/installer/install-volar-server.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-"$(dirname "$0")/npm_install.sh" vue-language-server @vue/language-server@~2.1.0
+"$(dirname "$0")/npm_install.sh" vue-language-server @vue/language-server@^3.0.0
 mv vue-language-server volar-server
-npm install typescript@5.5.4
+npm install typescript@5.8.3

--- a/settings.json
+++ b/settings.json
@@ -2147,18 +2147,6 @@
       }
     },
     {
-      "command": "typescript-language-server",
-      "url": "https://github.com/typescript-language-server/typescript-language-server",
-      "description": "TypeScript & JavaScript Language Server",
-      "requires": [
-        "npm"
-      ],
-      "root_uri_patterns": [
-        "package.json",
-        "tsconfig.json"
-      ]
-    },
-    {
       "command": "vtsls",
       "url": "https://github.com/yioneko/vtsls",
       "description": "LSP wrapper for typescript extension of vscode",

--- a/settings/typescript-language-server.vim
+++ b/settings/typescript-language-server.vim
@@ -1,35 +1,11 @@
 function! Vim_lsp_settings_typescript_language_server_get_blocklist() abort
     if empty(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), 'node_modules/'))
-        return ['typescript', 'javascript', 'typescriptreact', 'javascriptreact', 'vue']
+        return ['typescript', 'javascript', 'typescriptreact', 'javascriptreact']
     endif
     if !empty(lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'deno.json'))
-        return lsp_settings#utils#warning('server "typescript-language-server" is disabled since "deno.json" is found', ['typescript', 'javascript', 'typescriptreact', 'javascriptreact', 'vue'])
+        return lsp_settings#utils#warning('server "typescript-language-server" is disabled since "deno.json" is found', ['typescript', 'javascript', 'typescriptreact', 'javascriptreact'])
     endif
     return []
-endfunction
-
-function! s:find_vue_plugin() abort
-  let plugin_location = lsp_settings#servers_dir() .. '/volar-server/node_modules/@vue/typescript-plugin'
-  if !isdirectory(plugin_location)
-    return v:null
-  endif
-
-  return {
-  \ 'name': '@vue/typescript-plugin',
-  \ 'location': plugin_location,
-  \ 'languages': ['vue'],
-  \ }
-endfunction
-
-function! Vim_lsp_settings_typescript_language_server_setup_plugins() abort
-  let plugins = []
-
-  let vue_plugin = s:find_vue_plugin()
-  if !empty(vue_plugin)
-    call add(plugins, vue_plugin)
-  endif
-
-  return plugins
 endfunction
 
 augroup vim_lsp_settings_typescript_language_server
@@ -48,9 +24,8 @@ augroup vim_lsp_settings_typescript_language_server
       \     'includeInlayEnumMemberValueHints': v:true,
       \     'includeInlayFunctionLikeReturnTypeHints': v:true
       \   },
-      \   'plugins': Vim_lsp_settings_typescript_language_server_setup_plugins(),
       \ }),
-      \ 'allowlist': lsp_settings#get('typescript-language-server', 'allowlist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact', 'typescript.tsx', 'vue']),
+      \ 'allowlist': lsp_settings#get('typescript-language-server', 'allowlist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact', 'typescript.tsx']),
       \ 'blocklist': lsp_settings#get('typescript-language-server', 'blocklist', Vim_lsp_settings_typescript_language_server_get_blocklist()),
       \ 'config': lsp_settings#get('typescript-language-server', 'config', lsp_settings#server_config('typescript-language-server')),
       \ 'workspace_config': lsp_settings#get('typescript-language-server', 'workspace_config', {}),

--- a/settings/volar-server.vim
+++ b/settings/volar-server.vim
@@ -14,10 +14,13 @@ augroup END
 function s:on_tsserver_request(id, data) abort
   let body = a:data['response']['result']['body']
 
-  call lsp#notification('volar-server', {
-  \   'method': 'tsserver/response',
-  \   'params': [a:id, body]
-  \ })
+  call lsp#callbag#pipe(
+    \ lsp#notification('volar-server', {
+    \   'method': 'tsserver/response',
+    \   'params': [[a:id, body]]
+    \ }),
+    \ lsp#callbag#subscribe()
+    \ )
 endfunction
 
 function s:on_notification(server_name, data) abort

--- a/settings/volar-server.vim
+++ b/settings/volar-server.vim
@@ -55,18 +55,16 @@ function! s:on_lsp_buffer_enabled() abort
   " cf. https://github.com/vuejs/language-tools/wiki/Neovim
   call lsp#register_notifications('volar-server', function('s:on_notification'))
 
-  " check typescript-language-server
-  let ts_server_dir = lsp_settings#servers_dir() .. '/typescript-language-server'
+  " check vtsls installation
   let vtsls_server_dir = lsp_settings#servers_dir() .. '/vtsls'
-  if !isdirectory(ts_server_dir) && !isdirectory(vtsls_server_dir)
-    call lsp_settings#utils#warning('Please install typescript-language-server or vtsls to enable Vue support')
+  if !isdirectory(vtsls_server_dir)
+    call lsp_settings#utils#warning('Please install vtsls to enable Vue support')
   endif
 
   if !exists('g:lsp_settings_filetype_vue') ||
   \ index(g:lsp_settings_filetype_vue, 'volar-server') == -1 ||
-  \ (index(g:lsp_settings_filetype_vue, 'typescript-language-server') == -1 &&
-  \  index(g:lsp_settings_filetype_vue, 'vtsls') == -1)
-    call lsp_settings#utils#warning('''volar-server'' and one of ''typescript-language-server'' and ''vtsls'' should be included in g:lsp_settings_filetype_vue to enable Vue support')
+  \ index(g:lsp_settings_filetype_vue, 'vtsls') == -1
+    call lsp_settings#utils#warning('Add both ''volar-server'' and ''vtsls'' to g:lsp_settings_filetype_vue to enable Vue support')
   endif
 endfunction
 

--- a/settings/vtsls.vim
+++ b/settings/vtsls.vim
@@ -18,6 +18,7 @@ function! s:find_vue_plugin() abort
   \ 'name': '@vue/typescript-plugin',
   \ 'location': plugin_location,
   \ 'languages': ['vue'],
+  \ 'configNamespace': 'typescript',
   \ }
 endfunction
 


### PR DESCRIPTION
There are 2 breaking changes according to the upgrade guide [^1].
* TypeScript Language Server and Vue Language Server now communicate on LSP protocol, previously they did it on named pipes, so I added some code to do that by follwoing Neovim example [^2]
  * And, now only vtsls is supported becuase typescript-language-server doesn't support this communication method right now
* `typescript.tsdk` option has dropped so I just removed it.


[^1]: https://github.com/vuejs/language-tools/discussions/5456
[^2]: https://github.com/vuejs/language-tools/wiki/Neovim