### PR TITLE
Fix kotlin-lsp not running on linux and update to the latest version

### DIFF
--- a/installer/install-kotlin-lsp.cmd
+++ b/installer/install-kotlin-lsp.cmd
@@ -1,8 +1,14 @@
 @echo off
 
 setlocal
-curl -L -o server.zip "https://download-cdn.jetbrains.com/kotlin-lsp/0.252.17811/kotlin-0.252.17811.zip"
+
+if not %PROCESSOR_ARCHITECTURE%==AMD64 (
+  echo %PROCESSOR_ARCHITECTURE% is not supported
+  exit /b 1
+)
+
+set version=261.13587.0
+
+curl -L -o server.zip "https://download-cdn.jetbrains.com/kotlin-lsp/%version%/kotlin-lsp-%version%-win-x64.zip"
 call "%~dp0\run_unzip.cmd" server.zip
 del server.zip
-
-curl -L -o kotlin-lsp.cmd "https://raw.githubusercontent.com/Kotlin/kotlin-lsp/refs/heads/main/scripts/kotlin-lsp.cmd"

--- a/installer/install-kotlin-lsp.sh
+++ b/installer/install-kotlin-lsp.sh
@@ -2,6 +2,38 @@
 
 set -e
 
-curl -L -o server.zip "https://download-cdn.jetbrains.com/kotlin-lsp/0.252.17811/kotlin-0.252.17811.zip"
+os="$(uname -s | tr "[:upper:]" "[:lower:]")"
+arch="$(uname -m)"
+
+case $os in
+darwin)
+  os=mac
+  ;;
+linux) ;;
+*)
+  echo "$os is not supported"
+  exit 1
+  ;;
+esac
+
+case $arch in
+aarch64) ;;
+arm64)
+  arch=aarch64
+  ;;
+x86_64)
+  arch=x64
+  ;;
+*)
+  echo "$arch is not supported"
+  exit 1
+  ;;
+esac
+
+version=261.13587.0
+
+curl -L -o server.zip "https://download-cdn.jetbrains.com/kotlin-lsp/${version}/kotlin-lsp-${version}-${os}-${arch}.zip"
 unzip server.zip
 rm server.zip
+chmod +x kotlin-lsp.sh
+ln -s kotlin-lsp.sh kotlin-lsp


### PR DESCRIPTION
Fixed kotlin-lsp not running on linux due to vim-lsp-settings expecting the file to be named kotlin-lsp while it was actually named kotlin-lsp.sh by making a symbolic link. Also made kotlin-lsp.sh executable and updated kotlin-lsp to the latest version.

Since kotlin-lsp starting from version [v261.13587.0](https://github.com/Kotlin/kotlin-lsp/releases/tag/kotlin-lsp%2Fv261.13587.0) provides platform-specific builds I added some logic to download the appropriate version.

Lastly in the changelog they say "no JDK required by default, the language server bundles its own" so maybe Java requirement may be dropped but I'm not familiar with Java nor with vim-lsp-settings enough to assess if that change would be correct.