### PR TITLE
Update taplo lsp settings

### DIFF
--- a/installer/install-taplo-lsp.cmd
+++ b/installer/install-taplo-lsp.cmd
@@ -1,15 +1,25 @@
 @echo off
-
 setlocal
 
-set LATEST=0.2.6
-curl -L "https://github.com/tamasfe/taplo/releases/download/release-lsp-%LATEST%/taplo-lsp-windows-x86_64.zip" -o taplo-lsp-windows-x86_64.zip
-call "%~dp0\run_unzip.cmd" taplo-lsp-windows-x86_64.zip
-del taplo-lsp-windows-x86_64.zip
+if "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
+    set architecture=x86_64
+) else if "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
+    set architecture=aarch64
+) else if "%PROCESSOR_ARCHITECTURE%"=="x86" (
+    set architecture=x86
+) else (
+    echo Unkown architecture, unable to install Taplo Language Server.
+    exit /b
+)
+
+set taploFile=taplo-windows-%architecture%.zip
+set downloadLocation=https://github.com/tamasfe/taplo/releases/latest/download/%taploFile%
+curl -L -o %taploFile% %downloadLocation%
+call "%~dp0\run_unzip.cmd" %taploFile%
+del %taploFile%
 
 echo @echo off ^
 
-%%~dp0\taplo-lsp.exe %%* ^
+%%~dp0\taplo.exe %%* ^
 
 > taplo-lsp.cmd
-

--- a/settings/taplo-lsp.vim
+++ b/settings/taplo-lsp.vim
@@ -41,7 +41,7 @@ augroup vim_lsp_settings_taplo_lsp
   au!
   LspRegisterServer {
       \ 'name': 'taplo-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('taplo-lsp', 'cmd', [lsp_settings#exec_path('taplo-lsp')]+lsp_settings#get('taplo-lsp', 'args', has('win32') ? ['run'] : ['lsp','stdio']))},
+      \ 'cmd': {server_info->lsp_settings#get('taplo-lsp', 'cmd', [lsp_settings#exec_path('taplo')]+lsp_settings#get('taplo-lsp', 'args', ['lsp','stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('taplo-lsp', 'root_uri', lsp_settings#root_uri('taplo-lsp'))},
       \ 'initialization_options': lsp_settings#get('taplo-lsp', 'initialization_options', g:vim_lsp_settings_taplo_lsp_options),
       \ 'allowlist': lsp_settings#get('taplo-lsp', 'allowlist', ['toml']),
@@ -50,7 +50,7 @@ augroup vim_lsp_settings_taplo_lsp
       \ 'workspace_config': lsp_settings#get('taplo-lsp', 'workspace_config', {'evenBetterToml': g:vim_lsp_settings_taplo_lsp_options}),
       \ 'semantic_highlight': lsp_settings#get('taplo-lsp', 'semantic_highlight', {}),
       \ }
-  autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled() 
+  autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled()
 augroup END
 
 

--- a/settings/taplo-lsp.vim
+++ b/settings/taplo-lsp.vim
@@ -41,7 +41,7 @@ augroup vim_lsp_settings_taplo_lsp
   au!
   LspRegisterServer {
       \ 'name': 'taplo-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('taplo-lsp', 'cmd', [lsp_settings#exec_path('taplo')]+lsp_settings#get('taplo-lsp', 'args', ['lsp','stdio']))},
+      \ 'cmd': {server_info->lsp_settings#get('taplo-lsp', 'cmd', [lsp_settings#exec_path('taplo-lsp')]+lsp_settings#get('taplo-lsp', 'args', ['lsp','stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('taplo-lsp', 'root_uri', lsp_settings#root_uri('taplo-lsp'))},
       \ 'initialization_options': lsp_settings#get('taplo-lsp', 'initialization_options', g:vim_lsp_settings_taplo_lsp_options),
       \ 'allowlist': lsp_settings#get('taplo-lsp', 'allowlist', ['toml']),


### PR DESCRIPTION
Modified only for Windows:

- update Windows installer to support the latest version
- updated installed to detect windows os architecture 