### PR TITLE
Check vtsls is used for Vue Language Tools (volar-server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,10 +450,12 @@ For more details, please see [Sorbet](https://sorbet.org/docs/vscode#installing-
 
 ### [volar (Vue Language Tools)](https://github.com/vuejs/language-tools)
 
-To enable Vue support, both `vtsls` and `volar-server` should be installed and enabled in `vue` filetype.
+Vue Language Tools v3 works only with `vtsls`, which is another TypeScript Language Server implementation.
+So, you need to install both `vtsls` and `volar-server` and specify them to be used with the following code:
 
 ```vim
 let g:lsp_settings_filetype_vue = ['vtsls', 'volar-server']
+let g:lsp_settings_filetype_typescript = ['vtsls']
 ```
 
 ## Extra Configurations

--- a/settings/volar-server.vim
+++ b/settings/volar-server.vim
@@ -66,6 +66,11 @@ function! s:on_lsp_buffer_enabled() abort
   \ index(g:lsp_settings_filetype_vue, 'vtsls') == -1
     call lsp_settings#utils#warning('Add both ''volar-server'' and ''vtsls'' to g:lsp_settings_filetype_vue to enable Vue support')
   endif
+
+  if !exists('g:lsp_settings_filetype_typescript') ||
+  \ index(g:lsp_settings_filetype_vue, 'vtsls') == -1
+    call lsp_settings#utils#warning('Set ''vtsls'' to g:lsp_settings_filetype_typescript to enable Vue support')
+  endif
 endfunction
 
 augroup lsp_install_volar_server


### PR DESCRIPTION
`vtsls` should be used also in .ts file for cast that .ts file refers .vue file.
So, I added code to check the setting, and update README.