### PR TITLE
Fix oxc installer asset names for latest release downloads

### DIFF
--- a/installer/install-oxfmt.cmd
+++ b/installer/install-oxfmt.cmd
@@ -5,11 +5,11 @@ setlocal
 set ARCH=%PROCESSOR_ARCHITECTURE%
 
 if /I "%ARCH%"=="ARM64" (
-  set ZIPNAME=oxfmt-win32-arm64.zip
-  set EXEFILE=oxfmt-win32-arm64.exe
+  set ZIPNAME=oxfmt-aarch64-pc-windows-msvc.zip
+  set EXEFILE=oxfmt-aarch64-pc-windows-msvc.exe
 ) else (
-  set ZIPNAME=oxfmt-win32-x64.zip
-  set EXEFILE=oxfmt-win32-x64.exe
+  set ZIPNAME=oxfmt-x86_64-pc-windows-msvc.zip
+  set EXEFILE=oxfmt-x86_64-pc-windows-msvc.exe
 )
 
 curl -L -o "%ZIPNAME%" "https://github.com/oxc-project/oxc/releases/latest/download/%ZIPNAME%"

--- a/installer/install-oxfmt.sh
+++ b/installer/install-oxfmt.sh
@@ -18,23 +18,23 @@ linux)
   esac
   if [ "$arch" = "x86_64" ]; then
     if [ "$kernel" = "musl" ]; then
-      platform="linux-x64-musl"
+      platform="x86_64-unknown-linux-musl"
     else
-      platform="linux-x64"
+      platform="x86_64-unknown-linux-gnu"
     fi
   else
     if [ "$kernel" = "musl" ]; then
-      platform="linux-arm64-musl"
+      platform="aarch64-unknown-linux-musl"
     else
-      platform="linux-arm64"
+      platform="aarch64-unknown-linux-gnu"
     fi
   fi
   ;;
 darwin)
   if [ "$arch" = "x86_64" ]; then
-    platform="darwin-x64"
+    platform="x86_64-apple-darwin"
   else
-    platform="darwin-arm64"
+    platform="aarch64-apple-darwin"
   fi
   ;;
 esac

--- a/installer/install-oxlint.cmd
+++ b/installer/install-oxlint.cmd
@@ -5,11 +5,11 @@ setlocal
 set ARCH=%PROCESSOR_ARCHITECTURE%
 
 if /I "%ARCH%"=="ARM64" (
-  set ZIPNAME=oxlint-win32-arm64.zip
-  set EXEFILE=oxlint-win32-arm64.exe
+  set ZIPNAME=oxlint-aarch64-pc-windows-msvc.zip
+  set EXEFILE=oxlint-aarch64-pc-windows-msvc.exe
 ) else (
-  set ZIPNAME=oxlint-win32-x64.zip
-  set EXEFILE=oxlint-win32-x64.exe
+  set ZIPNAME=oxlint-x86_64-pc-windows-msvc.zip
+  set EXEFILE=oxlint-x86_64-pc-windows-msvc.exe
 )
 
 curl -L -o "%ZIPNAME%" "https://github.com/oxc-project/oxc/releases/latest/download/%ZIPNAME%"

--- a/installer/install-oxlint.sh
+++ b/installer/install-oxlint.sh
@@ -18,23 +18,23 @@ linux)
   esac
   if [ "$arch" = "x86_64" ]; then
     if [ "$kernel" = "musl" ]; then
-      platform="linux-x64-musl"
+      platform="x86_64-unknown-linux-musl"
     else
-      platform="linux-x64"
+      platform="x86_64-unknown-linux-gnu"
     fi
   else
     if [ "$kernel" = "musl" ]; then
-      platform="linux-arm64-musl"
+      platform="aarch64-unknown-linux-musl"
     else
-      platform="linux-arm64"
+      platform="aarch64-unknown-linux-gnu"
     fi
   fi
   ;;
 darwin)
   if [ "$arch" = "x86_64" ]; then
-    platform="darwin-x64"
+    platform="x86_64-apple-darwin"
   else
-    platform="darwin-arm64"
+    platform="aarch64-apple-darwin"
   fi
   ;;
 esac


### PR DESCRIPTION
Hi,

oxc download url has been changed since  https://github.com/oxc-project/oxc/releases/tag/apps_v1.46.0
