### PR TITLE
README: Fix unclosed bracket for rust-analyzer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ let g:lsp_settings = {
 \     'checkOnSave': v:false,
 \     'diagnostics': v:false,
 \   },
+\ }
 \}
 ```
 


### PR DESCRIPTION
fixes the following codeblock in README, which is not valid vimscript:
```
let g:lsp_experimental_workspace_folders = 1
let g:lsp_settings_filetype_rust = ['rust-analyzer', 'bacon-ls']
let g:lsp_settings = {
\ 'rust-analyzer': {
\   'initialization_options': {
\     'checkOnSave': v:false,
\     'diagnostics': v:false,
\   },
\}
```