### PR TITLE
Add angular lsp to htmlangular filetype

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -724,6 +724,19 @@
       ]
     }
   ],
+  "htmlangular": [
+    {
+      "command": "angular-language-server",
+      "url": "https://github.com/angular/vscode-ng-language-service",
+      "description": "Angular extension for Visual Studio Code",
+      "config": {
+        "refresh_pattern": "\\(/\\|\\k\\+\\)$"
+      },
+      "requires": [
+        "npm"
+      ]
+    }
+  ],
   "hy": [
     {
       "command": "hyuga",

--- a/settings/angular-language-server.vim
+++ b/settings/angular-language-server.vim
@@ -5,7 +5,7 @@ augroup vim_lsp_settings_angular_language_server
       \ 'cmd': {server_info->lsp_settings#get('angular-language-server', 'cmd', [lsp_settings#exec_path('angular-language-server')]+lsp_settings#get('angular-language-server', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('angular-language-server', 'root_uri', lsp_settings#root_uri('angular-language-server'))},
       \ 'initialization_options': lsp_settings#get('angular-language-server', 'initialization_options', {'diagnostics': 'true'}),
-      \ 'allowlist': lsp_settings#get('angular-language-server', 'allowlist', {x-> empty(lsp_settings#root_path(['angular.json'])) ? [] : ['html']}),
+      \ 'allowlist': lsp_settings#get('angular-language-server', 'allowlist', {x-> empty(lsp_settings#root_path(['angular.json'])) ? [] : ['html', 'htmlangular']}),
       \ 'blocklist': lsp_settings#get('angular-language-server', 'blocklist', []),
       \ 'config': lsp_settings#get('angular-language-server', 'config', lsp_settings#server_config('angular-language-server')),
       \ 'workspace_config': lsp_settings#get('angular-language-server', 'workspace_config', {}),


### PR DESCRIPTION
Vim has added an "htmlangular" filetype due to changes in angular syntax. The angular lsp should be made available for that filetype.