### PR TITLE
Bump kakehashi version

### DIFF
--- a/installer/install-kakehashi.cmd
+++ b/installer/install-kakehashi.cmd
@@ -1,6 +1,6 @@
 @echo off
 
 setlocal
-curl -L -o "kakehashi-windows.zip" "https://github.com/atusy/kakehashi/releases/latest/download/kakehashi-v0.0.10-x86_64-pc-windows-msvc.zip"
+curl -L -o "kakehashi-windows.zip" "https://github.com/atusy/kakehashi/releases/latest/download/kakehashi-v0.5.0-x86_64-pc-windows-msvc.zip"
 call "%~dp0\run_unzip.cmd" kakehashi-windows.zip
 del kakehashi-windows.zip

--- a/installer/install-kakehashi.sh
+++ b/installer/install-kakehashi.sh
@@ -33,7 +33,7 @@ darwin)
 esac
 
 # Download latest release
-url="https://github.com/atusy/kakehashi/releases/latest/download/kakehashi-v0.0.10-${platform}.tar.gz"
+url="https://github.com/atusy/kakehashi/releases/latest/download/kakehashi-v0.5.0-${platform}.tar.gz"
 curl -L -o "kakehashi-${platform}.tar.gz" "$url"
 tar xzf "kakehashi-${platform}.tar.gz"
 rm "kakehashi-${platform}.tar.gz"


### PR DESCRIPTION
Hi, I've update kakehashi version

Current installer did not work well.

before:

<img width="741" height="99" alt="スクリーンショット 2026-05-20 1 19 57" src="https://github.com/user-attachments/assets/01a23ee3-9614-4ffe-94df-a8704824fdc3" />

after:

<img width="740" height="100" alt="スクリーンショット 2026-05-20 1 24 29" src="https://github.com/user-attachments/assets/624d19a7-421d-4807-8581-7c6583316803" />

It would be very appreciate to try windows installer 🙏 

Thank you