### PR TITLE
Add support for Linux aarch64 to tinymist installer

### DIFF
--- a/installer/install-tinymist.sh
+++ b/installer/install-tinymist.sh
@@ -10,6 +10,9 @@ x86_64)
   arch="x64"
   ;;
 arm64) ;;
+aarch64)
+  arch="arm64"
+  ;;
 *)
   printf "%s doesn't supported by bash installer" "$os"
   exit 1


### PR DESCRIPTION
I tried to install tinymist on my Raspberry Pi OS, but the installation failed.
It seems the current installer script doesn't support Linux environments which the output of `uname -m` is `aarch64`.

I updated the UNIX installer script to be able to download `tinymist-linux-arm64` on Linux aarch64.

I confirmed it works on below environment:
```
$ uname -srvmo
Linux 6.12.34+rpt-rpi-v8 #1 SMP PREEMPT Debian 1:6.12.34-1+rpt1~bookworm (2025-06-26) aarch64 GNU/Linux
```