### PR TITLE
Add Ty settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ You can change the directory to install servers by set `g:lsp_settings_servers_d
 | Python            | pylyzer                             |    Yes    |      Yes      |
 | Python            | ruff                                |    Yes    |      Yes      |
 | Python            | ruff-lsp                            |    Yes    |      Yes      |
+| Python            | ty                                  |    Yes    |      Yes      |
 | Prisma            | prisma-language-server              |    Yes    |      Yes      |
 | Qml               | qmlls                               |    Yes    |      Yes      |
 | R                 | languageserver                      |    Yes    |      No       |
@@ -436,7 +437,7 @@ directories from the qt install root.
  \}
 
  By default, the qmlls server will search the QML_IMPORT PATH (-E option).
- ```
+```
 
 ### [rubocop lsp mode (Ruby)](https://docs.rubocop.org/rubocop/usage/lsp.html)
 

--- a/data/catalog.json
+++ b/data/catalog.json
@@ -4952,6 +4952,12 @@
       "url": "https://raw.githubusercontent.com/rliebz/tusk/main/tusk.schema.json"
     },
     {
+      "name": "Ty",
+      "description": "Ty, An extremely fast Python type checker and language server.",
+      "fileMatch": ["ty.toml", ".ty.toml"],
+      "url": "https://json.schemastore.org/ty.json"
+    },
+    {
       "name": "typewiz.json",
       "description": "Typewiz configuration file",
       "fileMatch": ["typewiz.json"],

--- a/installer/install-ty.cmd
+++ b/installer/install-ty.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+call "%~dp0\pip_install.cmd" ty ty

--- a/installer/install-ty.sh
+++ b/installer/install-ty.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+"$(dirname "$0")/pip_install.sh" ty ty

--- a/settings.json
+++ b/settings.json
@@ -323,6 +323,17 @@
       }
     }
   ],
+  "fennel": [
+    {
+      "command": "fennel-ls",
+      "url": "https://git.sr.ht/~xerool/fennel-ls",
+      "description": "Provides intelligent editing features for fennel files.",
+      "requires": [
+        "lua",
+        "make"
+      ]
+    }
+  ],
   "fortran": [
     {
       "command": "fortls",
@@ -1631,6 +1642,18 @@
       "root_uri_patterns": [
         "Cargo.toml"
       ]
+    },
+    {
+      "command": "bacon-ls",
+      "url": "https://github.com/crisidev/bacon-ls",
+      "description": "A Language Server for Rust using Bacon diagnostics",
+      "requires": [
+        "cargo"
+      ],
+      "root_uri_patterns": [
+        "bacon.toml",
+        "Cargo.lock"
+      ]
     }
   ],
   "sass": [
@@ -2161,18 +2184,6 @@
         ],
         "name": "leafOfTree/vim-vue-plugin"
       }
-    },
-    {
-      "command": "typescript-language-server",
-      "url": "https://github.com/typescript-language-server/typescript-language-server",
-      "description": "TypeScript & JavaScript Language Server",
-      "requires": [
-        "npm"
-      ],
-      "root_uri_patterns": [
-        "package.json",
-        "tsconfig.json"
-      ]
     },
     {
       "command": "vtsls",

--- a/settings.json
+++ b/settings.json
@@ -323,17 +323,6 @@
       }
     }
   ],
-  "fennel": [
-    {
-      "command": "fennel-ls",
-      "url": "https://git.sr.ht/~xerool/fennel-ls",
-      "description": "Provides intelligent editing features for fennel files.",
-      "requires": [
-        "lua",
-        "make"
-      ]
-    }
-  ],
   "fortran": [
     {
       "command": "fortls",
@@ -1457,6 +1446,22 @@
       ]
     },
     {
+      "command": "ty",
+      "url": "https://github.com/astral-sh/ty",
+      "description": "An extremely fast Python type checker and language server.",
+      "requires": [
+        "py"
+      ]
+    },
+    {
+      "command": "ty",
+      "url": "https://github.com/astral-sh/ty",
+      "description": "An extremely fast Python type checker and language server.",
+      "requires": [
+        "python3"
+      ]
+    },
+    {
       "command": "ruff-lsp",
       "url": "https://github.com/charliermarsh/ruff-lsp",
       "description": "A Language Server Protocol implementation for Ruff.",
@@ -1625,18 +1630,6 @@
       "requires": [],
       "root_uri_patterns": [
         "Cargo.toml"
-      ]
-    },
-    {
-      "command": "bacon-ls",
-      "url": "https://github.com/crisidev/bacon-ls",
-      "description": "A Language Server for Rust using Bacon diagnostics",
-      "requires": [
-        "cargo"
-      ],
-      "root_uri_patterns": [
-        "bacon.toml",
-        "Cargo.lock"
       ]
     }
   ],
@@ -2168,6 +2161,18 @@
         ],
         "name": "leafOfTree/vim-vue-plugin"
       }
+    },
+    {
+      "command": "typescript-language-server",
+      "url": "https://github.com/typescript-language-server/typescript-language-server",
+      "description": "TypeScript & JavaScript Language Server",
+      "requires": [
+        "npm"
+      ],
+      "root_uri_patterns": [
+        "package.json",
+        "tsconfig.json"
+      ]
     },
     {
       "command": "vtsls",

--- a/settings/ty.vim
+++ b/settings/ty.vim
@@ -1,0 +1,14 @@
+augroup vim_lsp_settings_ruff
+  au!
+  LspRegisterServer {
+      \ 'name': 'ty',
+      \ 'cmd': {server_info->lsp_settings#get('ty', 'cmd', [lsp_settings#exec_path('ty')]+lsp_settings#get('ty', 'args', ['server']))},
+      \ 'root_uri':{server_info->lsp_settings#get('ty', 'root_uri', lsp_settings#root_uri('ty'))},
+      \ 'initialization_options': lsp_settings#get('ty', 'initialization_options', v:null),
+      \ 'allowlist': lsp_settings#get('ty', 'allowlist', ['python']),
+      \ 'blocklist': lsp_settings#get('ty', 'blocklist', []),
+      \ 'config': lsp_settings#get('ty', 'config', lsp_settings#server_config('ty')),
+      \ 'workspace_config': lsp_settings#get('ty', 'workspace_config', {}),
+      \ 'semantic_highlight': lsp_settings#get('ty', 'semantic_highlight', {}),
+      \ }
+augroup END

--- a/settings/ty.vim
+++ b/settings/ty.vim
@@ -1,4 +1,4 @@
-augroup vim_lsp_settings_ruff
+augroup vim_lsp_settings_ty
   au!
   LspRegisterServer {
       \ 'name': 'ty',


### PR DESCRIPTION
Add support for `Ty` An extremely fast Python type checker and language server, written in Rust.

- https://docs.astral.sh/ty/