### PR TITLE
Pin GitHub release installer versions

### DIFF
--- a/installer/install-clangd.sh
+++ b/installer/install-clangd.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+version="22.1.6"
+
 # On MacOS, use clangd in Command Line Tools for Xcode.
 if command -v xcrun 2>/dev/null && xcrun --find clangd 2>/dev/null; then
   cat <<'EOF' >clangd
@@ -13,94 +15,10 @@ EOF
   exit
 fi
 
-if command -v lsb_release 2>/dev/null; then
-  distributor_id=$(lsb_release -a 2>&1 | grep 'Distributor ID' | awk '{print $3}')
-elif [ -e /etc/fedora-release ]; then
-  distributor_id="Fedora"
-elif [ -e /etc/redhat-release ]; then
-  distributor_id=$(cut -d ' ' -f 1 /etc/redhat-release)
-elif [ -e /etc/arch-release ]; then
-  distributor_id="Arch"
-elif [ -e /etc/SuSE-release ]; then
-  distributor_id="SUSE"
-elif [ -e /etc/mandriva-release ]; then
-  distributor_id="Mandriva"
-elif [ -e /etc/vine-release ]; then
-  distributor_id="Vine"
-elif [ -e /etc/gentoo-release ]; then
-  distributor_id="Gentoo"
-else
-  distributor_id="Unknown"
-fi
-
-filename() {
-  distributor_id=$1
-  version=$2
-
-  os=$(uname -s | tr "[:upper:]" "[:lower:]")
-
-  case $os in
-  linux)
-    platform="pc-linux-gnu"
-    ;;
-  darwin)
-    platform="apple-darwin"
-    ;;
-  esac
-
-  case $distributor_id in
-  # Check Ubuntu version
-  Ubuntu)
-    ubuntu_version=$(lsb_release -a 2>&1 | grep 'Release' | awk '{print $2}')
-    case $ubuntu_version in
-    14.04 | 16.04 | 18.04 | 20.04)
-      platform="linux-gnu-ubuntu-$ubuntu_version"
-      ;;
-    22.04)
-      platform="linux-gnu-ubuntu-20.04"
-      ;;
-    esac
-    ;;
-  # Check LinuxMint version
-  LinuxMint)
-    linuxmint_version=$(lsb_release -a 2>&1 | grep 'Release' | awk '{print $2}')
-    case $linuxmint_version in
-    19 | 19.1 | 19.2 | 19.3)
-      platform="linux-gnu-ubuntu-18.04"
-      ;;
-    18 | 18.1 | 18.2 | 18.3)
-      platform="linux-gnu-ubuntu-16.04"
-      ;;
-    esac
-    ;;
-  # Check RedHat OS version
-  Fedora | Oracle | CentOS)
-    case $version in
-    9.0.0 | 10.0.0)
-      platform="linux-sles11.3"
-      ;;
-    11.0.0)
-      platform="linux-sles12.4"
-      ;;
-    esac
-    ;;
-  esac
-
-  # Check Architecture
-  arch=$(uname -m)
-  case $arch in
-  aarch64)
-    platform="linux-gnu"
-    ;;
-  esac
-
-  echo "clang+llvm-$version-$arch-$platform"
-}
-
 # Search for local clangd in PATH
 if which "clangd" >/dev/null; then
-    clangd --version
-    exit 0
+  clangd --version
+  exit 0
 fi
 for llvm_version in $(seq 30 -1 9); do
   cmd="clangd-$llvm_version"
@@ -112,21 +30,53 @@ for llvm_version in $(seq 30 -1 9); do
   fi
 done
 
-# Search for an installable clang+llvm release.
-for llvm_version in 15 14 13 12 11 10 9; do
-  filename="$(filename "$distributor_id" "$llvm_version.0.0")"
-  url="https://github.com/llvm/llvm-project/releases/download/llvmorg-$llvm_version.0.0/$filename.tar.xz"
-  response_code=$(curl -sIL "${url}" -o /dev/null -w "%{response_code}")
+# Otherwise download a prebuilt release from the LLVM project.
+# Asset naming reference:
+#   https://github.com/llvm/llvm-project/releases
+os=$(uname -s | tr "[:upper:]" "[:lower:]")
+arch=$(uname -m)
+ext="tar.xz"
 
-  # If version exists, install it and exit.
-  if [ "${response_code}" -ne "404" ]; then
-    echo "Downloading clangd and LLVM $llvm_version..."
-    curl -L "$url" | unxz | tar x --strip-components=1 "$filename"/
-    ln -sf bin/clangd .
-    ./clangd --version
-    exit 0
-  fi
-done
+case $os in
+linux)
+  case $arch in
+  x86_64)
+    filename="LLVM-$version-Linux-X64"
+    ;;
+  aarch64 | arm64)
+    filename="LLVM-$version-Linux-ARM64"
+    ;;
+  armv7l)
+    filename="clang+llvm-$version-armv7a-linux-gnueabihf"
+    ext="tar.gz"
+    ;;
+  *)
+    echo "unsupported architecture: $arch"
+    exit 1
+    ;;
+  esac
+  ;;
+darwin)
+  case $arch in
+  arm64 | aarch64)
+    filename="LLVM-$version-macOS-ARM64"
+    ;;
+  *)
+    echo "unsupported architecture: $arch"
+    exit 1
+    ;;
+  esac
+  ;;
+*)
+  echo "unsupported OS: $os"
+  exit 1
+  ;;
+esac
 
-echo "Could not find an installable clangd release!"
-exit 1
+url="https://github.com/llvm/llvm-project/releases/download/llvmorg-$version/$filename.$ext"
+echo "Downloading clangd and LLVM $version..."
+curl -L -o "clangd.$ext" "$url"
+tar -xf "clangd.$ext" --strip-components=1 "$filename"
+rm -f "clangd.$ext"
+ln -sf bin/clangd .
+./clangd --version

--- a/installer/install-clangd.sh
+++ b/installer/install-clangd.sh
@@ -23,7 +23,7 @@ fi
 for llvm_version in $(seq 30 -1 9); do
   cmd="clangd-$llvm_version"
   if which "$cmd" >/dev/null; then
-    echo "Found $(which $cmd)"
+    echo "Found $(which "$cmd")"
     ln -sf "$(which "$cmd")" clangd
     ./clangd --version
     exit 0

--- a/installer/install-deno.cmd
+++ b/installer/install-deno.cmd
@@ -1,6 +1,7 @@
 @echo off
 
 setlocal
-curl -L -o deno-x86_64-pc-windows-msvc.zip "https://github.com/denoland/deno/releases/latest/download/deno-x86_64-pc-windows-msvc.zip"
+set VERSION=v2.7.14
+curl -L -o deno-x86_64-pc-windows-msvc.zip "https://github.com/denoland/deno/releases/download/%VERSION%/deno-x86_64-pc-windows-msvc.zip"
 call "%~dp0\run_unzip.cmd" deno-x86_64-pc-windows-msvc.zip
 del deno-x86_64-pc-windows-msvc.zip

--- a/installer/install-deno.sh
+++ b/installer/install-deno.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+version="v2.7.14"
+
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
 
 case $os in
@@ -17,5 +19,5 @@ darwin)
   ;;
 esac
 
-curl -L -o "deno-$os.zip" "https://github.com/denoland/deno/releases/latest/download/$filename"
+curl -L -o "deno-$os.zip" "https://github.com/denoland/deno/releases/download/$version/$filename"
 unzip "deno-$os.zip"

--- a/installer/install-helm-ls.cmd
+++ b/installer/install-helm-ls.cmd
@@ -1,5 +1,6 @@
 @echo off
 
 setlocal
+set VERSION=v0.5.4
 echo Downloading helm-ls...
-curl -L -o helm-ls.exe  "https://github.com/mrjosh/helm-ls/releases/latest/download/helm_ls_windows_amd64.exe"
+curl -L -o helm-ls.exe  "https://github.com/mrjosh/helm-ls/releases/download/%VERSION%/helm_ls_windows_amd64.exe"

--- a/installer/install-helm-ls.sh
+++ b/installer/install-helm-ls.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+version="v0.5.4"
+
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
 
 case $os in
@@ -21,5 +23,5 @@ darwin)
   ;;
 esac
 
-curl -L -o helm-ls "https://github.com/mrjosh/helm-ls/releases/latest/download/$filename"
+curl -L -o helm-ls "https://github.com/mrjosh/helm-ls/releases/download/$version/$filename"
 chmod 755 helm-ls

--- a/installer/install-kakehashi.cmd
+++ b/installer/install-kakehashi.cmd
@@ -1,6 +1,7 @@
 @echo off
 
 setlocal
-curl -L -o "kakehashi-windows.zip" "https://github.com/atusy/kakehashi/releases/latest/download/kakehashi-v0.5.0-x86_64-pc-windows-msvc.zip"
+set VERSION=v0.5.0
+curl -L -o "kakehashi-windows.zip" "https://github.com/atusy/kakehashi/releases/download/%VERSION%/kakehashi-%VERSION%-x86_64-pc-windows-msvc.zip"
 call "%~dp0\run_unzip.cmd" kakehashi-windows.zip
 del kakehashi-windows.zip

--- a/installer/install-kakehashi.sh
+++ b/installer/install-kakehashi.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+version="v0.5.0"
+
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
 arch="$(uname -m)"
 
@@ -32,8 +34,7 @@ darwin)
   ;;
 esac
 
-# Download latest release
-url="https://github.com/atusy/kakehashi/releases/latest/download/kakehashi-v0.5.0-${platform}.tar.gz"
+url="https://github.com/atusy/kakehashi/releases/download/${version}/kakehashi-${version}-${platform}.tar.gz"
 curl -L -o "kakehashi-${platform}.tar.gz" "$url"
 tar xzf "kakehashi-${platform}.tar.gz"
 rm "kakehashi-${platform}.tar.gz"

--- a/installer/install-kotlin-language-server.cmd
+++ b/installer/install-kotlin-language-server.cmd
@@ -1,7 +1,8 @@
 @echo off
 
 setlocal
-curl -L -o server.zip "https://github.com/fwcd/kotlin-language-server/releases/latest/download/server.zip"
+set VERSION=1.3.13
+curl -L -o server.zip "https://github.com/fwcd/kotlin-language-server/releases/download/%VERSION%/server.zip"
 call "%~dp0\run_unzip.cmd" server.zip
 del server.zip
 

--- a/installer/install-kotlin-language-server.sh
+++ b/installer/install-kotlin-language-server.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-curl -L -o server.zip "https://github.com/fwcd/kotlin-language-server/releases/latest/download/server.zip"
+version="1.3.13"
+
+curl -L -o server.zip "https://github.com/fwcd/kotlin-language-server/releases/download/$version/server.zip"
 unzip server.zip
 rm server.zip
 

--- a/installer/install-markdown-oxide.cmd
+++ b/installer/install-markdown-oxide.cmd
@@ -1,6 +1,7 @@
 @echo off
 
 setlocal
-curl -L -o "markdown-oxide-windows.zip" "https://github.com/atusy/markdown-oxide/releases/latest/download/markdown-oxide-v0.25.10-x86_64-pc-windows-gnu.zip"
+set VERSION=v0.25.10
+curl -L -o "markdown-oxide-windows.zip" "https://github.com/Feel-ix-343/markdown-oxide/releases/download/%VERSION%/markdown-oxide-%VERSION%-x86_64-pc-windows-gnu.zip"
 call "%~dp0\run_unzip.cmd" markdown-oxide-windows.zip
 del markdown-oxide-windows.zip

--- a/installer/install-markdown-oxide.sh
+++ b/installer/install-markdown-oxide.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+version="v0.25.10"
+
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
 arch="$(uname -m)"
 
@@ -32,10 +34,9 @@ darwin)
   ;;
 esac
 
-# Download latest release
-url="https://github.com/Feel-ix-343/markdown-oxide/releases/latest/download/markdown-oxide-v0.25.10-${platform}.tar.gz"
+url="https://github.com/Feel-ix-343/markdown-oxide/releases/download/${version}/markdown-oxide-${version}-${platform}.tar.gz"
 curl -L -o "markdown-oxide-${platform}.tar.gz" "$url"
 tar xzf "markdown-oxide-${platform}.tar.gz"
-mv markdown-oxide-v0.25.10-${platform}/markdown-oxide markdown-oxide
-rm "markdown-oxide-${platform}.tar.gz"
+mv "markdown-oxide-${version}-${platform}/markdown-oxide" markdown-oxide
+rm -rf "markdown-oxide-${version}-${platform}" "markdown-oxide-${platform}.tar.gz"
 chmod +x markdown-oxide

--- a/installer/install-marksman.cmd
+++ b/installer/install-marksman.cmd
@@ -1,3 +1,5 @@
 @echo off
 
-curl -L -o marksman.exe "https://github.com/artempyanykh/marksman/releases/latest/download/marksman.exe"
+setlocal
+set VERSION=2026-02-08
+curl -L -o marksman.exe "https://github.com/artempyanykh/marksman/releases/download/%VERSION%/marksman.exe"

--- a/installer/install-marksman.sh
+++ b/installer/install-marksman.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+version="2026-02-08"
+
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
 if [ $(uname -m) = "x86_64" ];
 then
@@ -18,5 +20,5 @@ darwin)
   ;;
 esac
 
-curl -L -o marksman "https://github.com/artempyanykh/marksman/releases/latest/download/marksman-$platform"
+curl -L -o marksman "https://github.com/artempyanykh/marksman/releases/download/$version/marksman-$platform"
 chmod +x marksman

--- a/installer/install-marksman.sh
+++ b/installer/install-marksman.sh
@@ -5,7 +5,7 @@ set -e
 version="2026-02-08"
 
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
-if [ $(uname -m) = "x86_64" ];
+if [ "$(uname -m)" = "x86_64" ];
 then
   arch="x64"
 else

--- a/installer/install-ntt.cmd
+++ b/installer/install-ntt.cmd
@@ -1,6 +1,7 @@
 @echo off
 
 setlocal
-curl -LO "https://github.com/nokia/ntt/releases/latest/download/ntt_windows_x86_64.zip"
+set VERSION=v0.23.2
+curl -LO "https://github.com/nokia/ntt/releases/download/%VERSION%/ntt_windows_x86_64.zip"
 unzip ntt_windows_x86_64.zip
 rm ntt_windows_x86_64.zip

--- a/installer/install-ntt.sh
+++ b/installer/install-ntt.sh
@@ -3,11 +3,13 @@
 set -e
 #set -o pipefail
 
+version="v0.23.2"
+
 os="$(uname -s | tr "[:upper:]" "[:lower:]")"
 
 case "${os}" in
 darwin | linux)
-  url="https://github.com/nokia/ntt/releases/latest/download/ntt_${os}_x86_64.tar.gz"
+  url="https://github.com/nokia/ntt/releases/download/${version}/ntt_${os}_x86_64.tar.gz"
   curl -L "$url" | tar xz ntt
   chmod +x ntt
   ;;

--- a/installer/install-omnisharp-lsp.cmd
+++ b/installer/install-omnisharp-lsp.cmd
@@ -1,15 +1,17 @@
 @echo off
 setlocal
 
-for /f "delims=" %%i in ('dotnet --version') do set version=%%i
+set VERSION=v1.39.15
+
+for /f "delims=" %%i in ('dotnet --version') do set dotnet_version=%%i
 
 
-set mainVersion=%version:.=&rem %
+set mainVersion=%dotnet_version:.=&rem %
 
 if /i "%mainVersion%" geq "6" (
-	curl -L -o omnisharp.zip "https://github.com/OmniSharp/omnisharp-roslyn/releases/latest/download/omnisharp-win-x64-net6.0.zip"
+	curl -L -o omnisharp.zip "https://github.com/OmniSharp/omnisharp-roslyn/releases/download/%VERSION%/omnisharp-win-x64-net6.0.zip"
 ) else (
-	curl -L -o omnisharp.zip "https://github.com/OmniSharp/omnisharp-roslyn/releases/latest/download/omnisharp-win-x64.zip"
+	curl -L -o omnisharp.zip "https://github.com/OmniSharp/omnisharp-roslyn/releases/download/%VERSION%/omnisharp-win-x64.zip"
 )
 
 call "%~dp0\run_unzip.cmd" omnisharp.zip

--- a/installer/install-omnisharp-lsp.sh
+++ b/installer/install-omnisharp-lsp.sh
@@ -2,10 +2,12 @@
 
 set -e
 
+version="v1.39.15"
+
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
 arch="-x64"
 net6=""
-version=$(dotnet --version)
+dotnet_version=$(dotnet --version)
 
 case $os in
 linux) ;;
@@ -19,12 +21,12 @@ darwin)
   ;;
 esac
 
-case $version in
+case $dotnet_version in
 *.*)
-  mainVersion=${version%%.*}
+  mainVersion=${dotnet_version%%.*}
   ;;
 *)
-  mainVersion=$version
+  mainVersion=$dotnet_version
   ;;
 esac
 
@@ -49,7 +51,7 @@ omnisharp_cmd=\${base_dir}/OmniSharp
 EOF
 fi
 
-url="https://github.com/OmniSharp/omnisharp-roslyn/releases/latest/download/omnisharp-$os$arch$net6.tar.gz"
+url="https://github.com/OmniSharp/omnisharp-roslyn/releases/download/$version/omnisharp-$os$arch$net6.tar.gz"
 curl -L "$url" | tar xz
 
 chmod +x run

--- a/installer/install-package-version-server.cmd
+++ b/installer/install-package-version-server.cmd
@@ -1,6 +1,7 @@
 @echo off
 
 setlocal
-curl -L -o "package-version-server.zip" "https://github.com/zed-industries/package-version-server/releases/latest/download/package-version-server-x86_64-pc-windows-msvc.zip"
+set VERSION=v0.0.10
+curl -L -o "package-version-server.zip" "https://github.com/zed-industries/package-version-server/releases/download/%VERSION%/package-version-server-x86_64-pc-windows-msvc.zip"
 call "%~dp0\run_unzip.cmd" package-version-server.zip
 del package-version-server.zip

--- a/installer/install-package-version-server.sh
+++ b/installer/install-package-version-server.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+version="v0.0.10"
+
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
 arch="$(uname -m)"
 ext="tar.gz"
@@ -43,7 +45,7 @@ mingw64_nt*)
   ;;
 esac
 
-curl -L -o "package-version-server.$ext" "https://github.com/zed-industries/package-version-server/releases/latest/download/package-version-server-$platform.$ext"
+curl -L -o "package-version-server.$ext" "https://github.com/zed-industries/package-version-server/releases/download/$version/package-version-server-$platform.$ext"
 if [ "$ext" = "zip" ]; then
   unzip "package-version-server.$ext"
 else

--- a/installer/install-perlnavigator.cmd
+++ b/installer/install-perlnavigator.cmd
@@ -1,7 +1,8 @@
 @echo off
 
 setlocal
-curl -L -o perlnavigator-win-x86_64.zip "https://github.com/bscan/PerlNavigator/releases/latest/download/perlnavigator-win-x86_64.zip"
+set VERSION=v0.8.20
+curl -L -o perlnavigator-win-x86_64.zip "https://github.com/bscan/PerlNavigator/releases/download/%VERSION%/perlnavigator-win-x86_64.zip"
 call "%~dp0\run_unzip.cmd" perlnavigator-win-x86_64.zip
 move perlnavigator-win-x86_64\perlnavigator.exe .
 rd /Q /S perlnavigator-win-x86_64

--- a/installer/install-perlnavigator.sh
+++ b/installer/install-perlnavigator.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+version="v0.8.20"
+
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
 
 case $os in
@@ -15,7 +17,7 @@ darwin)
   ;;
 esac
 
-curl -L -o "perlnavigator-$os-x86_64.zip" "https://github.com/bscan/PerlNavigator/releases/latest/download/perlnavigator-$os-x86_64.zip"
+curl -L -o "perlnavigator-$os-x86_64.zip" "https://github.com/bscan/PerlNavigator/releases/download/$version/perlnavigator-$os-x86_64.zip"
 unzip "perlnavigator-$os-x86_64.zip"
 mv "perlnavigator-$os-x86_64/perlnavigator" .
 rm -rf "perlnavigator-$os-x86_64" "perlnavigator-$os-x86_64.zip"

--- a/installer/install-rust-analyzer.cmd
+++ b/installer/install-rust-analyzer.cmd
@@ -1,6 +1,7 @@
 @echo off
 
 setlocal
-curl -L -o "rust-analyzer-windows.zip" "https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/rust-analyzer-x86_64-pc-windows-msvc.zip"
+set VERSION=2026-05-18
+curl -L -o "rust-analyzer-windows.zip" "https://github.com/rust-analyzer/rust-analyzer/releases/download/%VERSION%/rust-analyzer-x86_64-pc-windows-msvc.zip"
 call "%~dp0\run_unzip.cmd" rust-analyzer-windows.zip
 del rust-analyzer-windows.zip rust_analyzer.pdb

--- a/installer/install-rust-analyzer.sh
+++ b/installer/install-rust-analyzer.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+version="2026-05-18"
+
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
 arch="$(uname -m)"
 
@@ -42,7 +44,7 @@ mingw64_nt*)
   ;;
 esac
 
-curl -L -o "rust-analyzer-$platform.gz" "https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/rust-analyzer-$platform.gz"
+curl -L -o "rust-analyzer-$platform.gz" "https://github.com/rust-analyzer/rust-analyzer/releases/download/$version/rust-analyzer-$platform.gz"
 gzip -d "rust-analyzer-$platform.gz"
 
 mv rust-analyzer-$platform rust-analyzer

--- a/installer/install-starpls.cmd
+++ b/installer/install-starpls.cmd
@@ -1,3 +1,5 @@
 @echo off
 
-curl -L -o "starpls.exe" "https://github.com/withered-magic/starpls/releases/latest/download/starpls-windows-amd64.exe"
+setlocal
+set VERSION=v0.1.22
+curl -L -o "starpls.exe" "https://github.com/withered-magic/starpls/releases/download/%VERSION%/starpls-windows-amd64.exe"

--- a/installer/install-starpls.sh
+++ b/installer/install-starpls.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+version="v0.1.22"
+
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
 arch="$(uname -m)"
 
@@ -36,6 +38,6 @@ mingw64_nt*)
   ;;
 esac
 
-curl -L -o "starpls" "https://github.com/withered-magic/starpls/releases/latest/download/starpls-$platform"
+curl -L -o "starpls" "https://github.com/withered-magic/starpls/releases/download/$version/starpls-$platform"
 
 chmod +x starpls

--- a/installer/install-systemd-lsp.cmd
+++ b/installer/install-systemd-lsp.cmd
@@ -1,3 +1,5 @@
 @echo off
 
-curl -L -o "systemd-lsp.exe" "https://github.com/JFryy/systemd-lsp/releases/download/v2025.07.10/systemd-lsp-x86_64-pc-windows-msvc.exe"
+setlocal
+set VERSION=v2026.04.21
+curl -L -o "systemd-lsp.exe" "https://github.com/JFryy/systemd-lsp/releases/download/%VERSION%/systemd-lsp-x86_64-pc-windows-msvc.exe"

--- a/installer/install-systemd-lsp.sh
+++ b/installer/install-systemd-lsp.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+version="v2026.04.21"
+
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
 arch="$(uname -m)"
 
@@ -30,6 +32,6 @@ darwin)
   ;;
 esac
 
-curl -L -o "systemd-lsp" "https://github.com/JFryy/systemd-lsp/releases/download/v2025.07.10/$file"
+curl -L -o "systemd-lsp" "https://github.com/JFryy/systemd-lsp/releases/download/$version/$file"
 
 chmod +x systemd-lsp

--- a/installer/install-taplo-lsp.cmd
+++ b/installer/install-taplo-lsp.cmd
@@ -1,6 +1,8 @@
 @echo off
 setlocal
 
+set VERSION=0.10.0
+
 if "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
     set architecture=x86_64
 ) else if "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
@@ -13,7 +15,7 @@ if "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
 )
 
 set taploFile=taplo-windows-%architecture%.zip
-set downloadLocation=https://github.com/tamasfe/taplo/releases/latest/download/%taploFile%
+set downloadLocation=https://github.com/tamasfe/taplo/releases/download/%VERSION%/%taploFile%
 curl -L -o %taploFile% %downloadLocation%
 call "%~dp0\run_unzip.cmd" %taploFile%
 del %taploFile%

--- a/installer/install-taplo-lsp.sh
+++ b/installer/install-taplo-lsp.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+version="0.10.0"
+
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
 architecture=$(uname -m)
 
@@ -21,6 +23,6 @@ darwin)
   ;;
 esac
 
-curl -L "https://github.com/tamasfe/taplo/releases/latest/download/taplo-$platform.gz" | gzip -d >taplo-lsp
+curl -L "https://github.com/tamasfe/taplo/releases/download/$version/taplo-$platform.gz" | gzip -d >taplo-lsp
 
 chmod +x taplo-lsp

--- a/installer/install-texlab.cmd
+++ b/installer/install-texlab.cmd
@@ -1,6 +1,7 @@
 @echo off
 
 setlocal
-curl -L -o texlab-x86_64-windows.zip "https://github.com/latex-lsp/texlab/releases/latest/download/texlab-x86_64-windows.zip"
+set VERSION=v5.25.1
+curl -L -o texlab-x86_64-windows.zip "https://github.com/latex-lsp/texlab/releases/download/%VERSION%/texlab-x86_64-windows.zip"
 call "%~dp0\run_unzip.cmd" texlab-x86_64-windows.zip
 del texlab-x86_64-windows.zip

--- a/installer/install-texlab.sh
+++ b/installer/install-texlab.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+version="v5.25.1"
+
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
 arch=$(uname -m)
 
@@ -31,5 +33,5 @@ arm64)
   ;;
 esac
 
-url="https://github.com/latex-lsp/texlab/releases/latest/download/texlab-$arch-$os.tar.gz"
+url="https://github.com/latex-lsp/texlab/releases/download/$version/texlab-$arch-$os.tar.gz"
 curl -L "$url" | tar xzv

--- a/installer/install-tinymist.cmd
+++ b/installer/install-tinymist.cmd
@@ -1,4 +1,5 @@
 @echo off
 
 setlocal
-curl -L -o tinymist.exe "https://github.com/Myriad-Dreamin/tinymist/releases/latest/download/tinymist-win32-x64.exe"
+set VERSION=v0.14.18
+curl -L -o tinymist.exe "https://github.com/Myriad-Dreamin/tinymist/releases/download/%VERSION%/tinymist-win32-x64.exe"

--- a/installer/install-tinymist.sh
+++ b/installer/install-tinymist.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+version="v0.14.18"
+
 os="$(uname -s | tr "[:upper:]" "[:lower:]")"
 arch=$(uname -m)
 
@@ -28,5 +30,5 @@ linux) ;;
   ;;
 esac
 
-curl -L -o tinymist "https://github.com/Myriad-Dreamin/tinymist/releases/latest/download/tinymist-${os}-${arch}"
+curl -L -o tinymist "https://github.com/Myriad-Dreamin/tinymist/releases/download/${version}/tinymist-${os}-${arch}"
 chmod +x tinymist

--- a/installer/install-typos-lsp.cmd
+++ b/installer/install-typos-lsp.cmd
@@ -1,9 +1,9 @@
 @echo off
 
 setlocal
-for /f "usebackq" %%V in (`curl -Ls -o nul -w "%%{url_effective}" https://github.com/tekumara/typos-lsp/releases/latest`) do set VERSION=%%~nxV
+set VERSION=v0.1.52
 set FILE="typos-lsp-%VERSION%-x86_64-pc-windows-msvc.zip"
-curl -L -o %FILE% "https://github.com/tekumara/typos-lsp/releases/latest/download/%FILE%"
+curl -L -o %FILE% "https://github.com/tekumara/typos-lsp/releases/download/%VERSION%/%FILE%"
 call "%~dp0\run_unzip.cmd" %FILE%
 move target\x86_64-pc-windows-msvc\release\typos-lsp.exe .
 rd /Q /S target

--- a/installer/install-typos-lsp.sh
+++ b/installer/install-typos-lsp.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+version="v0.1.52"
+
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
 arch=$(uname -m | tr "[:upper:]" "[:lower:]")
 
@@ -38,7 +40,6 @@ darwin)
   ;;
 esac
 
-version=$(basename "$(curl -Ls -o /dev/null -w %\{url_effective\} https://github.com/tekumara/typos-lsp/releases/latest)")
 filename="typos-lsp-$version-$tuple.tar.gz"
 
-curl -L "https://github.com/tekumara/typos-lsp/releases/latest/download/$filename" | tar -xvz
+curl -L "https://github.com/tekumara/typos-lsp/releases/download/$version/$filename" | tar -xvz

--- a/installer/install-typst-lsp.cmd
+++ b/installer/install-typst-lsp.cmd
@@ -1,4 +1,5 @@
 @echo off
 
 setlocal
-curl -L -o typst-lsp-x86_64-pc-windows-msvc.exe "https://github.com/nvarner/typst-lsp/releases/latest/download/typst-lsp-x86_64-pc-windows-msvc.exe"
+set VERSION=v0.13.0
+curl -L -o typst-lsp-x86_64-pc-windows-msvc.exe "https://github.com/nvarner/typst-lsp/releases/download/%VERSION%/typst-lsp-x86_64-pc-windows-msvc.exe"

--- a/installer/install-typst-lsp.sh
+++ b/installer/install-typst-lsp.sh
@@ -3,6 +3,8 @@
 set -e
 #set -o pipefail
 
+version="v0.13.0"
+
 os="$(uname -s | tr "[:upper:]" "[:lower:]")"
 arch=$(uname -m)
 
@@ -19,10 +21,10 @@ esac
 
 case "${os}" in
 darwin)
-  url="https://github.com/nvarner/typst-lsp/releases/latest/download/typst-lsp-${arch}-apple-darwin"
+  url="https://github.com/nvarner/typst-lsp/releases/download/${version}/typst-lsp-${arch}-apple-darwin"
   ;;
 linux)
-  url="https://github.com/nvarner/typst-lsp/releases/latest/download/typst-lsp-${arch}-unknown-linux-gnu"
+  url="https://github.com/nvarner/typst-lsp/releases/download/${version}/typst-lsp-${arch}-unknown-linux-gnu"
   ;;
 *)
   echo >&2 "$os is not supported"

--- a/installer/install-veryl-ls.cmd
+++ b/installer/install-veryl-ls.cmd
@@ -1,7 +1,8 @@
 @echo off
 
 setlocal
-curl -L -o veryl-x86_64-windows.zip "https://github.com/veryl-lang/veryl/releases/latest/download/veryl-x86_64-windows.zip"
+set VERSION=v0.20.0
+curl -L -o veryl-x86_64-windows.zip "https://github.com/veryl-lang/veryl/releases/download/%VERSION%/veryl-x86_64-windows.zip"
 call "%~dp0\run_unzip.cmd" veryl-x86_64-windows.zip
 del veryl.exe
 del veryl-x86_64-windows.zip

--- a/installer/install-veryl-ls.sh
+++ b/installer/install-veryl-ls.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+version="v0.20.0"
+
 os=$(uname -s | tr "[:upper:]" "[:lower:]")
 
 case $os in
@@ -17,7 +19,7 @@ darwin)
   ;;
 esac
 
-curl -L -o veryl-x86_64-$os.zip "https://github.com/veryl-lang/veryl/releases/latest/download/veryl-x86_64-$os.zip"
+curl -L -o veryl-x86_64-$os.zip "https://github.com/veryl-lang/veryl/releases/download/$version/veryl-x86_64-$os.zip"
 unzip veryl-x86_64-$os.zip
 rm veryl
 rm veryl-x86_64-$os.zip


### PR DESCRIPTION
Fixes `install-clangd.sh`, which was broken because the old `clang+llvm-{ver}-pc-linux-gnu.tar.xz` asset names no longer exist for current LLVM releases.

Converts 19 other installers (38 files) from `releases/latest/download/...` to a pinned `version=`/`set VERSION=` line plus `releases/download/$version/...` URLs, so they can be kept current by a single sed pass over the `version=` declarations.

Drive-by fixes folded in:
- `install-markdown-oxide.cmd` pointed at a 404 fork; repointed to `Feel-ix-343/markdown-oxide` upstream.
- `install-systemd-lsp.{sh,cmd}` had a hardcoded mid-URL version that was stale; now pinned to the current release.
- `install-typos-lsp.{sh,cmd}` drops the curl-redirect dance used to learn the latest tag.
- `install-omnisharp-lsp.{sh,cmd}` renames the script-local `version` (dotnet runtime version) to `dotnet_version` so the pinned release version can coexist without shadowing.

biome and oxlint are intentionally left as-is: biome's tag (`@biomejs/biome@X.Y.Z`) needs URL encoding, and `oxc-project/oxc` publishes parallel `apps_v*` and `crates_v*` streams where `releases/latest` is ambiguous.