### PR TITLE
Call lsp_settings#register_server() directly in settings files

### DIFF
--- a/settings/analysis-server-dart-snapshot.vim
+++ b/settings/analysis-server-dart-snapshot.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_analysis_server_dart_snapshot
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'analysis-server-dart-snapshot',
       \ 'cmd': {server_info->lsp_settings#get('analysis-server-dart-snapshot', 'cmd', [lsp_settings#exec_path('analysis-server-dart-snapshot')]+lsp_settings#get('analysis-server-dart-snapshot', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('analysis-server-dart-snapshot', 'root_uri', lsp_settings#root_uri('analysis-server-dart-snapshot'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_analysis_server_dart_snapshot
       \ 'config': lsp_settings#get('analysis-server-dart-snapshot', 'config', lsp_settings#server_config('analysis-server-dart-snapshot')),
       \ 'workspace_config': lsp_settings#get('analysis-server-dart-snapshot', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('analysis-server-dart-snapshot', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/analysis-server-dart-snapshot.vim
+++ b/settings/analysis-server-dart-snapshot.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_analysis_server_dart_snapshot
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'analysis-server-dart-snapshot',
-      \ 'cmd': {server_info->lsp_settings#get('analysis-server-dart-snapshot', 'cmd', [lsp_settings#exec_path('analysis-server-dart-snapshot')]+lsp_settings#get('analysis-server-dart-snapshot', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('analysis-server-dart-snapshot', 'root_uri', lsp_settings#root_uri('analysis-server-dart-snapshot'))},
-      \ 'initialization_options': lsp_settings#get('analysis-server-dart-snapshot', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('analysis-server-dart-snapshot', 'allowlist', ['dart']),
-      \ 'blocklist': lsp_settings#get('analysis-server-dart-snapshot', 'blocklist', []),
-      \ 'config': lsp_settings#get('analysis-server-dart-snapshot', 'config', lsp_settings#server_config('analysis-server-dart-snapshot')),
-      \ 'workspace_config': lsp_settings#get('analysis-server-dart-snapshot', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('analysis-server-dart-snapshot', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'analysis-server-dart-snapshot',
+    \ 'cmd': {server_info->lsp_settings#get('analysis-server-dart-snapshot', 'cmd', [lsp_settings#exec_path('analysis-server-dart-snapshot')]+lsp_settings#get('analysis-server-dart-snapshot', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('analysis-server-dart-snapshot', 'root_uri', lsp_settings#root_uri('analysis-server-dart-snapshot'))},
+    \ 'initialization_options': lsp_settings#get('analysis-server-dart-snapshot', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('analysis-server-dart-snapshot', 'allowlist', ['dart']),
+    \ 'blocklist': lsp_settings#get('analysis-server-dart-snapshot', 'blocklist', []),
+    \ 'config': lsp_settings#get('analysis-server-dart-snapshot', 'config', lsp_settings#server_config('analysis-server-dart-snapshot')),
+    \ 'workspace_config': lsp_settings#get('analysis-server-dart-snapshot', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('analysis-server-dart-snapshot', 'semantic_highlight', {}),
+    \ })

--- a/settings/angular-language-server.vim
+++ b/settings/angular-language-server.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_angular_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'angular-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('angular-language-server', 'cmd', [lsp_settings#exec_path('angular-language-server')]+lsp_settings#get('angular-language-server', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('angular-language-server', 'root_uri', lsp_settings#root_uri('angular-language-server'))},
-      \ 'initialization_options': lsp_settings#get('angular-language-server', 'initialization_options', {'diagnostics': 'true'}),
-      \ 'allowlist': lsp_settings#get('angular-language-server', 'allowlist', {x-> empty(lsp_settings#root_path(['angular.json'])) ? [] : ['html']}),
-      \ 'blocklist': lsp_settings#get('angular-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('angular-language-server', 'config', lsp_settings#server_config('angular-language-server')),
-      \ 'workspace_config': lsp_settings#get('angular-language-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('angular-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'angular-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('angular-language-server', 'cmd', [lsp_settings#exec_path('angular-language-server')]+lsp_settings#get('angular-language-server', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('angular-language-server', 'root_uri', lsp_settings#root_uri('angular-language-server'))},
+    \ 'initialization_options': lsp_settings#get('angular-language-server', 'initialization_options', {'diagnostics': 'true'}),
+    \ 'allowlist': lsp_settings#get('angular-language-server', 'allowlist', {x-> empty(lsp_settings#root_path(['angular.json'])) ? [] : ['html']}),
+    \ 'blocklist': lsp_settings#get('angular-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('angular-language-server', 'config', lsp_settings#server_config('angular-language-server')),
+    \ 'workspace_config': lsp_settings#get('angular-language-server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('angular-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/angular-language-server.vim
+++ b/settings/angular-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_angular_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'angular-language-server',
       \ 'cmd': {server_info->lsp_settings#get('angular-language-server', 'cmd', [lsp_settings#exec_path('angular-language-server')]+lsp_settings#get('angular-language-server', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('angular-language-server', 'root_uri', lsp_settings#root_uri('angular-language-server'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_angular_language_server
       \ 'config': lsp_settings#get('angular-language-server', 'config', lsp_settings#server_config('angular-language-server')),
       \ 'workspace_config': lsp_settings#get('angular-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('angular-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/apex-jorje-lsp.vim
+++ b/settings/apex-jorje-lsp.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_apex_jorje_lsp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'apex-jorje-lsp',
       \ 'cmd': {server_info->lsp_settings#get('apex-jorje-lsp', 'cmd', [lsp_settings#exec_path('apex-jorje-lsp')]+lsp_settings#get('apex-jorje-lsp', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('apex-jorje-lsp', 'root_uri', lsp_settings#root_uri('apex-jorje-lsp'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_apex_jorje_lsp
       \ 'config': lsp_settings#get('apex-jorje-lsp', 'config', lsp_settings#server_config('apex-jorje-lsp')),
       \ 'workspace_config': lsp_settings#get('apex-jorje-lsp', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('apex-jorje-lsp', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/apex-jorje-lsp.vim
+++ b/settings/apex-jorje-lsp.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_apex_jorje_lsp
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'apex-jorje-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('apex-jorje-lsp', 'cmd', [lsp_settings#exec_path('apex-jorje-lsp')]+lsp_settings#get('apex-jorje-lsp', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('apex-jorje-lsp', 'root_uri', lsp_settings#root_uri('apex-jorje-lsp'))},
-      \ 'initialization_options': lsp_settings#get('apex-jorje-lsp', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('apex-jorje-lsp', 'allowlist', ['apex']),
-      \ 'blocklist': lsp_settings#get('apex-jorje-lsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('apex-jorje-lsp', 'config', lsp_settings#server_config('apex-jorje-lsp')),
-      \ 'workspace_config': lsp_settings#get('apex-jorje-lsp', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('apex-jorje-lsp', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'apex-jorje-lsp',
+    \ 'cmd': {server_info->lsp_settings#get('apex-jorje-lsp', 'cmd', [lsp_settings#exec_path('apex-jorje-lsp')]+lsp_settings#get('apex-jorje-lsp', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('apex-jorje-lsp', 'root_uri', lsp_settings#root_uri('apex-jorje-lsp'))},
+    \ 'initialization_options': lsp_settings#get('apex-jorje-lsp', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('apex-jorje-lsp', 'allowlist', ['apex']),
+    \ 'blocklist': lsp_settings#get('apex-jorje-lsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('apex-jorje-lsp', 'config', lsp_settings#server_config('apex-jorje-lsp')),
+    \ 'workspace_config': lsp_settings#get('apex-jorje-lsp', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('apex-jorje-lsp', 'semantic_highlight', {}),
+    \ })

--- a/settings/astro-ls.vim
+++ b/settings/astro-ls.vim
@@ -13,7 +13,7 @@ function! s:get_current_ts_path() abort
         \ }
 endfunction
 
-function! Vim_lsp_settings_astro_setup_ts_path(options) abort
+function! s:setup_ts_path(options) abort
   let initialization_options = deepcopy(a:options)
   let initialization_options['typescript'] = s:get_current_ts_path()
   return initialization_options
@@ -27,15 +27,15 @@ let g:vim_lsp_settings_astro_options = {
 
 augroup vim_lsp_settings_astro_ls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
         \ 'name': 'astro-ls',
         \ 'cmd': {server_info->lsp_settings#get('astro-ls', 'cmd', [lsp_settings#exec_path('astro-ls')]+lsp_settings#get('astro-ls', 'args', ['--stdio']))},
         \ 'root_uri':{server_info->lsp_settings#get('astro-ls', 'root_uri', lsp_settings#root_uri('astro-ls'))},
-        \ 'initialization_options': lsp_settings#get('astro-ls', 'initialization_options', Vim_lsp_settings_astro_setup_ts_path(g:vim_lsp_settings_astro_options)),
+        \ 'initialization_options': lsp_settings#get('astro-ls', 'initialization_options', s:setup_ts_path(g:vim_lsp_settings_astro_options)),
         \ 'allowlist': lsp_settings#get('astro-ls', 'allowlist', ['astro']),
         \ 'blocklist': lsp_settings#get('astro-ls', 'blocklist', []),
         \ 'config': lsp_settings#get('astro-ls', 'config', lsp_settings#server_config('astro-ls')),
         \ 'workspace_config': lsp_settings#get('astro-ls', 'workspace_config', {}),
         \ 'semantic_highlight': lsp_settings#get('astro-ls', 'semantic_highlight', {}),
-        \ }
+        \ })
 augroup END

--- a/settings/astro-ls.vim
+++ b/settings/astro-ls.vim
@@ -25,17 +25,14 @@ let g:vim_lsp_settings_astro_options = {
       \   },
       \ }
 
-augroup vim_lsp_settings_astro_ls
-  au!
-  call lsp_settings#register_server({
-        \ 'name': 'astro-ls',
-        \ 'cmd': {server_info->lsp_settings#get('astro-ls', 'cmd', [lsp_settings#exec_path('astro-ls')]+lsp_settings#get('astro-ls', 'args', ['--stdio']))},
-        \ 'root_uri':{server_info->lsp_settings#get('astro-ls', 'root_uri', lsp_settings#root_uri('astro-ls'))},
-        \ 'initialization_options': lsp_settings#get('astro-ls', 'initialization_options', s:setup_ts_path(g:vim_lsp_settings_astro_options)),
-        \ 'allowlist': lsp_settings#get('astro-ls', 'allowlist', ['astro']),
-        \ 'blocklist': lsp_settings#get('astro-ls', 'blocklist', []),
-        \ 'config': lsp_settings#get('astro-ls', 'config', lsp_settings#server_config('astro-ls')),
-        \ 'workspace_config': lsp_settings#get('astro-ls', 'workspace_config', {}),
-        \ 'semantic_highlight': lsp_settings#get('astro-ls', 'semantic_highlight', {}),
-        \ })
-augroup END
+call lsp_settings#register_server({
+      \ 'name': 'astro-ls',
+      \ 'cmd': {server_info->lsp_settings#get('astro-ls', 'cmd', [lsp_settings#exec_path('astro-ls')]+lsp_settings#get('astro-ls', 'args', ['--stdio']))},
+      \ 'root_uri':{server_info->lsp_settings#get('astro-ls', 'root_uri', lsp_settings#root_uri('astro-ls'))},
+      \ 'initialization_options': lsp_settings#get('astro-ls', 'initialization_options', s:setup_ts_path(g:vim_lsp_settings_astro_options)),
+      \ 'allowlist': lsp_settings#get('astro-ls', 'allowlist', ['astro']),
+      \ 'blocklist': lsp_settings#get('astro-ls', 'blocklist', []),
+      \ 'config': lsp_settings#get('astro-ls', 'config', lsp_settings#server_config('astro-ls')),
+      \ 'workspace_config': lsp_settings#get('astro-ls', 'workspace_config', {}),
+      \ 'semantic_highlight': lsp_settings#get('astro-ls', 'semantic_highlight', {}),
+      \ })

--- a/settings/aws-lsp-yaml.vim
+++ b/settings/aws-lsp-yaml.vim
@@ -1,17 +1,14 @@
-augroup vim_lsp_settings_aws_lsp_yaml
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'aws-lsp-yaml',
-      \ 'cmd': {server_info->lsp_settings#get('aws-lsp-yaml', 'cmd', [lsp_settings#exec_path('aws-lsp-yaml')]+lsp_settings#get('aws-lsp-yaml', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('aws-lsp-yaml', 'root_uri', lsp_settings#root_uri('aws-lsp-yaml'))},
-      \ 'initialization_options': lsp_settings#get('aws-lsp-yaml', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('aws-lsp-yaml', 'allowlist', ['yaml']),
-      \ 'blocklist': lsp_settings#get('aws-lsp-yaml', 'blocklist', []),
-      \ 'config': lsp_settings#get('aws-lsp-yaml', 'config', lsp_settings#server_config('aws-lsp-yaml')),
-      \ 'workspace_config': lsp_settings#merge('aws-lsp-yaml', 'workspace_config', {'yaml': {'format': {'enable': v:true}, 'schemas': lsp_settings#utils#load_schemas_map('aws-lsp-yaml')}}),
-      \ 'semantic_highlight': lsp_settings#get('aws-lsp-yaml', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'aws-lsp-yaml',
+    \ 'cmd': {server_info->lsp_settings#get('aws-lsp-yaml', 'cmd', [lsp_settings#exec_path('aws-lsp-yaml')]+lsp_settings#get('aws-lsp-yaml', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('aws-lsp-yaml', 'root_uri', lsp_settings#root_uri('aws-lsp-yaml'))},
+    \ 'initialization_options': lsp_settings#get('aws-lsp-yaml', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('aws-lsp-yaml', 'allowlist', ['yaml']),
+    \ 'blocklist': lsp_settings#get('aws-lsp-yaml', 'blocklist', []),
+    \ 'config': lsp_settings#get('aws-lsp-yaml', 'config', lsp_settings#server_config('aws-lsp-yaml')),
+    \ 'workspace_config': lsp_settings#merge('aws-lsp-yaml', 'workspace_config', {'yaml': {'format': {'enable': v:true}, 'schemas': lsp_settings#utils#load_schemas_map('aws-lsp-yaml')}}),
+    \ 'semantic_highlight': lsp_settings#get('aws-lsp-yaml', 'semantic_highlight', {}),
+    \ })
 
 function! s:set_schema(url) abort
   let l:name = fnamemodify(lsp#utils#get_buffer_uri(), ':t')

--- a/settings/aws-lsp-yaml.vim
+++ b/settings/aws-lsp-yaml.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_aws_lsp_yaml
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'aws-lsp-yaml',
       \ 'cmd': {server_info->lsp_settings#get('aws-lsp-yaml', 'cmd', [lsp_settings#exec_path('aws-lsp-yaml')]+lsp_settings#get('aws-lsp-yaml', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('aws-lsp-yaml', 'root_uri', lsp_settings#root_uri('aws-lsp-yaml'))},
@@ -10,7 +10,7 @@ augroup vim_lsp_settings_aws_lsp_yaml
       \ 'config': lsp_settings#get('aws-lsp-yaml', 'config', lsp_settings#server_config('aws-lsp-yaml')),
       \ 'workspace_config': lsp_settings#merge('aws-lsp-yaml', 'workspace_config', {'yaml': {'format': {'enable': v:true}, 'schemas': lsp_settings#utils#load_schemas_map('aws-lsp-yaml')}}),
       \ 'semantic_highlight': lsp_settings#get('aws-lsp-yaml', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END
 
 function! s:set_schema(url) abort

--- a/settings/aws-lsp-yaml.vim
+++ b/settings/aws-lsp-yaml.vim
@@ -26,7 +26,7 @@ function! s:on_lsp_buffer_enabled() abort
   endif
 endfunction
 
-augroup lsp_install_yaml
+augroup vim_lsp_settings_aws_lsp_yaml
   au!
   autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled()
 augroup END

--- a/settings/bacon-ls.vim
+++ b/settings/bacon-ls.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_bacon_ls
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'bacon-ls',
-      \ 'cmd': {server_info->lsp_settings#get('bacon-ls', 'cmd', [lsp_settings#exec_path('bacon-ls')]+lsp_settings#get('bacon-ls', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('bacon-ls', 'root_uri', lsp_settings#root_uri('bacon-ls'))},
-      \ 'initialization_options': lsp_settings#get('bacon-ls', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('bacon-ls', 'allowlist', ['rust']),
-      \ 'blocklist': lsp_settings#get('bacon-ls', 'blocklist', []),
-      \ 'config': lsp_settings#get('bacon-ls', 'config', lsp_settings#server_config('bacon-ls')),
-      \ 'workspace_config': lsp_settings#get('bacon-ls', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('bacon-ls', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'bacon-ls',
+    \ 'cmd': {server_info->lsp_settings#get('bacon-ls', 'cmd', [lsp_settings#exec_path('bacon-ls')]+lsp_settings#get('bacon-ls', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('bacon-ls', 'root_uri', lsp_settings#root_uri('bacon-ls'))},
+    \ 'initialization_options': lsp_settings#get('bacon-ls', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('bacon-ls', 'allowlist', ['rust']),
+    \ 'blocklist': lsp_settings#get('bacon-ls', 'blocklist', []),
+    \ 'config': lsp_settings#get('bacon-ls', 'config', lsp_settings#server_config('bacon-ls')),
+    \ 'workspace_config': lsp_settings#get('bacon-ls', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('bacon-ls', 'semantic_highlight', {}),
+    \ })

--- a/settings/bacon-ls.vim
+++ b/settings/bacon-ls.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_bacon_ls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'bacon-ls',
       \ 'cmd': {server_info->lsp_settings#get('bacon-ls', 'cmd', [lsp_settings#exec_path('bacon-ls')]+lsp_settings#get('bacon-ls', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('bacon-ls', 'root_uri', lsp_settings#root_uri('bacon-ls'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_bacon_ls
       \ 'config': lsp_settings#get('bacon-ls', 'config', lsp_settings#server_config('bacon-ls')),
       \ 'workspace_config': lsp_settings#get('bacon-ls', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('bacon-ls', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/basedpyright-langserver.vim
+++ b/settings/basedpyright-langserver.vim
@@ -1,20 +1,17 @@
-augroup vim_lsp_settings_basedpyright_langserver
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'basedpyright-langserver',
-      \ 'cmd': {server_info->lsp_settings#get('basedpyright-langserver', 'cmd', [lsp_settings#exec_path('basedpyright-langserver')]+lsp_settings#get('basedpyright-langserver', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('basedpyright-langserver', 'root_uri', lsp_settings#root_uri('basedpyright-langserver'))},
-      \ 'initialization_options': lsp_settings#get('basedpyright-langserver', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('basedpyright-langserver', 'allowlist', ['python']),
-      \ 'blocklist': lsp_settings#get('basedpyright-langserver', 'blocklist', []),
-      \ 'config': lsp_settings#get('basedpyright-langserver', 'config', lsp_settings#server_config('basedpyright-langserver')),
-      \ 'workspace_config': lsp_settings#get('basedpyright-langserver', 'workspace_config', {
-      \   'python': {
-      \     'analysis': {
-      \       'useLibraryCodeForTypes': v:true
-      \     },
-      \   },
-      \ }),
-      \ 'semantic_highlight': lsp_settings#get('basedpyright-langserver', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'basedpyright-langserver',
+    \ 'cmd': {server_info->lsp_settings#get('basedpyright-langserver', 'cmd', [lsp_settings#exec_path('basedpyright-langserver')]+lsp_settings#get('basedpyright-langserver', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('basedpyright-langserver', 'root_uri', lsp_settings#root_uri('basedpyright-langserver'))},
+    \ 'initialization_options': lsp_settings#get('basedpyright-langserver', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('basedpyright-langserver', 'allowlist', ['python']),
+    \ 'blocklist': lsp_settings#get('basedpyright-langserver', 'blocklist', []),
+    \ 'config': lsp_settings#get('basedpyright-langserver', 'config', lsp_settings#server_config('basedpyright-langserver')),
+    \ 'workspace_config': lsp_settings#get('basedpyright-langserver', 'workspace_config', {
+    \   'python': {
+    \     'analysis': {
+    \       'useLibraryCodeForTypes': v:true
+    \     },
+    \   },
+    \ }),
+    \ 'semantic_highlight': lsp_settings#get('basedpyright-langserver', 'semantic_highlight', {}),
+    \ })

--- a/settings/basedpyright-langserver.vim
+++ b/settings/basedpyright-langserver.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_basedpyright_langserver
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'basedpyright-langserver',
       \ 'cmd': {server_info->lsp_settings#get('basedpyright-langserver', 'cmd', [lsp_settings#exec_path('basedpyright-langserver')]+lsp_settings#get('basedpyright-langserver', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('basedpyright-langserver', 'root_uri', lsp_settings#root_uri('basedpyright-langserver'))},
@@ -16,5 +16,5 @@ augroup vim_lsp_settings_basedpyright_langserver
       \   },
       \ }),
       \ 'semantic_highlight': lsp_settings#get('basedpyright-langserver', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/bash-language-server.vim
+++ b/settings/bash-language-server.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_bash_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'bash-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('bash-language-server', 'cmd', [lsp_settings#exec_path('bash-language-server')]+lsp_settings#get('bash-language-server', 'args', ['start']))},
-      \ 'root_uri':{server_info->lsp_settings#get('bash-language-server', 'root_uri', lsp_settings#root_uri('bash-language-server'))},
-      \ 'initialization_options': lsp_settings#get('bash-language-server', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('bash-language-server', 'allowlist', ['sh']),
-      \ 'blocklist': lsp_settings#get('bash-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('bash-language-server', 'config', lsp_settings#server_config('bash-language-server')),
-      \ 'workspace_config': lsp_settings#get('bash-language-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('bash-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'bash-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('bash-language-server', 'cmd', [lsp_settings#exec_path('bash-language-server')]+lsp_settings#get('bash-language-server', 'args', ['start']))},
+    \ 'root_uri':{server_info->lsp_settings#get('bash-language-server', 'root_uri', lsp_settings#root_uri('bash-language-server'))},
+    \ 'initialization_options': lsp_settings#get('bash-language-server', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('bash-language-server', 'allowlist', ['sh']),
+    \ 'blocklist': lsp_settings#get('bash-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('bash-language-server', 'config', lsp_settings#server_config('bash-language-server')),
+    \ 'workspace_config': lsp_settings#get('bash-language-server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('bash-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/bash-language-server.vim
+++ b/settings/bash-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_bash_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'bash-language-server',
       \ 'cmd': {server_info->lsp_settings#get('bash-language-server', 'cmd', [lsp_settings#exec_path('bash-language-server')]+lsp_settings#get('bash-language-server', 'args', ['start']))},
       \ 'root_uri':{server_info->lsp_settings#get('bash-language-server', 'root_uri', lsp_settings#root_uri('bash-language-server'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_bash_language_server
       \ 'config': lsp_settings#get('bash-language-server', 'config', lsp_settings#server_config('bash-language-server')),
       \ 'workspace_config': lsp_settings#get('bash-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('bash-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/biome.vim
+++ b/settings/biome.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_biome
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'biome',
       \ 'cmd': {server_info->lsp_settings#get('biome', 'cmd', [lsp_settings#exec_path('biome')]+lsp_settings#get('biome', 'args', ['lsp-proxy']))},
       \ 'root_uri':{server_info->lsp_settings#get('biome', 'root_uri', lsp_settings#root_uri('biome'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_biome
       \ 'config': lsp_settings#get('biome', 'config', {}),
       \ 'workspace_config': lsp_settings#get('biome', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('biome', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/biome.vim
+++ b/settings/biome.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_biome
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'biome',
-      \ 'cmd': {server_info->lsp_settings#get('biome', 'cmd', [lsp_settings#exec_path('biome')]+lsp_settings#get('biome', 'args', ['lsp-proxy']))},
-      \ 'root_uri':{server_info->lsp_settings#get('biome', 'root_uri', lsp_settings#root_uri('biome'))},
-      \ 'initialization_options': lsp_settings#get('biome', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('biome', 'allowlist', ['typescript', 'javascript', 'typescriptreact', 'javascriptreact', 'json', 'jsonc']),
-      \ 'blocklist': lsp_settings#get('biome', 'blocklist', []),
-      \ 'config': lsp_settings#get('biome', 'config', {}),
-      \ 'workspace_config': lsp_settings#get('biome', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('biome', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'biome',
+    \ 'cmd': {server_info->lsp_settings#get('biome', 'cmd', [lsp_settings#exec_path('biome')]+lsp_settings#get('biome', 'args', ['lsp-proxy']))},
+    \ 'root_uri':{server_info->lsp_settings#get('biome', 'root_uri', lsp_settings#root_uri('biome'))},
+    \ 'initialization_options': lsp_settings#get('biome', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('biome', 'allowlist', ['typescript', 'javascript', 'typescriptreact', 'javascriptreact', 'json', 'jsonc']),
+    \ 'blocklist': lsp_settings#get('biome', 'blocklist', []),
+    \ 'config': lsp_settings#get('biome', 'config', {}),
+    \ 'workspace_config': lsp_settings#get('biome', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('biome', 'semantic_highlight', {}),
+    \ })

--- a/settings/buf.vim
+++ b/settings/buf.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_buf
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'buf',
-      \ 'cmd': {server_info->lsp_settings#get('buf', 'cmd', [lsp_settings#exec_path('buf')]+lsp_settings#get('buf', 'args', ['lsp', 'serve']))},
-      \ 'root_uri':{server_info->lsp_settings#get('buf', 'root_uri', lsp_settings#root_uri('buf'))},
-      \ 'initialization_options': lsp_settings#get('buf', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('buf', 'allowlist', ['proto']),
-      \ 'blocklist': lsp_settings#get('buf', 'blocklist', []),
-      \ 'config': lsp_settings#get('buf', 'config', lsp_settings#server_config('buf')),
-      \ 'workspace_config': lsp_settings#get('buf', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('buf', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'buf',
+    \ 'cmd': {server_info->lsp_settings#get('buf', 'cmd', [lsp_settings#exec_path('buf')]+lsp_settings#get('buf', 'args', ['lsp', 'serve']))},
+    \ 'root_uri':{server_info->lsp_settings#get('buf', 'root_uri', lsp_settings#root_uri('buf'))},
+    \ 'initialization_options': lsp_settings#get('buf', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('buf', 'allowlist', ['proto']),
+    \ 'blocklist': lsp_settings#get('buf', 'blocklist', []),
+    \ 'config': lsp_settings#get('buf', 'config', lsp_settings#server_config('buf')),
+    \ 'workspace_config': lsp_settings#get('buf', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('buf', 'semantic_highlight', {}),
+    \ })

--- a/settings/buf.vim
+++ b/settings/buf.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_buf
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'buf',
       \ 'cmd': {server_info->lsp_settings#get('buf', 'cmd', [lsp_settings#exec_path('buf')]+lsp_settings#get('buf', 'args', ['lsp', 'serve']))},
       \ 'root_uri':{server_info->lsp_settings#get('buf', 'root_uri', lsp_settings#root_uri('buf'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_buf
       \ 'config': lsp_settings#get('buf', 'config', lsp_settings#server_config('buf')),
       \ 'workspace_config': lsp_settings#get('buf', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('buf', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/cl-lsp.vim
+++ b/settings/cl-lsp.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_cl_lsp
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'cl-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('cl-lsp', 'cmd', {key, name-> ['ros', '-Q', '--', trim(filter(systemlist('ros version'), 'v:val=~"^homedir"')[0][8:], '"''') . '/bin/cl-lsp']+lsp_settings#get('cl-lsp', 'args', ['--stdio'])})},
-      \ 'root_uri':{server_info->lsp_settings#get('cl-lsp', 'root_uri', lsp_settings#root_uri('cl-lsp'))},
-      \ 'initialization_options': lsp_settings#get('cl-lsp', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('cl-lsp', 'allowlist', ['lisp']),
-      \ 'blocklist': lsp_settings#get('cl-lsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('cl-lsp', 'config', lsp_settings#server_config('cl-lsp')),
-      \ 'workspace_config': lsp_settings#get('cl-lsp', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('cl-lsp', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'cl-lsp',
+    \ 'cmd': {server_info->lsp_settings#get('cl-lsp', 'cmd', {key, name-> ['ros', '-Q', '--', trim(filter(systemlist('ros version'), 'v:val=~"^homedir"')[0][8:], '"''') . '/bin/cl-lsp']+lsp_settings#get('cl-lsp', 'args', ['--stdio'])})},
+    \ 'root_uri':{server_info->lsp_settings#get('cl-lsp', 'root_uri', lsp_settings#root_uri('cl-lsp'))},
+    \ 'initialization_options': lsp_settings#get('cl-lsp', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('cl-lsp', 'allowlist', ['lisp']),
+    \ 'blocklist': lsp_settings#get('cl-lsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('cl-lsp', 'config', lsp_settings#server_config('cl-lsp')),
+    \ 'workspace_config': lsp_settings#get('cl-lsp', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('cl-lsp', 'semantic_highlight', {}),
+    \ })

--- a/settings/cl-lsp.vim
+++ b/settings/cl-lsp.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_cl_lsp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'cl-lsp',
       \ 'cmd': {server_info->lsp_settings#get('cl-lsp', 'cmd', {key, name-> ['ros', '-Q', '--', trim(filter(systemlist('ros version'), 'v:val=~"^homedir"')[0][8:], '"''') . '/bin/cl-lsp']+lsp_settings#get('cl-lsp', 'args', ['--stdio'])})},
       \ 'root_uri':{server_info->lsp_settings#get('cl-lsp', 'root_uri', lsp_settings#root_uri('cl-lsp'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_cl_lsp
       \ 'config': lsp_settings#get('cl-lsp', 'config', lsp_settings#server_config('cl-lsp')),
       \ 'workspace_config': lsp_settings#get('cl-lsp', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('cl-lsp', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/clangd.vim
+++ b/settings/clangd.vim
@@ -1,17 +1,14 @@
-augroup vim_lsp_settings_clangd
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'clangd',
-      \ 'cmd': {server_info->lsp_settings#get('clangd', 'cmd', [lsp_settings#exec_path('clangd')]+lsp_settings#get('clangd', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('clangd', 'root_uri', lsp_settings#root_uri('clangd'))},
-      \ 'initialization_options': lsp_settings#get('clangd', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('clangd', 'allowlist', ['c', 'cpp', 'objc', 'objcpp', 'cuda']),
-      \ 'blocklist': lsp_settings#get('clangd', 'blocklist', []),
-      \ 'config': lsp_settings#get('clangd', 'config', lsp_settings#server_config('clangd')),
-      \ 'workspace_config': lsp_settings#get('clangd', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('clangd', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'clangd',
+    \ 'cmd': {server_info->lsp_settings#get('clangd', 'cmd', [lsp_settings#exec_path('clangd')]+lsp_settings#get('clangd', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('clangd', 'root_uri', lsp_settings#root_uri('clangd'))},
+    \ 'initialization_options': lsp_settings#get('clangd', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('clangd', 'allowlist', ['c', 'cpp', 'objc', 'objcpp', 'cuda']),
+    \ 'blocklist': lsp_settings#get('clangd', 'blocklist', []),
+    \ 'config': lsp_settings#get('clangd', 'config', lsp_settings#server_config('clangd')),
+    \ 'workspace_config': lsp_settings#get('clangd', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('clangd', 'semantic_highlight', {}),
+    \ })
 
 function! s:handle_document_switch_source_header(ctx, server, type, has_extension, data) abort "ctx = {counter, list, last_command_id}
   if a:ctx['last_command_id'] != lsp#_last_command()

--- a/settings/clangd.vim
+++ b/settings/clangd.vim
@@ -84,7 +84,7 @@ function! s:on_lsp_buffer_enabled() abort
   nnoremap <buffer> <plug>(lsp-switch-source-header) :<c-u>call <SID>document_switch_source_header()<cr>
 endfunction
 
-augroup lsp_install_clangd
+augroup vim_lsp_settings_clangd
   au!
   autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled()
 augroup END

--- a/settings/clangd.vim
+++ b/settings/clangd.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_clangd
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'clangd',
       \ 'cmd': {server_info->lsp_settings#get('clangd', 'cmd', [lsp_settings#exec_path('clangd')]+lsp_settings#get('clangd', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('clangd', 'root_uri', lsp_settings#root_uri('clangd'))},
@@ -10,7 +10,7 @@ augroup vim_lsp_settings_clangd
       \ 'config': lsp_settings#get('clangd', 'config', lsp_settings#server_config('clangd')),
       \ 'workspace_config': lsp_settings#get('clangd', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('clangd', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END
 
 function! s:handle_document_switch_source_header(ctx, server, type, has_extension, data) abort "ctx = {counter, list, last_command_id}

--- a/settings/clj-kondo-lsp.vim
+++ b/settings/clj-kondo-lsp.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_clj_kondo_lsp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'clj-kondo-lsp',
       \ 'cmd': {server_info->lsp_settings#get('clj-kondo-lsp', 'cmd', ['java', '-jar', lsp_settings#exec_path('clj-kondo-lsp')]+lsp_settings#get('clj-kondo-lsp', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('clj-kondo-lsp', 'root_uri', lsp_settings#root_uri('clj-kondo-lsp'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_clj_kondo_lsp
       \ 'config': lsp_settings#get('clj-kondo-lsp', 'config', lsp_settings#server_config('clj-kondo-lsp')),
       \ 'workspace_config': lsp_settings#get('clj-kondo-lsp', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('clj-kondo-lsp', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/clj-kondo-lsp.vim
+++ b/settings/clj-kondo-lsp.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_clj_kondo_lsp
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'clj-kondo-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('clj-kondo-lsp', 'cmd', ['java', '-jar', lsp_settings#exec_path('clj-kondo-lsp')]+lsp_settings#get('clj-kondo-lsp', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('clj-kondo-lsp', 'root_uri', lsp_settings#root_uri('clj-kondo-lsp'))},
-      \ 'initialization_options': lsp_settings#get('clj-kondo-lsp', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('clj-kondo-lsp', 'allowlist', ['clojure']),
-      \ 'blocklist': lsp_settings#get('clj-kondo-lsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('clj-kondo-lsp', 'config', lsp_settings#server_config('clj-kondo-lsp')),
-      \ 'workspace_config': lsp_settings#get('clj-kondo-lsp', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('clj-kondo-lsp', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'clj-kondo-lsp',
+    \ 'cmd': {server_info->lsp_settings#get('clj-kondo-lsp', 'cmd', ['java', '-jar', lsp_settings#exec_path('clj-kondo-lsp')]+lsp_settings#get('clj-kondo-lsp', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('clj-kondo-lsp', 'root_uri', lsp_settings#root_uri('clj-kondo-lsp'))},
+    \ 'initialization_options': lsp_settings#get('clj-kondo-lsp', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('clj-kondo-lsp', 'allowlist', ['clojure']),
+    \ 'blocklist': lsp_settings#get('clj-kondo-lsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('clj-kondo-lsp', 'config', lsp_settings#server_config('clj-kondo-lsp')),
+    \ 'workspace_config': lsp_settings#get('clj-kondo-lsp', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('clj-kondo-lsp', 'semantic_highlight', {}),
+    \ })

--- a/settings/clojure-lsp.vim
+++ b/settings/clojure-lsp.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_clojure_lsp
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'clojure-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('clojure-lsp', 'cmd', [lsp_settings#exec_path('clojure-lsp')]+lsp_settings#get('clojure-lsp', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('clojure-lsp', 'root_uri', lsp_settings#root_uri('clojure-lsp'))},
-      \ 'initialization_options': lsp_settings#get('clojure-lsp', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('clojure-lsp', 'allowlist', ['clojure']),
-      \ 'blocklist': lsp_settings#get('clojure-lsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('clojure-lsp', 'config', lsp_settings#server_config('clojure-lsp')),
-      \ 'workspace_config': lsp_settings#get('clojure-lsp', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('clojure-lsp', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'clojure-lsp',
+    \ 'cmd': {server_info->lsp_settings#get('clojure-lsp', 'cmd', [lsp_settings#exec_path('clojure-lsp')]+lsp_settings#get('clojure-lsp', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('clojure-lsp', 'root_uri', lsp_settings#root_uri('clojure-lsp'))},
+    \ 'initialization_options': lsp_settings#get('clojure-lsp', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('clojure-lsp', 'allowlist', ['clojure']),
+    \ 'blocklist': lsp_settings#get('clojure-lsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('clojure-lsp', 'config', lsp_settings#server_config('clojure-lsp')),
+    \ 'workspace_config': lsp_settings#get('clojure-lsp', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('clojure-lsp', 'semantic_highlight', {}),
+    \ })

--- a/settings/clojure-lsp.vim
+++ b/settings/clojure-lsp.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_clojure_lsp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'clojure-lsp',
       \ 'cmd': {server_info->lsp_settings#get('clojure-lsp', 'cmd', [lsp_settings#exec_path('clojure-lsp')]+lsp_settings#get('clojure-lsp', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('clojure-lsp', 'root_uri', lsp_settings#root_uri('clojure-lsp'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_clojure_lsp
       \ 'config': lsp_settings#get('clojure-lsp', 'config', lsp_settings#server_config('clojure-lsp')),
       \ 'workspace_config': lsp_settings#get('clojure-lsp', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('clojure-lsp', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/cmake-language-server.vim
+++ b/settings/cmake-language-server.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_cmake-language-server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'cmake-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('cmake-language-server', 'cmd', [lsp_settings#exec_path('cmake-language-server')]+lsp_settings#get('cmake-language-server', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('cmake-language-server', 'root_uri', lsp_settings#root_uri('cmake-language-server'))},
-      \ 'initialization_options': lsp_settings#get('cmake-language-server', 'initialization_options', {'buildDirectory': 'build'}),
-      \ 'allowlist': lsp_settings#get('cmake-language-server', 'allowlist', ['cmake']),
-      \ 'blocklist': lsp_settings#get('cmake-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('cmake-language-server', 'config', lsp_settings#server_config('cmake-language-server')),
-      \ 'workspace_config': lsp_settings#get('cmake-language-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('cmake-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'cmake-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('cmake-language-server', 'cmd', [lsp_settings#exec_path('cmake-language-server')]+lsp_settings#get('cmake-language-server', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('cmake-language-server', 'root_uri', lsp_settings#root_uri('cmake-language-server'))},
+    \ 'initialization_options': lsp_settings#get('cmake-language-server', 'initialization_options', {'buildDirectory': 'build'}),
+    \ 'allowlist': lsp_settings#get('cmake-language-server', 'allowlist', ['cmake']),
+    \ 'blocklist': lsp_settings#get('cmake-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('cmake-language-server', 'config', lsp_settings#server_config('cmake-language-server')),
+    \ 'workspace_config': lsp_settings#get('cmake-language-server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('cmake-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/cmake-language-server.vim
+++ b/settings/cmake-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_cmake-language-server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'cmake-language-server',
       \ 'cmd': {server_info->lsp_settings#get('cmake-language-server', 'cmd', [lsp_settings#exec_path('cmake-language-server')]+lsp_settings#get('cmake-language-server', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('cmake-language-server', 'root_uri', lsp_settings#root_uri('cmake-language-server'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_cmake-language-server
       \ 'config': lsp_settings#get('cmake-language-server', 'config', lsp_settings#server_config('cmake-language-server')),
       \ 'workspace_config': lsp_settings#get('cmake-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('cmake-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/cobol-language-support.vim
+++ b/settings/cobol-language-support.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_cobol_language_support
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'cobol-language-support',
-      \ 'cmd': {server_info->lsp_settings#get('cobol-language-support', 'cmd', [lsp_settings#exec_path('cobol-language-support')]+lsp_settings#get('cobol-language-support', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('cobol-language-server', 'root_uri', lsp_settings#root_uri('cobol-language-support'))},
-      \ 'initialization_options': lsp_settings#get('cobol-language-support', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('cobol-language-support', 'allowlist', ['cobol']),
-      \ 'blocklist': lsp_settings#get('cobol-language-support', 'blocklist', []),
-      \ 'config': lsp_settings#get('cobol-language-support', 'config', lsp_settings#server_config('cobol-language-support')),
-      \ 'workspace_config': lsp_settings#get('cobol-language-support', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('cobol-language-support', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'cobol-language-support',
+    \ 'cmd': {server_info->lsp_settings#get('cobol-language-support', 'cmd', [lsp_settings#exec_path('cobol-language-support')]+lsp_settings#get('cobol-language-support', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('cobol-language-server', 'root_uri', lsp_settings#root_uri('cobol-language-support'))},
+    \ 'initialization_options': lsp_settings#get('cobol-language-support', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('cobol-language-support', 'allowlist', ['cobol']),
+    \ 'blocklist': lsp_settings#get('cobol-language-support', 'blocklist', []),
+    \ 'config': lsp_settings#get('cobol-language-support', 'config', lsp_settings#server_config('cobol-language-support')),
+    \ 'workspace_config': lsp_settings#get('cobol-language-support', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('cobol-language-support', 'semantic_highlight', {}),
+    \ })

--- a/settings/cobol-language-support.vim
+++ b/settings/cobol-language-support.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_cobol_language_support
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'cobol-language-support',
       \ 'cmd': {server_info->lsp_settings#get('cobol-language-support', 'cmd', [lsp_settings#exec_path('cobol-language-support')]+lsp_settings#get('cobol-language-support', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('cobol-language-server', 'root_uri', lsp_settings#root_uri('cobol-language-support'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_cobol_language_support
       \ 'config': lsp_settings#get('cobol-language-support', 'config', lsp_settings#server_config('cobol-language-support')),
       \ 'workspace_config': lsp_settings#get('cobol-language-support', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('cobol-language-support', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/copilot-language-server.vim
+++ b/settings/copilot-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_copilot_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'copilot-language-server',
       \ 'cmd': {server_info->lsp_settings#get('copilot-language-server', 'cmd', [lsp_settings#exec_path('copilot-language-server')]+lsp_settings#get('copilot-language-server', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('copilot-language-server', 'root_uri', lsp_settings#root_uri('copilot-language-server'))},
@@ -10,7 +10,7 @@ augroup vim_lsp_settings_copilot_language_server
       \ 'config': lsp_settings#get('copilot-language-server', 'config', lsp_settings#server_config('copilot-language-server')),
       \ 'workspace_config': lsp_settings#merge('copilot-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('copilot-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END
 
 function! s:handle_finish(data) abort

--- a/settings/copilot-language-server.vim
+++ b/settings/copilot-language-server.vim
@@ -1,17 +1,14 @@
-augroup vim_lsp_settings_copilot_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'copilot-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('copilot-language-server', 'cmd', [lsp_settings#exec_path('copilot-language-server')]+lsp_settings#get('copilot-language-server', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('copilot-language-server', 'root_uri', lsp_settings#root_uri('copilot-language-server'))},
-      \ 'initialization_options': lsp_settings#get('copilot-language-server', 'initialization_options', {"editorInfo": { "name": "GNU ed", "version": "1.19" }, "editorPluginInfo": { "name": "GitHub Copilot for ed", "version": "1.0.0" }}),
-      \ 'allowlist': lsp_settings#get('copilot-language-server', 'allowlist', ['*']),
-      \ 'blocklist': lsp_settings#get('copilot-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('copilot-language-server', 'config', lsp_settings#server_config('copilot-language-server')),
-      \ 'workspace_config': lsp_settings#merge('copilot-language-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('copilot-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'copilot-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('copilot-language-server', 'cmd', [lsp_settings#exec_path('copilot-language-server')]+lsp_settings#get('copilot-language-server', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('copilot-language-server', 'root_uri', lsp_settings#root_uri('copilot-language-server'))},
+    \ 'initialization_options': lsp_settings#get('copilot-language-server', 'initialization_options', {"editorInfo": { "name": "GNU ed", "version": "1.19" }, "editorPluginInfo": { "name": "GitHub Copilot for ed", "version": "1.0.0" }}),
+    \ 'allowlist': lsp_settings#get('copilot-language-server', 'allowlist', ['*']),
+    \ 'blocklist': lsp_settings#get('copilot-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('copilot-language-server', 'config', lsp_settings#server_config('copilot-language-server')),
+    \ 'workspace_config': lsp_settings#merge('copilot-language-server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('copilot-language-server', 'semantic_highlight', {}),
+    \ })
 
 function! s:handle_finish(data) abort
   let l:command = a:data['response']['result']

--- a/settings/copilot-language-server.vim
+++ b/settings/copilot-language-server.vim
@@ -51,7 +51,7 @@ function! s:on_lsp_buffer_enabled() abort
   \ })
 endfunction
 
-augroup lsp_install_copilot
+augroup vim_lsp_settings_copilot_language_server
   au!
   autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled()
 augroup END

--- a/settings/crystalline.vim
+++ b/settings/crystalline.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_crystalline
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'crystalline',
-      \ 'cmd': {server_info->lsp_settings#get('crystalline', 'cmd', [lsp_settings#exec_path('crystalline')]+lsp_settings#get('crystalline', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('crystalline', 'root_uri', lsp_settings#root_uri('crystalline'))},
-      \ 'initialization_options': lsp_settings#get('crystalline', 'initialization_options', {'diagnostics': 'true'}),
-      \ 'allowlist': lsp_settings#get('crystalline', 'allowlist', ['crystal']),
-      \ 'blocklist': lsp_settings#get('crystalline', 'blocklist', []),
-      \ 'config': lsp_settings#get('crystalline', 'config', lsp_settings#server_config('crystalline')),
-      \ 'workspace_config': lsp_settings#get('crystalline', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('crystalline', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'crystalline',
+    \ 'cmd': {server_info->lsp_settings#get('crystalline', 'cmd', [lsp_settings#exec_path('crystalline')]+lsp_settings#get('crystalline', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('crystalline', 'root_uri', lsp_settings#root_uri('crystalline'))},
+    \ 'initialization_options': lsp_settings#get('crystalline', 'initialization_options', {'diagnostics': 'true'}),
+    \ 'allowlist': lsp_settings#get('crystalline', 'allowlist', ['crystal']),
+    \ 'blocklist': lsp_settings#get('crystalline', 'blocklist', []),
+    \ 'config': lsp_settings#get('crystalline', 'config', lsp_settings#server_config('crystalline')),
+    \ 'workspace_config': lsp_settings#get('crystalline', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('crystalline', 'semantic_highlight', {}),
+    \ })

--- a/settings/crystalline.vim
+++ b/settings/crystalline.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_crystalline
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'crystalline',
       \ 'cmd': {server_info->lsp_settings#get('crystalline', 'cmd', [lsp_settings#exec_path('crystalline')]+lsp_settings#get('crystalline', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('crystalline', 'root_uri', lsp_settings#root_uri('crystalline'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_crystalline
       \ 'config': lsp_settings#get('crystalline', 'config', lsp_settings#server_config('crystalline')),
       \ 'workspace_config': lsp_settings#get('crystalline', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('crystalline', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/css-languageserver.vim
+++ b/settings/css-languageserver.vim
@@ -1,20 +1,17 @@
-augroup vim_lsp_settings_css_languageserver
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'css-languageserver',
-      \ 'cmd': {server_info->lsp_settings#get('css-languageserver', 'cmd', [lsp_settings#exec_path('css-languageserver')]+lsp_settings#get('css-languageserver', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('css-languageserver', 'root_uri', lsp_settings#root_uri('css-languageserver'))},
-      \ 'initialization_options': lsp_settings#get('css-languageserver', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('css-languageserver', 'allowlist', ['css', 'less', 'sass', 'scss']),
-      \ 'blocklist': lsp_settings#get('css-languageserver', 'blocklist', []),
-      \ 'config': lsp_settings#get('css-languageserver', 'config', lsp_settings#server_config('css-languageserver')),
-      \ 'workspace_config': lsp_settings#get('css-languageserver', 'workspace_config', {
-      \   'css': {'lint': {'validProperties': []}},
-      \   'less': {'lint': {'validProperties': []}},
-      \   'sass': {'lint': {'validProperties': []}},
-      \   'scss': {'lint': {'validProperties': []}},
-      \ }),
-      \ 'semantic_highlight': lsp_settings#get('css-languageserver', 'semantic_highlight', {}),
-      \ 'deprecated': v:true,
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'css-languageserver',
+    \ 'cmd': {server_info->lsp_settings#get('css-languageserver', 'cmd', [lsp_settings#exec_path('css-languageserver')]+lsp_settings#get('css-languageserver', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('css-languageserver', 'root_uri', lsp_settings#root_uri('css-languageserver'))},
+    \ 'initialization_options': lsp_settings#get('css-languageserver', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('css-languageserver', 'allowlist', ['css', 'less', 'sass', 'scss']),
+    \ 'blocklist': lsp_settings#get('css-languageserver', 'blocklist', []),
+    \ 'config': lsp_settings#get('css-languageserver', 'config', lsp_settings#server_config('css-languageserver')),
+    \ 'workspace_config': lsp_settings#get('css-languageserver', 'workspace_config', {
+    \   'css': {'lint': {'validProperties': []}},
+    \   'less': {'lint': {'validProperties': []}},
+    \   'sass': {'lint': {'validProperties': []}},
+    \   'scss': {'lint': {'validProperties': []}},
+    \ }),
+    \ 'semantic_highlight': lsp_settings#get('css-languageserver', 'semantic_highlight', {}),
+    \ 'deprecated': v:true,
+    \ })

--- a/settings/css-languageserver.vim
+++ b/settings/css-languageserver.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_css_languageserver
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'css-languageserver',
       \ 'cmd': {server_info->lsp_settings#get('css-languageserver', 'cmd', [lsp_settings#exec_path('css-languageserver')]+lsp_settings#get('css-languageserver', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('css-languageserver', 'root_uri', lsp_settings#root_uri('css-languageserver'))},
@@ -16,5 +16,5 @@ augroup vim_lsp_settings_css_languageserver
       \ }),
       \ 'semantic_highlight': lsp_settings#get('css-languageserver', 'semantic_highlight', {}),
       \ 'deprecated': v:true,
-      \ }
+      \ })
 augroup END

--- a/settings/debian-lsp.vim
+++ b/settings/debian-lsp.vim
@@ -1,11 +1,11 @@
 augroup vim_lsp_settings_debian_lsp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'debian-lsp',
       \ 'cmd': {server_info->lsp_settings#get('debian-lsp', 'cmd', [lsp_settings#exec_path('debian-lsp')]+lsp_settings#get('debian-lsp', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('debian-lsp', 'root_uri', lsp_settings#root_uri('debian-lsp'))},
       \ 'allowlist': lsp_settings#get('debian-lsp', 'allowlist', ['debcontrol', 'debcopyright', 'debchangelog', 'debsources', 'debwatch', 'debupstream', 'autopkgtest']),
       \ 'blocklist': lsp_settings#get('debian-lsp', 'blocklist', []),
       \ 'config': lsp_settings#get('debian-lsp', 'config', lsp_settings#server_config('debian-lsp')),
-      \ }
+      \ })
 augroup END

--- a/settings/debian-lsp.vim
+++ b/settings/debian-lsp.vim
@@ -1,11 +1,8 @@
-augroup vim_lsp_settings_debian_lsp
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'debian-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('debian-lsp', 'cmd', [lsp_settings#exec_path('debian-lsp')]+lsp_settings#get('debian-lsp', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('debian-lsp', 'root_uri', lsp_settings#root_uri('debian-lsp'))},
-      \ 'allowlist': lsp_settings#get('debian-lsp', 'allowlist', ['debcontrol', 'debcopyright', 'debchangelog', 'debsources', 'debwatch', 'debupstream', 'autopkgtest']),
-      \ 'blocklist': lsp_settings#get('debian-lsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('debian-lsp', 'config', lsp_settings#server_config('debian-lsp')),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'debian-lsp',
+    \ 'cmd': {server_info->lsp_settings#get('debian-lsp', 'cmd', [lsp_settings#exec_path('debian-lsp')]+lsp_settings#get('debian-lsp', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('debian-lsp', 'root_uri', lsp_settings#root_uri('debian-lsp'))},
+    \ 'allowlist': lsp_settings#get('debian-lsp', 'allowlist', ['debcontrol', 'debcopyright', 'debchangelog', 'debsources', 'debwatch', 'debupstream', 'autopkgtest']),
+    \ 'blocklist': lsp_settings#get('debian-lsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('debian-lsp', 'config', lsp_settings#server_config('debian-lsp')),
+    \ })

--- a/settings/deno.vim
+++ b/settings/deno.vim
@@ -1,4 +1,4 @@
-function! Vim_lsp_settings_deno_get_blocklist() abort
+function! s:get_blocklist() abort
     if !empty(lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'deno.json'))
         return []
     endif
@@ -15,13 +15,13 @@ endfunction
 
 augroup vim_lsp_settings_deno
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'deno',
       \ 'cmd': {server_info->lsp_settings#get('deno', 'cmd', [lsp_settings#exec_path('deno')]+lsp_settings#get('deno', 'args', ['lsp']))},
       \ 'root_uri':{server_info->lsp_settings#get('deno', 'root_uri', lsp_settings#root_uri('deno'))},
       \ 'initialization_options': lsp_settings#get('deno', 'initialization_options', {}),
       \ 'allowlist': lsp_settings#get('deno', 'allowlist', ['typescript', 'javascript', 'typescriptreact', 'javascriptreact']),
-      \ 'blocklist': lsp_settings#get('deno', 'blocklist', Vim_lsp_settings_deno_get_blocklist()),
+      \ 'blocklist': lsp_settings#get('deno', 'blocklist', s:get_blocklist()),
       \ 'config': lsp_settings#get('deno', 'config', lsp_settings#server_config('deno')),
       \ 'workspace_config': lsp_settings#get('deno', 'workspace_config', {
       \   'deno': {
@@ -77,7 +77,7 @@ augroup vim_lsp_settings_deno
       \   },
       \ }),
       \ 'semantic_highlight': lsp_settings#get('deno', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END
 
 function! s:open_new_buffer(ctx, server, type, data) abort

--- a/settings/deno.vim
+++ b/settings/deno.vim
@@ -425,7 +425,7 @@ function! s:register_command() abort
     call lsp#register_command('', function('s:noop'))
 endfunction
 
-augroup lsp_install_deno
+augroup vim_lsp_settings_deno
   au!
   autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled()
   autocmd User lsp_setup call s:register_command()

--- a/settings/deno.vim
+++ b/settings/deno.vim
@@ -13,72 +13,69 @@ function! s:get_blocklist() abort
     return ['typescript', 'javascript', 'typescriptreact', 'javascriptreact']
 endfunction
 
-augroup vim_lsp_settings_deno
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'deno',
-      \ 'cmd': {server_info->lsp_settings#get('deno', 'cmd', [lsp_settings#exec_path('deno')]+lsp_settings#get('deno', 'args', ['lsp']))},
-      \ 'root_uri':{server_info->lsp_settings#get('deno', 'root_uri', lsp_settings#root_uri('deno'))},
-      \ 'initialization_options': lsp_settings#get('deno', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('deno', 'allowlist', ['typescript', 'javascript', 'typescriptreact', 'javascriptreact']),
-      \ 'blocklist': lsp_settings#get('deno', 'blocklist', s:get_blocklist()),
-      \ 'config': lsp_settings#get('deno', 'config', lsp_settings#server_config('deno')),
-      \ 'workspace_config': lsp_settings#get('deno', 'workspace_config', {
-      \   'deno': {
-      \     'enable': v:true,
-      \     'lint': v:true,
-      \     'unstable': v:true,
-      \     'importMap': empty(lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'import_map.json')) ? v:null : lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'import_map.json'),
-      \     'codeLens': {
-      \       'implementations': v:true,
-      \       'references': v:true,
-      \       'referencesAllFunctions': v:true,
-      \       'test': v:true,
-      \       'testArgs': ['--allow-all'],
-      \     },
-      \     "suggest": {
-      \       "autoImports": v:true,
-      \       "completeFunctionCalls": v:true,
-      \       "names": v:true,
-      \       "paths": v:true,
-      \       "imports": {
-      \         "autoDiscover": v:false,
-      \         "hosts": {
-      \           "https://deno.land/": v:true,
-      \         },
-      \       },
-      \     },
-      \     'config': empty(lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'tsconfig.json')) ? empty(lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), "deno.json")) ? v:null : lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), "deno.json") : lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'tsconfig.json'),
-      \     'internalDebug': lsp_settings#get('deno', 'internalDebug', v:false),
-      \   },
-      \   'typescript': {
-      \     'inlayHints': {
-      \       'parameterNames': {
-      \         'enabled': 'all',
-      \         'suppressWhenArgumentMatchesName': v:true,
-      \       },
-      \       'parameterTypes': {
-      \         'enabled': v:true,
-      \       },
-      \       'variableTypes': {
-      \         'enabled': v:true,
-      \         'suppressWhenTypeMatchesName': v:true,
-      \       },
-      \       'propertyDeclarationTypes': {
-      \         'enabled': v:true,
-      \       },
-      \       'functionLikeReturnTypes': {
-      \         'enabled': v:true,
-      \       },
-      \       'enumMemberValues': {
-      \         'enabled': v:true,
-      \       },
-      \     },
-      \   },
-      \ }),
-      \ 'semantic_highlight': lsp_settings#get('deno', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'deno',
+    \ 'cmd': {server_info->lsp_settings#get('deno', 'cmd', [lsp_settings#exec_path('deno')]+lsp_settings#get('deno', 'args', ['lsp']))},
+    \ 'root_uri':{server_info->lsp_settings#get('deno', 'root_uri', lsp_settings#root_uri('deno'))},
+    \ 'initialization_options': lsp_settings#get('deno', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('deno', 'allowlist', ['typescript', 'javascript', 'typescriptreact', 'javascriptreact']),
+    \ 'blocklist': lsp_settings#get('deno', 'blocklist', s:get_blocklist()),
+    \ 'config': lsp_settings#get('deno', 'config', lsp_settings#server_config('deno')),
+    \ 'workspace_config': lsp_settings#get('deno', 'workspace_config', {
+    \   'deno': {
+    \     'enable': v:true,
+    \     'lint': v:true,
+    \     'unstable': v:true,
+    \     'importMap': empty(lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'import_map.json')) ? v:null : lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'import_map.json'),
+    \     'codeLens': {
+    \       'implementations': v:true,
+    \       'references': v:true,
+    \       'referencesAllFunctions': v:true,
+    \       'test': v:true,
+    \       'testArgs': ['--allow-all'],
+    \     },
+    \     "suggest": {
+    \       "autoImports": v:true,
+    \       "completeFunctionCalls": v:true,
+    \       "names": v:true,
+    \       "paths": v:true,
+    \       "imports": {
+    \         "autoDiscover": v:false,
+    \         "hosts": {
+    \           "https://deno.land/": v:true,
+    \         },
+    \       },
+    \     },
+    \     'config': empty(lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'tsconfig.json')) ? empty(lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), "deno.json")) ? v:null : lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), "deno.json") : lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'tsconfig.json'),
+    \     'internalDebug': lsp_settings#get('deno', 'internalDebug', v:false),
+    \   },
+    \   'typescript': {
+    \     'inlayHints': {
+    \       'parameterNames': {
+    \         'enabled': 'all',
+    \         'suppressWhenArgumentMatchesName': v:true,
+    \       },
+    \       'parameterTypes': {
+    \         'enabled': v:true,
+    \       },
+    \       'variableTypes': {
+    \         'enabled': v:true,
+    \         'suppressWhenTypeMatchesName': v:true,
+    \       },
+    \       'propertyDeclarationTypes': {
+    \         'enabled': v:true,
+    \       },
+    \       'functionLikeReturnTypes': {
+    \         'enabled': v:true,
+    \       },
+    \       'enumMemberValues': {
+    \         'enabled': v:true,
+    \       },
+    \     },
+    \   },
+    \ }),
+    \ 'semantic_highlight': lsp_settings#get('deno', 'semantic_highlight', {}),
+    \ })
 
 function! s:open_new_buffer(ctx, server, type, data) abort
     " Based on vim-lsp/autoload/lsp/utils/location.vim s:open_location

--- a/settings/digestif.vim
+++ b/settings/digestif.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_digestif
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'digestif',
-      \ 'cmd': {server_info->lsp_settings#get('digestif', 'cmd', [lsp_settings#exec_path('digestif')]+lsp_settings#get('digestif', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('digestif', 'root_uri', lsp_settings#root_uri('digestif'))},
-      \ 'initialization_options': lsp_settings#get('digestif', 'initialization_options', has('macunix') ? v:null : {'diagnostics': 'true'}),
-      \ 'allowlist': lsp_settings#get('digestif', 'allowlist', ['plaintex', 'tex']),
-      \ 'blocklist': lsp_settings#get('digestif', 'blocklist', []),
-      \ 'config': lsp_settings#get('digestif', 'config', lsp_settings#server_config('digestif')),
-      \ 'workspace_config': lsp_settings#get('digestif', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('digestif', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'digestif',
+    \ 'cmd': {server_info->lsp_settings#get('digestif', 'cmd', [lsp_settings#exec_path('digestif')]+lsp_settings#get('digestif', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('digestif', 'root_uri', lsp_settings#root_uri('digestif'))},
+    \ 'initialization_options': lsp_settings#get('digestif', 'initialization_options', has('macunix') ? v:null : {'diagnostics': 'true'}),
+    \ 'allowlist': lsp_settings#get('digestif', 'allowlist', ['plaintex', 'tex']),
+    \ 'blocklist': lsp_settings#get('digestif', 'blocklist', []),
+    \ 'config': lsp_settings#get('digestif', 'config', lsp_settings#server_config('digestif')),
+    \ 'workspace_config': lsp_settings#get('digestif', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('digestif', 'semantic_highlight', {}),
+    \ })

--- a/settings/digestif.vim
+++ b/settings/digestif.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_digestif
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'digestif',
       \ 'cmd': {server_info->lsp_settings#get('digestif', 'cmd', [lsp_settings#exec_path('digestif')]+lsp_settings#get('digestif', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('digestif', 'root_uri', lsp_settings#root_uri('digestif'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_digestif
       \ 'config': lsp_settings#get('digestif', 'config', lsp_settings#server_config('digestif')),
       \ 'workspace_config': lsp_settings#get('digestif', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('digestif', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/dls.vim
+++ b/settings/dls.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_dls
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'dls',
-      \ 'cmd': {server_info->lsp_settings#get('dls', 'cmd', [lsp_settings#exec_path('dls')]+lsp_settings#get('dls', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('dls', 'root_uri', lsp_settings#root_uri('dls'))},
-      \ 'initialization_options': lsp_settings#get('dls', 'initialization_options', {'diagnostics': 'true'}),
-      \ 'allowlist': lsp_settings#get('dls', 'allowlist', ['d']),
-      \ 'blocklist': lsp_settings#get('dls', 'blocklist', []),
-      \ 'config': lsp_settings#get('dls', 'config', lsp_settings#server_config('dls')),
-      \ 'workspace_config': lsp_settings#get('dls', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('dls', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'dls',
+    \ 'cmd': {server_info->lsp_settings#get('dls', 'cmd', [lsp_settings#exec_path('dls')]+lsp_settings#get('dls', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('dls', 'root_uri', lsp_settings#root_uri('dls'))},
+    \ 'initialization_options': lsp_settings#get('dls', 'initialization_options', {'diagnostics': 'true'}),
+    \ 'allowlist': lsp_settings#get('dls', 'allowlist', ['d']),
+    \ 'blocklist': lsp_settings#get('dls', 'blocklist', []),
+    \ 'config': lsp_settings#get('dls', 'config', lsp_settings#server_config('dls')),
+    \ 'workspace_config': lsp_settings#get('dls', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('dls', 'semantic_highlight', {}),
+    \ })

--- a/settings/dls.vim
+++ b/settings/dls.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_dls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'dls',
       \ 'cmd': {server_info->lsp_settings#get('dls', 'cmd', [lsp_settings#exec_path('dls')]+lsp_settings#get('dls', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('dls', 'root_uri', lsp_settings#root_uri('dls'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_dls
       \ 'config': lsp_settings#get('dls', 'config', lsp_settings#server_config('dls')),
       \ 'workspace_config': lsp_settings#get('dls', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('dls', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/docker-langserver.vim
+++ b/settings/docker-langserver.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_dockerfile_language_server_nodejs
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'docker-langserver',
       \ 'cmd': {server_info->lsp_settings#get('docker-langserver', 'cmd', [lsp_settings#exec_path('docker-langserver')]+lsp_settings#get('docker-langserver', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('docker-langserver', 'root_uri', lsp_settings#root_uri('docker-langserver'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_dockerfile_language_server_nodejs
       \ 'config': lsp_settings#get('docker-langserver', 'config', lsp_settings#server_config('docker-langserver')),
       \ 'workspace_config': lsp_settings#get('docker-langserver', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('docker-langserver', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/docker-langserver.vim
+++ b/settings/docker-langserver.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_dockerfile_language_server_nodejs
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'docker-langserver',
-      \ 'cmd': {server_info->lsp_settings#get('docker-langserver', 'cmd', [lsp_settings#exec_path('docker-langserver')]+lsp_settings#get('docker-langserver', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('docker-langserver', 'root_uri', lsp_settings#root_uri('docker-langserver'))},
-      \ 'initialization_options': lsp_settings#get('docker-langserver', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('docker-langserver', 'allowlist', ['dockerfile']),
-      \ 'blocklist': lsp_settings#get('docker-langserver', 'blocklist', []),
-      \ 'config': lsp_settings#get('docker-langserver', 'config', lsp_settings#server_config('docker-langserver')),
-      \ 'workspace_config': lsp_settings#get('docker-langserver', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('docker-langserver', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'docker-langserver',
+    \ 'cmd': {server_info->lsp_settings#get('docker-langserver', 'cmd', [lsp_settings#exec_path('docker-langserver')]+lsp_settings#get('docker-langserver', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('docker-langserver', 'root_uri', lsp_settings#root_uri('docker-langserver'))},
+    \ 'initialization_options': lsp_settings#get('docker-langserver', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('docker-langserver', 'allowlist', ['dockerfile']),
+    \ 'blocklist': lsp_settings#get('docker-langserver', 'blocklist', []),
+    \ 'config': lsp_settings#get('docker-langserver', 'config', lsp_settings#server_config('docker-langserver')),
+    \ 'workspace_config': lsp_settings#get('docker-langserver', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('docker-langserver', 'semantic_highlight', {}),
+    \ })

--- a/settings/dot-language-server.vim
+++ b/settings/dot-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_dot_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'dot-language-server',
       \ 'cmd': {server_info->lsp_settings#get('dot-language-server', 'cmd', [lsp_settings#exec_path('dot-language-server')]+lsp_settings#get('dot-language-server', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('dot-language-server', 'root_uri', lsp_settings#root_uri('dot-language-server'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_dot_language_server
       \ 'config': lsp_settings#get('dot-language-server', 'config', lsp_settings#server_config('dot-language-server')),
       \ 'workspace_config': lsp_settings#get('dot-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('dot-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/dot-language-server.vim
+++ b/settings/dot-language-server.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_dot_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'dot-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('dot-language-server', 'cmd', [lsp_settings#exec_path('dot-language-server')]+lsp_settings#get('dot-language-server', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('dot-language-server', 'root_uri', lsp_settings#root_uri('dot-language-server'))},
-      \ 'initialization_options': lsp_settings#get('dot-language-server', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('dot-language-server', 'allowlist', ['dot']),
-      \ 'blocklist': lsp_settings#get('dot-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('dot-language-server', 'config', lsp_settings#server_config('dot-language-server')),
-      \ 'workspace_config': lsp_settings#get('dot-language-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('dot-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'dot-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('dot-language-server', 'cmd', [lsp_settings#exec_path('dot-language-server')]+lsp_settings#get('dot-language-server', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('dot-language-server', 'root_uri', lsp_settings#root_uri('dot-language-server'))},
+    \ 'initialization_options': lsp_settings#get('dot-language-server', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('dot-language-server', 'allowlist', ['dot']),
+    \ 'blocklist': lsp_settings#get('dot-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('dot-language-server', 'config', lsp_settings#server_config('dot-language-server')),
+    \ 'workspace_config': lsp_settings#get('dot-language-server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('dot-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/eclipse-jdt-ls.vim
+++ b/settings/eclipse-jdt-ls.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_eclipse_jdt_ls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'eclipse-jdt-ls',
       \ 'cmd': {server_info->lsp_settings#get('eclipse-jdt-ls', 'cmd', [lsp_settings#exec_path('eclipse-jdt-ls')]+lsp_settings#get('eclipse-jdt-ls', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('eclipse-jdt-ls', 'root_uri', lsp_settings#root_uri('eclipse-jdt-ls'))},
@@ -10,7 +10,7 @@ augroup vim_lsp_settings_eclipse_jdt_ls
       \ 'config': lsp_settings#get('eclipse-jdt-ls', 'config', lsp_settings#server_config('eclipse-jdt-ls')),
       \ 'workspace_config': lsp_settings#get('eclipse-jdt-ls', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('eclipse-jdt-ls', 'semantic_highlight', {}),
-      \ }
+      \ })
   autocmd User lsp_setup call s:register_command()
 augroup END
 

--- a/settings/eclipse-jdt-ls.vim
+++ b/settings/eclipse-jdt-ls.vim
@@ -1,16 +1,17 @@
+call lsp_settings#register_server({
+    \ 'name': 'eclipse-jdt-ls',
+    \ 'cmd': {server_info->lsp_settings#get('eclipse-jdt-ls', 'cmd', [lsp_settings#exec_path('eclipse-jdt-ls')]+lsp_settings#get('eclipse-jdt-ls', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('eclipse-jdt-ls', 'root_uri', lsp_settings#root_uri('eclipse-jdt-ls'))},
+    \ 'initialization_options': lsp_settings#get('eclipse-jdt-ls', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('eclipse-jdt-ls', 'allowlist', ['java']),
+    \ 'blocklist': lsp_settings#get('eclipse-jdt-ls', 'blocklist', []),
+    \ 'config': lsp_settings#get('eclipse-jdt-ls', 'config', lsp_settings#server_config('eclipse-jdt-ls')),
+    \ 'workspace_config': lsp_settings#get('eclipse-jdt-ls', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('eclipse-jdt-ls', 'semantic_highlight', {}),
+    \ })
+
 augroup vim_lsp_settings_eclipse_jdt_ls
   au!
-  call lsp_settings#register_server({
-      \ 'name': 'eclipse-jdt-ls',
-      \ 'cmd': {server_info->lsp_settings#get('eclipse-jdt-ls', 'cmd', [lsp_settings#exec_path('eclipse-jdt-ls')]+lsp_settings#get('eclipse-jdt-ls', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('eclipse-jdt-ls', 'root_uri', lsp_settings#root_uri('eclipse-jdt-ls'))},
-      \ 'initialization_options': lsp_settings#get('eclipse-jdt-ls', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('eclipse-jdt-ls', 'allowlist', ['java']),
-      \ 'blocklist': lsp_settings#get('eclipse-jdt-ls', 'blocklist', []),
-      \ 'config': lsp_settings#get('eclipse-jdt-ls', 'config', lsp_settings#server_config('eclipse-jdt-ls')),
-      \ 'workspace_config': lsp_settings#get('eclipse-jdt-ls', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('eclipse-jdt-ls', 'semantic_highlight', {}),
-      \ })
   autocmd User lsp_setup call s:register_command()
 augroup END
 

--- a/settings/efm-langserver.vim
+++ b/settings/efm-langserver.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_efm_langserver
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'efm-langserver',
-      \ 'cmd': {server_info->lsp_settings#get('efm-langserver', 'cmd', [lsp_settings#exec_path('efm-langserver')]+lsp_settings#get('efm-langserver', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('efm-langserver', 'root_uri', lsp_settings#root_uri('efm-langserver'))},
-      \ 'initialization_options': lsp_settings#get('efm-langserver', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('efm-langserver', 'allowlist', ['*']),
-      \ 'blocklist': lsp_settings#get('efm-langserver', 'blocklist', []),
-      \ 'config': lsp_settings#get('efm-langserver', 'config', lsp_settings#server_config('efm-langserver')),
-      \ 'workspace_config': lsp_settings#get('efm-langserver', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('efm-langserver', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'efm-langserver',
+    \ 'cmd': {server_info->lsp_settings#get('efm-langserver', 'cmd', [lsp_settings#exec_path('efm-langserver')]+lsp_settings#get('efm-langserver', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('efm-langserver', 'root_uri', lsp_settings#root_uri('efm-langserver'))},
+    \ 'initialization_options': lsp_settings#get('efm-langserver', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('efm-langserver', 'allowlist', ['*']),
+    \ 'blocklist': lsp_settings#get('efm-langserver', 'blocklist', []),
+    \ 'config': lsp_settings#get('efm-langserver', 'config', lsp_settings#server_config('efm-langserver')),
+    \ 'workspace_config': lsp_settings#get('efm-langserver', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('efm-langserver', 'semantic_highlight', {}),
+    \ })

--- a/settings/efm-langserver.vim
+++ b/settings/efm-langserver.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_efm_langserver
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'efm-langserver',
       \ 'cmd': {server_info->lsp_settings#get('efm-langserver', 'cmd', [lsp_settings#exec_path('efm-langserver')]+lsp_settings#get('efm-langserver', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('efm-langserver', 'root_uri', lsp_settings#root_uri('efm-langserver'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_efm_langserver
       \ 'config': lsp_settings#get('efm-langserver', 'config', lsp_settings#server_config('efm-langserver')),
       \ 'workspace_config': lsp_settings#get('efm-langserver', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('efm-langserver', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/elixir-ls.vim
+++ b/settings/elixir-ls.vim
@@ -1,15 +1,12 @@
-augroup vim_lsp_settings_elixir_ls
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'elixir-ls',
-      \ 'cmd': {server_info->lsp_settings#get('elixir-ls', 'cmd', [lsp_settings#exec_path('elixir-ls')]+lsp_settings#get('elixir-ls', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('elixir-ls', 'root_uri', lsp_settings#root_uri('elixir-ls'))},
-      \ 'initialization_options': lsp_settings#get('elixir-ls', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('elixir-ls', 'allowlist', ['elixir']),
-      \ 'blocklist': lsp_settings#get('elixir-ls', 'blocklist', []),
-      \ 'config': lsp_settings#get('elixir-ls', 'config', lsp_settings#server_config('elixir-ls')),
-      \ 'workspace_config': lsp_settings#get('elixir-ls', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('elixir-ls', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'elixir-ls',
+    \ 'cmd': {server_info->lsp_settings#get('elixir-ls', 'cmd', [lsp_settings#exec_path('elixir-ls')]+lsp_settings#get('elixir-ls', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('elixir-ls', 'root_uri', lsp_settings#root_uri('elixir-ls'))},
+    \ 'initialization_options': lsp_settings#get('elixir-ls', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('elixir-ls', 'allowlist', ['elixir']),
+    \ 'blocklist': lsp_settings#get('elixir-ls', 'blocklist', []),
+    \ 'config': lsp_settings#get('elixir-ls', 'config', lsp_settings#server_config('elixir-ls')),
+    \ 'workspace_config': lsp_settings#get('elixir-ls', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('elixir-ls', 'semantic_highlight', {}),
+    \ })
 

--- a/settings/elixir-ls.vim
+++ b/settings/elixir-ls.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_elixir_ls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'elixir-ls',
       \ 'cmd': {server_info->lsp_settings#get('elixir-ls', 'cmd', [lsp_settings#exec_path('elixir-ls')]+lsp_settings#get('elixir-ls', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('elixir-ls', 'root_uri', lsp_settings#root_uri('elixir-ls'))},
@@ -10,6 +10,6 @@ augroup vim_lsp_settings_elixir_ls
       \ 'config': lsp_settings#get('elixir-ls', 'config', lsp_settings#server_config('elixir-ls')),
       \ 'workspace_config': lsp_settings#get('elixir-ls', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('elixir-ls', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END
 

--- a/settings/elm-language-server.vim
+++ b/settings/elm-language-server.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_elm_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'elm-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('elm-language-server', 'cmd', [lsp_settings#exec_path('elm-language-server')]+lsp_settings#get('elm-language-server', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('elm-language-server', 'root_uri', lsp_settings#root_uri('elm-language-server'))},
-      \ 'initialization_options': lsp_settings#get('elm-language-server', 'initialization_options', {'elmPath': 'elm', 'runtime': 'node', 'elmFormatPath': 'elm-format', 'elmTestPath': 'elm-test'}),
-      \ 'allowlist': lsp_settings#get('elm-language-server', 'allowlist', ['elm', 'elm.tsx']),
-      \ 'blocklist': lsp_settings#get('elm-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('elm-language-server', 'config', lsp_settings#server_config('elm-language-server')),
-      \ 'workspace_config': lsp_settings#get('elm-language-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('elm-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'elm-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('elm-language-server', 'cmd', [lsp_settings#exec_path('elm-language-server')]+lsp_settings#get('elm-language-server', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('elm-language-server', 'root_uri', lsp_settings#root_uri('elm-language-server'))},
+    \ 'initialization_options': lsp_settings#get('elm-language-server', 'initialization_options', {'elmPath': 'elm', 'runtime': 'node', 'elmFormatPath': 'elm-format', 'elmTestPath': 'elm-test'}),
+    \ 'allowlist': lsp_settings#get('elm-language-server', 'allowlist', ['elm', 'elm.tsx']),
+    \ 'blocklist': lsp_settings#get('elm-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('elm-language-server', 'config', lsp_settings#server_config('elm-language-server')),
+    \ 'workspace_config': lsp_settings#get('elm-language-server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('elm-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/elm-language-server.vim
+++ b/settings/elm-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_elm_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'elm-language-server',
       \ 'cmd': {server_info->lsp_settings#get('elm-language-server', 'cmd', [lsp_settings#exec_path('elm-language-server')]+lsp_settings#get('elm-language-server', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('elm-language-server', 'root_uri', lsp_settings#root_uri('elm-language-server'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_elm_language_server
       \ 'config': lsp_settings#get('elm-language-server', 'config', lsp_settings#server_config('elm-language-server')),
       \ 'workspace_config': lsp_settings#get('elm-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('elm-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/emmylua-ls.vim
+++ b/settings/emmylua-ls.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_emmylua_ls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'emmylua-ls',
       \ 'cmd': {server_info->lsp_settings#get('emmylua-ls', 'cmd', [lsp_settings#exec_path('emmylua-ls')]+lsp_settings#get('emmylua-ls', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('emmylua-ls', 'root_uri', lsp_settings#root_uri('emmylua-ls'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_emmylua_ls
       \ 'config': lsp_settings#get('emmylua-ls', 'config', lsp_settings#server_config('emmylua-ls')),
       \ 'workspace_config': lsp_settings#get('emmylua-ls', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('emmylua-ls', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/emmylua-ls.vim
+++ b/settings/emmylua-ls.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_emmylua_ls
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'emmylua-ls',
-      \ 'cmd': {server_info->lsp_settings#get('emmylua-ls', 'cmd', [lsp_settings#exec_path('emmylua-ls')]+lsp_settings#get('emmylua-ls', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('emmylua-ls', 'root_uri', lsp_settings#root_uri('emmylua-ls'))},
-      \ 'initialization_options': lsp_settings#get('emmylua-ls', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('emmylua-ls', 'allowlist', ['lua']),
-      \ 'blocklist': lsp_settings#get('emmylua-ls', 'blocklist', []),
-      \ 'config': lsp_settings#get('emmylua-ls', 'config', lsp_settings#server_config('emmylua-ls')),
-      \ 'workspace_config': lsp_settings#get('emmylua-ls', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('emmylua-ls', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'emmylua-ls',
+    \ 'cmd': {server_info->lsp_settings#get('emmylua-ls', 'cmd', [lsp_settings#exec_path('emmylua-ls')]+lsp_settings#get('emmylua-ls', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('emmylua-ls', 'root_uri', lsp_settings#root_uri('emmylua-ls'))},
+    \ 'initialization_options': lsp_settings#get('emmylua-ls', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('emmylua-ls', 'allowlist', ['lua']),
+    \ 'blocklist': lsp_settings#get('emmylua-ls', 'blocklist', []),
+    \ 'config': lsp_settings#get('emmylua-ls', 'config', lsp_settings#server_config('emmylua-ls')),
+    \ 'workspace_config': lsp_settings#get('emmylua-ls', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('emmylua-ls', 'semantic_highlight', {}),
+    \ })

--- a/settings/erlang-ls.vim
+++ b/settings/erlang-ls.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_erlang_ls
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'erlang-ls',
-      \ 'cmd': {server_info->lsp_settings#get('erlang-ls', 'cmd', [lsp_settings#exec_path('erlang-ls')]+lsp_settings#get('erlang-ls', 'args', ['--transport', 'stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('erlang-ls', 'root_uri', lsp_settings#root_uri('erlang-ls'))},
-      \ 'initialization_options': lsp_settings#get('erlang-ls', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('erlang-ls', 'allowlist', ['erlang']),
-      \ 'blocklist': lsp_settings#get('erlang-ls', 'blocklist', []),
-      \ 'config': lsp_settings#get('erlang-ls', 'config', lsp_settings#server_config('erlang-ls')),
-      \ 'workspace_config': lsp_settings#get('erlang-ls', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('erlang-ls', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'erlang-ls',
+    \ 'cmd': {server_info->lsp_settings#get('erlang-ls', 'cmd', [lsp_settings#exec_path('erlang-ls')]+lsp_settings#get('erlang-ls', 'args', ['--transport', 'stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('erlang-ls', 'root_uri', lsp_settings#root_uri('erlang-ls'))},
+    \ 'initialization_options': lsp_settings#get('erlang-ls', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('erlang-ls', 'allowlist', ['erlang']),
+    \ 'blocklist': lsp_settings#get('erlang-ls', 'blocklist', []),
+    \ 'config': lsp_settings#get('erlang-ls', 'config', lsp_settings#server_config('erlang-ls')),
+    \ 'workspace_config': lsp_settings#get('erlang-ls', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('erlang-ls', 'semantic_highlight', {}),
+    \ })

--- a/settings/erlang-ls.vim
+++ b/settings/erlang-ls.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_erlang_ls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'erlang-ls',
       \ 'cmd': {server_info->lsp_settings#get('erlang-ls', 'cmd', [lsp_settings#exec_path('erlang-ls')]+lsp_settings#get('erlang-ls', 'args', ['--transport', 'stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('erlang-ls', 'root_uri', lsp_settings#root_uri('erlang-ls'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_erlang_ls
       \ 'config': lsp_settings#get('erlang-ls', 'config', lsp_settings#server_config('erlang-ls')),
       \ 'workspace_config': lsp_settings#get('erlang-ls', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('erlang-ls', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/esbonio.vim
+++ b/settings/esbonio.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_esbonio
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'esbonio',
-      \ 'cmd': {server_info->lsp_settings#get('esbonio', 'cmd', [lsp_settings#exec_path('esbonio')]+lsp_settings#get('esbonio', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('esbonio', 'root_uri', lsp_settings#root_uri('esbonio'))},
-      \ 'initialization_options': lsp_settings#get('esbonio', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('esbonio', 'allowlist', ['rst']),
-      \ 'blocklist': lsp_settings#get('esbonio', 'blocklist', []),
-      \ 'config': lsp_settings#get('esbonio', 'config', lsp_settings#server_config('esbonio')),
-      \ 'workspace_config': lsp_settings#get('esbonio', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('esbonio', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'esbonio',
+    \ 'cmd': {server_info->lsp_settings#get('esbonio', 'cmd', [lsp_settings#exec_path('esbonio')]+lsp_settings#get('esbonio', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('esbonio', 'root_uri', lsp_settings#root_uri('esbonio'))},
+    \ 'initialization_options': lsp_settings#get('esbonio', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('esbonio', 'allowlist', ['rst']),
+    \ 'blocklist': lsp_settings#get('esbonio', 'blocklist', []),
+    \ 'config': lsp_settings#get('esbonio', 'config', lsp_settings#server_config('esbonio')),
+    \ 'workspace_config': lsp_settings#get('esbonio', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('esbonio', 'semantic_highlight', {}),
+    \ })

--- a/settings/esbonio.vim
+++ b/settings/esbonio.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_esbonio
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'esbonio',
       \ 'cmd': {server_info->lsp_settings#get('esbonio', 'cmd', [lsp_settings#exec_path('esbonio')]+lsp_settings#get('esbonio', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('esbonio', 'root_uri', lsp_settings#root_uri('esbonio'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_esbonio
       \ 'config': lsp_settings#get('esbonio', 'config', lsp_settings#server_config('esbonio')),
       \ 'workspace_config': lsp_settings#get('esbonio', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('esbonio', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/eslint-language-server.vim
+++ b/settings/eslint-language-server.vim
@@ -1,37 +1,34 @@
-augroup vim_lsp_settings_eslint_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'eslint-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('eslint-language-server', 'cmd', [lsp_settings#exec_path('eslint-language-server')]+lsp_settings#get('eslint-language-server', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('eslint-language-server', 'root_uri', lsp_settings#root_uri('eslint-language-server'))},
-      \ 'initialization_options': lsp_settings#get('eslint-language-server', 'initialization_options', {'diagnostics': 'true'}),
-      \ 'allowlist': lsp_settings#get('eslint-language-server', 'allowlist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact']),
-      \ 'blocklist': lsp_settings#get('eslint-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('eslint-language-server', 'config', lsp_settings#server_config('eslint-language-server')),
-      \ 'workspace_config': lsp_settings#get('eslint-language-server', 'workspace_config', {
-      \   'validate': 'probe',
-      \   'packageManager': 'npm',
-      \   'codeActionOnSave': {
-      \     'enable': v:true,
-      \     'mode': 'all',
-      \   },
-      \   'codeAction': {
-      \     'disableRuleComment': {
-      \       'enable': v:true,
-      \       'location': 'separateLine',
-      \     },
-      \     'showDocumentation': {
-      \       'enable': v:true,
-      \     },
-      \   },
-      \   'format': v:false,
-      \   'quiet': v:false,
-      \   'onIgnoredFiles': 'off',
-      \   'options': {},
-      \   'run': 'onType',
-      \   'nodePath': v:null,
-      \   'useFlatConfig': v:true,
-      \ }),
-      \ 'semantic_highlight': lsp_settings#get('eslint-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'eslint-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('eslint-language-server', 'cmd', [lsp_settings#exec_path('eslint-language-server')]+lsp_settings#get('eslint-language-server', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('eslint-language-server', 'root_uri', lsp_settings#root_uri('eslint-language-server'))},
+    \ 'initialization_options': lsp_settings#get('eslint-language-server', 'initialization_options', {'diagnostics': 'true'}),
+    \ 'allowlist': lsp_settings#get('eslint-language-server', 'allowlist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact']),
+    \ 'blocklist': lsp_settings#get('eslint-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('eslint-language-server', 'config', lsp_settings#server_config('eslint-language-server')),
+    \ 'workspace_config': lsp_settings#get('eslint-language-server', 'workspace_config', {
+    \   'validate': 'probe',
+    \   'packageManager': 'npm',
+    \   'codeActionOnSave': {
+    \     'enable': v:true,
+    \     'mode': 'all',
+    \   },
+    \   'codeAction': {
+    \     'disableRuleComment': {
+    \       'enable': v:true,
+    \       'location': 'separateLine',
+    \     },
+    \     'showDocumentation': {
+    \       'enable': v:true,
+    \     },
+    \   },
+    \   'format': v:false,
+    \   'quiet': v:false,
+    \   'onIgnoredFiles': 'off',
+    \   'options': {},
+    \   'run': 'onType',
+    \   'nodePath': v:null,
+    \   'useFlatConfig': v:true,
+    \ }),
+    \ 'semantic_highlight': lsp_settings#get('eslint-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/eslint-language-server.vim
+++ b/settings/eslint-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_eslint_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'eslint-language-server',
       \ 'cmd': {server_info->lsp_settings#get('eslint-language-server', 'cmd', [lsp_settings#exec_path('eslint-language-server')]+lsp_settings#get('eslint-language-server', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('eslint-language-server', 'root_uri', lsp_settings#root_uri('eslint-language-server'))},
@@ -33,5 +33,5 @@ augroup vim_lsp_settings_eslint_language_server
       \   'useFlatConfig': v:true,
       \ }),
       \ 'semantic_highlight': lsp_settings#get('eslint-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/fennel-ls.vim
+++ b/settings/fennel-ls.vim
@@ -5,7 +5,7 @@ augroup vim_lsp_settings_fennel_ls
   else
     let Fennel_ls_cmd = {server_info->lsp_settings#get('fennel-ls', 'cmd', [lsp_settings#exec_path('fennel-ls')]+lsp_settings#get('fennel-ls', 'args', []))}
   endif
-  LspRegisterServer {
+  call lsp_settings#register_server({
         \ 'name': 'fennel-ls',
         \ 'cmd': Fennel_ls_cmd,
         \ 'root_uri':{server_info->lsp_settings#get('fennel-ls', 'root_uri', lsp_settings#root_uri('fennel-ls'))},
@@ -15,5 +15,5 @@ augroup vim_lsp_settings_fennel_ls
         \ 'config': lsp_settings#get('fennel-ls', 'config', lsp_settings#server_config('fennel-ls')),
         \ 'workspace_config': lsp_settings#get('fennel-ls', 'workspace_config', {}),
         \ 'semantic_highlight': lsp_settings#get('fennel-ls', 'semantic_highlight', {}),
-        \ }
+        \ })
 augroup END

--- a/settings/fennel-ls.vim
+++ b/settings/fennel-ls.vim
@@ -1,19 +1,16 @@
-augroup vim_lsp_settings_fennel_ls
-  au!
-  if has('win32') || has('win64')
-    let Fennel_ls_cmd = {server_info->lsp_settings#get('fennel-ls', 'cmd', ['lua.exe', lsp_settings#servers_dir().'\fennel-ls\fennel-ls']+lsp_settings#get('fennel-ls', 'args', []))}
-  else
-    let Fennel_ls_cmd = {server_info->lsp_settings#get('fennel-ls', 'cmd', [lsp_settings#exec_path('fennel-ls')]+lsp_settings#get('fennel-ls', 'args', []))}
-  endif
-  call lsp_settings#register_server({
-        \ 'name': 'fennel-ls',
-        \ 'cmd': Fennel_ls_cmd,
-        \ 'root_uri':{server_info->lsp_settings#get('fennel-ls', 'root_uri', lsp_settings#root_uri('fennel-ls'))},
-        \ 'initialization_options': lsp_settings#get('fennel-ls', 'initialization_options', v:null),
-        \ 'allowlist': lsp_settings#get('fennel-ls', 'allowlist', ['fennel']),
-        \ 'blocklist': lsp_settings#get('fennel-ls', 'blocklist', []),
-        \ 'config': lsp_settings#get('fennel-ls', 'config', lsp_settings#server_config('fennel-ls')),
-        \ 'workspace_config': lsp_settings#get('fennel-ls', 'workspace_config', {}),
-        \ 'semantic_highlight': lsp_settings#get('fennel-ls', 'semantic_highlight', {}),
-        \ })
-augroup END
+if has('win32') || has('win64')
+  let Fennel_ls_cmd = {server_info->lsp_settings#get('fennel-ls', 'cmd', ['lua.exe', lsp_settings#servers_dir().'\fennel-ls\fennel-ls']+lsp_settings#get('fennel-ls', 'args', []))}
+else
+  let Fennel_ls_cmd = {server_info->lsp_settings#get('fennel-ls', 'cmd', [lsp_settings#exec_path('fennel-ls')]+lsp_settings#get('fennel-ls', 'args', []))}
+endif
+call lsp_settings#register_server({
+      \ 'name': 'fennel-ls',
+      \ 'cmd': Fennel_ls_cmd,
+      \ 'root_uri':{server_info->lsp_settings#get('fennel-ls', 'root_uri', lsp_settings#root_uri('fennel-ls'))},
+      \ 'initialization_options': lsp_settings#get('fennel-ls', 'initialization_options', v:null),
+      \ 'allowlist': lsp_settings#get('fennel-ls', 'allowlist', ['fennel']),
+      \ 'blocklist': lsp_settings#get('fennel-ls', 'blocklist', []),
+      \ 'config': lsp_settings#get('fennel-ls', 'config', lsp_settings#server_config('fennel-ls')),
+      \ 'workspace_config': lsp_settings#get('fennel-ls', 'workspace_config', {}),
+      \ 'semantic_highlight': lsp_settings#get('fennel-ls', 'semantic_highlight', {}),
+      \ })

--- a/settings/flow.vim
+++ b/settings/flow.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_flow
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'flow',
-      \ 'cmd': {server_info->lsp_settings#get('node', 'cmd', [lsp_settings#exec_path('flow')]+lsp_settings#get('flow', 'args', ['lsp']))},
-      \ 'root_uri': {server_info->lsp#utils#path_to_uri(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), '.flowconfig'))},
-      \ 'initialization_options': lsp_settings#get('flow', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('flow', 'allowlist', ['javascript', 'javascriptreact']),
-      \ 'blocklist': lsp_settings#get('flow', 'blocklist', []),
-      \ 'config': lsp_settings#get('flow', 'config', {}),
-      \ 'workspace_config': lsp_settings#get('flow', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('flow', 'semantic_highlight', {}),
-      \})
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'flow',
+    \ 'cmd': {server_info->lsp_settings#get('node', 'cmd', [lsp_settings#exec_path('flow')]+lsp_settings#get('flow', 'args', ['lsp']))},
+    \ 'root_uri': {server_info->lsp#utils#path_to_uri(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), '.flowconfig'))},
+    \ 'initialization_options': lsp_settings#get('flow', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('flow', 'allowlist', ['javascript', 'javascriptreact']),
+    \ 'blocklist': lsp_settings#get('flow', 'blocklist', []),
+    \ 'config': lsp_settings#get('flow', 'config', {}),
+    \ 'workspace_config': lsp_settings#get('flow', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('flow', 'semantic_highlight', {}),
+    \})

--- a/settings/flow.vim
+++ b/settings/flow.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_flow
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'flow',
       \ 'cmd': {server_info->lsp_settings#get('node', 'cmd', [lsp_settings#exec_path('flow')]+lsp_settings#get('flow', 'args', ['lsp']))},
       \ 'root_uri': {server_info->lsp#utils#path_to_uri(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), '.flowconfig'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_flow
       \ 'config': lsp_settings#get('flow', 'config', {}),
       \ 'workspace_config': lsp_settings#get('flow', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('flow', 'semantic_highlight', {}),
-      \}
+      \})
 augroup END

--- a/settings/fortls.vim
+++ b/settings/fortls.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_fortls
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'fortls',
-      \ 'cmd': {server_info->lsp_settings#get('fortls', 'cmd', [lsp_settings#exec_path('fortls')]+lsp_settings#get('fortls', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('fortls', 'root_uri', lsp_settings#root_uri('fortls'))},
-      \ 'initialization_options': lsp_settings#get('fortls', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('fortls', 'allowlist', ['fortran']),
-      \ 'blocklist': lsp_settings#get('fortls', 'blocklist', []),
-      \ 'config': lsp_settings#get('fortls', 'config', lsp_settings#server_config('fortls')),
-      \ 'workspace_config': lsp_settings#get('fortls', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('fortls', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'fortls',
+    \ 'cmd': {server_info->lsp_settings#get('fortls', 'cmd', [lsp_settings#exec_path('fortls')]+lsp_settings#get('fortls', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('fortls', 'root_uri', lsp_settings#root_uri('fortls'))},
+    \ 'initialization_options': lsp_settings#get('fortls', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('fortls', 'allowlist', ['fortran']),
+    \ 'blocklist': lsp_settings#get('fortls', 'blocklist', []),
+    \ 'config': lsp_settings#get('fortls', 'config', lsp_settings#server_config('fortls')),
+    \ 'workspace_config': lsp_settings#get('fortls', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('fortls', 'semantic_highlight', {}),
+    \ })

--- a/settings/fortls.vim
+++ b/settings/fortls.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_fortls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'fortls',
       \ 'cmd': {server_info->lsp_settings#get('fortls', 'cmd', [lsp_settings#exec_path('fortls')]+lsp_settings#get('fortls', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('fortls', 'root_uri', lsp_settings#root_uri('fortls'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_fortls
       \ 'config': lsp_settings#get('fortls', 'config', lsp_settings#server_config('fortls')),
       \ 'workspace_config': lsp_settings#get('fortls', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('fortls', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/fsautocomplete.vim
+++ b/settings/fsautocomplete.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_fsautocomplete
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'fsautocomplete',
       \ 'cmd': {server_info->lsp_settings#get('fsautocomplete', 'cmd', [lsp_settings#exec_path('fsautocomplete')]+lsp_settings#get('fsautocomplete', 'args', ['--adaptive-lsp-server-enabled']))},
       \ 'root_uri':{server_info->lsp_settings#get('fsautocomplete', 'root_uri', lsp_settings#root_uri('fsautocomplete'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_fsautocomplete
       \ 'config': lsp_settings#get('fsautocomplete', 'config', lsp_settings#server_config('fsautocomplete')),
       \ 'workspace_config': lsp_settings#get('fsautocomplete', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('fsautocomplete', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/fsautocomplete.vim
+++ b/settings/fsautocomplete.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_fsautocomplete
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'fsautocomplete',
-      \ 'cmd': {server_info->lsp_settings#get('fsautocomplete', 'cmd', [lsp_settings#exec_path('fsautocomplete')]+lsp_settings#get('fsautocomplete', 'args', ['--adaptive-lsp-server-enabled']))},
-      \ 'root_uri':{server_info->lsp_settings#get('fsautocomplete', 'root_uri', lsp_settings#root_uri('fsautocomplete'))},
-      \ 'initialization_options': lsp_settings#get('fsautocomplete', 'initialization_options', {'AutomaticWorkspaceInit': v:true}),
-      \ 'allowlist': lsp_settings#get('fsautocomplete', 'allowlist', ['fsharp']),
-      \ 'blocklist': lsp_settings#get('fsautocomplete', 'blocklist', []),
-      \ 'config': lsp_settings#get('fsautocomplete', 'config', lsp_settings#server_config('fsautocomplete')),
-      \ 'workspace_config': lsp_settings#get('fsautocomplete', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('fsautocomplete', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'fsautocomplete',
+    \ 'cmd': {server_info->lsp_settings#get('fsautocomplete', 'cmd', [lsp_settings#exec_path('fsautocomplete')]+lsp_settings#get('fsautocomplete', 'args', ['--adaptive-lsp-server-enabled']))},
+    \ 'root_uri':{server_info->lsp_settings#get('fsautocomplete', 'root_uri', lsp_settings#root_uri('fsautocomplete'))},
+    \ 'initialization_options': lsp_settings#get('fsautocomplete', 'initialization_options', {'AutomaticWorkspaceInit': v:true}),
+    \ 'allowlist': lsp_settings#get('fsautocomplete', 'allowlist', ['fsharp']),
+    \ 'blocklist': lsp_settings#get('fsautocomplete', 'blocklist', []),
+    \ 'config': lsp_settings#get('fsautocomplete', 'config', lsp_settings#server_config('fsautocomplete')),
+    \ 'workspace_config': lsp_settings#get('fsautocomplete', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('fsautocomplete', 'semantic_highlight', {}),
+    \ })

--- a/settings/fsharp-language-server.vim
+++ b/settings/fsharp-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_fsharp_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'fsharp-language-server',
       \ 'cmd': {server_info->lsp_settings#get('fsharp-language-server', 'cmd', [lsp_settings#exec_path('fsharp-language-server')]+lsp_settings#get('fsharp-language-server', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('fsharp-language-server', 'root_uri', lsp_settings#root_uri('fsharp-language-server'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_fsharp_language_server
       \ 'config': lsp_settings#get('fsharp-language-server', 'config', lsp_settings#server_config('fsharp-language-server')),
       \ 'workspace_config': lsp_settings#get('fsharp-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('fsharp-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/fsharp-language-server.vim
+++ b/settings/fsharp-language-server.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_fsharp_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'fsharp-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('fsharp-language-server', 'cmd', [lsp_settings#exec_path('fsharp-language-server')]+lsp_settings#get('fsharp-language-server', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('fsharp-language-server', 'root_uri', lsp_settings#root_uri('fsharp-language-server'))},
-      \ 'initialization_options': lsp_settings#get('fsharp-language-server', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('fsharp-language-server', 'allowlist', ['fsharp']),
-      \ 'blocklist': lsp_settings#get('fsharp-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('fsharp-language-server', 'config', lsp_settings#server_config('fsharp-language-server')),
-      \ 'workspace_config': lsp_settings#get('fsharp-language-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('fsharp-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'fsharp-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('fsharp-language-server', 'cmd', [lsp_settings#exec_path('fsharp-language-server')]+lsp_settings#get('fsharp-language-server', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('fsharp-language-server', 'root_uri', lsp_settings#root_uri('fsharp-language-server'))},
+    \ 'initialization_options': lsp_settings#get('fsharp-language-server', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('fsharp-language-server', 'allowlist', ['fsharp']),
+    \ 'blocklist': lsp_settings#get('fsharp-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('fsharp-language-server', 'config', lsp_settings#server_config('fsharp-language-server')),
+    \ 'workspace_config': lsp_settings#get('fsharp-language-server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('fsharp-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/gleam.vim
+++ b/settings/gleam.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_gleam
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'gleam',
       \ 'cmd': {server_info->lsp_settings#get('gleam', 'cmd', [lsp_settings#exec_path('gleam')]+lsp_settings#get('gleam', 'args', ['lsp']))},
       \ 'root_uri':{server_info->lsp_settings#get('gleam', 'root_uri', lsp_settings#root_uri('gleam'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_gleam
       \ 'config': lsp_settings#get('gleam', 'config', lsp_settings#server_config('gleam')),
       \ 'workspace_config': lsp_settings#get('gleam', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('gleam', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/gleam.vim
+++ b/settings/gleam.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_gleam
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'gleam',
-      \ 'cmd': {server_info->lsp_settings#get('gleam', 'cmd', [lsp_settings#exec_path('gleam')]+lsp_settings#get('gleam', 'args', ['lsp']))},
-      \ 'root_uri':{server_info->lsp_settings#get('gleam', 'root_uri', lsp_settings#root_uri('gleam'))},
-      \ 'initialization_options': lsp_settings#get('gleam', 'initialization_options', {'diagnostics': 'true'}),
-      \ 'allowlist': lsp_settings#get('gleam', 'allowlist', ['gleam']),
-      \ 'blocklist': lsp_settings#get('gleam', 'blocklist', []),
-      \ 'config': lsp_settings#get('gleam', 'config', lsp_settings#server_config('gleam')),
-      \ 'workspace_config': lsp_settings#get('gleam', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('gleam', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'gleam',
+    \ 'cmd': {server_info->lsp_settings#get('gleam', 'cmd', [lsp_settings#exec_path('gleam')]+lsp_settings#get('gleam', 'args', ['lsp']))},
+    \ 'root_uri':{server_info->lsp_settings#get('gleam', 'root_uri', lsp_settings#root_uri('gleam'))},
+    \ 'initialization_options': lsp_settings#get('gleam', 'initialization_options', {'diagnostics': 'true'}),
+    \ 'allowlist': lsp_settings#get('gleam', 'allowlist', ['gleam']),
+    \ 'blocklist': lsp_settings#get('gleam', 'blocklist', []),
+    \ 'config': lsp_settings#get('gleam', 'config', lsp_settings#server_config('gleam')),
+    \ 'workspace_config': lsp_settings#get('gleam', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('gleam', 'semantic_highlight', {}),
+    \ })

--- a/settings/glslls.vim
+++ b/settings/glslls.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_glslls
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'glslls',
-      \ 'cmd': {server_info->lsp_settings#get('glslls', 'cmd', [lsp_settings#exec_path('glslls')]+lsp_settings#get('glslls', 'args', ['--stdin']))},
-      \ 'root_uri':{server_info->lsp_settings#get('glslls', 'root_uri', lsp_settings#root_uri('glslls'))},
-      \ 'initialization_options': lsp_settings#get('glslls', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('glslls', 'allowlist', ['glsl']),
-      \ 'blocklist': lsp_settings#get('glslls', 'blocklist', []),
-      \ 'config': lsp_settings#get('glslls', 'config', lsp_settings#server_config('glslls')),
-      \ 'workspace_config': lsp_settings#get('glslls', 'workspace_config', {name, key->{'json': {'format': {'enable': v:true}, 'schemas': json_decode(join(readfile(expand('<sfile>:h:h') . '/data/catalog.json'), "\n"))['schemas']}}}),
-      \ 'semantic_highlight': lsp_settings#get('glslls', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'glslls',
+    \ 'cmd': {server_info->lsp_settings#get('glslls', 'cmd', [lsp_settings#exec_path('glslls')]+lsp_settings#get('glslls', 'args', ['--stdin']))},
+    \ 'root_uri':{server_info->lsp_settings#get('glslls', 'root_uri', lsp_settings#root_uri('glslls'))},
+    \ 'initialization_options': lsp_settings#get('glslls', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('glslls', 'allowlist', ['glsl']),
+    \ 'blocklist': lsp_settings#get('glslls', 'blocklist', []),
+    \ 'config': lsp_settings#get('glslls', 'config', lsp_settings#server_config('glslls')),
+    \ 'workspace_config': lsp_settings#get('glslls', 'workspace_config', {name, key->{'json': {'format': {'enable': v:true}, 'schemas': json_decode(join(readfile(expand('<sfile>:h:h') . '/data/catalog.json'), "\n"))['schemas']}}}),
+    \ 'semantic_highlight': lsp_settings#get('glslls', 'semantic_highlight', {}),
+    \ })

--- a/settings/glslls.vim
+++ b/settings/glslls.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_glslls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'glslls',
       \ 'cmd': {server_info->lsp_settings#get('glslls', 'cmd', [lsp_settings#exec_path('glslls')]+lsp_settings#get('glslls', 'args', ['--stdin']))},
       \ 'root_uri':{server_info->lsp_settings#get('glslls', 'root_uri', lsp_settings#root_uri('glslls'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_glslls
       \ 'config': lsp_settings#get('glslls', 'config', lsp_settings#server_config('glslls')),
       \ 'workspace_config': lsp_settings#get('glslls', 'workspace_config', {name, key->{'json': {'format': {'enable': v:true}, 'schemas': json_decode(join(readfile(expand('<sfile>:h:h') . '/data/catalog.json'), "\n"))['schemas']}}}),
       \ 'semantic_highlight': lsp_settings#get('glslls', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/godot.vim
+++ b/settings/godot.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_godot
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'godot',
-      \ 'tcp': {server_info->lsp_settings#get('godot', 'tcp', '127.0.0.1:6005')},
-      \ 'root_uri':{server_info->lsp_settings#get('godot', 'root_uri', lsp_settings#root_uri('godot'))},
-      \ 'initialization_options': lsp_settings#get('godot', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('godot', 'allowlist', ['gdscript3', 'gdscript']),
-      \ 'blocklist': lsp_settings#get('godot', 'blocklist', []),
-      \ 'config': lsp_settings#get('godot', 'config', lsp_settings#server_config('godot')),
-      \ 'workspace_config': lsp_settings#get('godot', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('godot', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'godot',
+    \ 'tcp': {server_info->lsp_settings#get('godot', 'tcp', '127.0.0.1:6005')},
+    \ 'root_uri':{server_info->lsp_settings#get('godot', 'root_uri', lsp_settings#root_uri('godot'))},
+    \ 'initialization_options': lsp_settings#get('godot', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('godot', 'allowlist', ['gdscript3', 'gdscript']),
+    \ 'blocklist': lsp_settings#get('godot', 'blocklist', []),
+    \ 'config': lsp_settings#get('godot', 'config', lsp_settings#server_config('godot')),
+    \ 'workspace_config': lsp_settings#get('godot', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('godot', 'semantic_highlight', {}),
+    \ })

--- a/settings/godot.vim
+++ b/settings/godot.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_godot
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'godot',
       \ 'tcp': {server_info->lsp_settings#get('godot', 'tcp', '127.0.0.1:6005')},
       \ 'root_uri':{server_info->lsp_settings#get('godot', 'root_uri', lsp_settings#root_uri('godot'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_godot
       \ 'config': lsp_settings#get('godot', 'config', lsp_settings#server_config('godot')),
       \ 'workspace_config': lsp_settings#get('godot', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('godot', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/golangci-lint-langserver.vim
+++ b/settings/golangci-lint-langserver.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_golangci_lint_langserver
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'golangci-lint-langserver',
       \ 'cmd': {server_info->lsp_settings#get('golangci-lint-langserver', 'cmd', [lsp_settings#exec_path('golangci-lint-langserver')]+lsp_settings#get('golangci-lint-langserver', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('golangci-lint-langserver', 'root_uri', lsp_settings#root_uri('golangci-lint-langserver'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_golangci_lint_langserver
       \ 'config': lsp_settings#get('golangci-lint-langserver', 'config', lsp_settings#server_config('golangci-lint-langserver')),
       \ 'workspace_config': lsp_settings#get('golangci-lint-langserver', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('golangci-lint-langserver', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/golangci-lint-langserver.vim
+++ b/settings/golangci-lint-langserver.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_golangci_lint_langserver
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'golangci-lint-langserver',
-      \ 'cmd': {server_info->lsp_settings#get('golangci-lint-langserver', 'cmd', [lsp_settings#exec_path('golangci-lint-langserver')]+lsp_settings#get('golangci-lint-langserver', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('golangci-lint-langserver', 'root_uri', lsp_settings#root_uri('golangci-lint-langserver'))},
-      \ 'initialization_options': lsp_settings#get('golangci-lint-langserver', 'initialization_options', {'command': ['golangci-lint', 'run', '--enable-all', '--disable', 'lll', '--out-format', 'json', '--issues-exit-code=1']}),
-      \ 'allowlist': lsp_settings#get('golangci-lint-langserver', 'allowlist', ['go']),
-      \ 'blocklist': lsp_settings#get('golangci-lint-langserver', 'blocklist', []),
-      \ 'config': lsp_settings#get('golangci-lint-langserver', 'config', lsp_settings#server_config('golangci-lint-langserver')),
-      \ 'workspace_config': lsp_settings#get('golangci-lint-langserver', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('golangci-lint-langserver', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'golangci-lint-langserver',
+    \ 'cmd': {server_info->lsp_settings#get('golangci-lint-langserver', 'cmd', [lsp_settings#exec_path('golangci-lint-langserver')]+lsp_settings#get('golangci-lint-langserver', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('golangci-lint-langserver', 'root_uri', lsp_settings#root_uri('golangci-lint-langserver'))},
+    \ 'initialization_options': lsp_settings#get('golangci-lint-langserver', 'initialization_options', {'command': ['golangci-lint', 'run', '--enable-all', '--disable', 'lll', '--out-format', 'json', '--issues-exit-code=1']}),
+    \ 'allowlist': lsp_settings#get('golangci-lint-langserver', 'allowlist', ['go']),
+    \ 'blocklist': lsp_settings#get('golangci-lint-langserver', 'blocklist', []),
+    \ 'config': lsp_settings#get('golangci-lint-langserver', 'config', lsp_settings#server_config('golangci-lint-langserver')),
+    \ 'workspace_config': lsp_settings#get('golangci-lint-langserver', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('golangci-lint-langserver', 'semantic_highlight', {}),
+    \ })

--- a/settings/gopls.vim
+++ b/settings/gopls.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_gopls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'gopls',
       \ 'cmd': {server_info->lsp_settings#get('gopls', 'cmd', [lsp_settings#exec_path('gopls')]+lsp_settings#get('gopls', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('gopls', 'root_uri', lsp_settings#root_uri('gopls'))},
@@ -34,7 +34,7 @@ augroup vim_lsp_settings_gopls
       \ 'config': lsp_settings#get('gopls', 'config', lsp_settings#server_config('gopls')),
       \ 'workspace_config': lsp_settings#get('gopls', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('gopls', 'semantic_highlight', {}),
-      \ }
+      \ })
   autocmd User lsp_setup call s:register_command()
 augroup END
 

--- a/settings/gopls.vim
+++ b/settings/gopls.vim
@@ -1,40 +1,41 @@
+call lsp_settings#register_server({
+    \ 'name': 'gopls',
+    \ 'cmd': {server_info->lsp_settings#get('gopls', 'cmd', [lsp_settings#exec_path('gopls')]+lsp_settings#get('gopls', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('gopls', 'root_uri', lsp_settings#root_uri('gopls'))},
+    \ 'initialization_options': lsp_settings#get('gopls', 'initialization_options', {
+    \     'completeUnimported': v:true,
+    \     'matcher': 'fuzzy',
+    \     'ui.inlayhint.hints': {
+    \         'assignVariableTypes': v:true,
+    \         'compositeLiteralFields': v:true,
+    \         'compositeLiteralTypes': v:true,
+    \         'constantValues': v:true,
+    \         'functionTypeParameters': v:true,
+    \         'parameterNames': v:true,
+    \         'rangeVariableTypes': v:true,
+    \     },
+    \     'codelenses': {
+    \         'generate': v:true,
+    \         'test': v:true,
+    \         'run_vulncheck_exp': v:true,
+    \     },
+    \ }),
+    \ 'capabilities': lsp_settings#get('gopls', 'capabilities', {
+    \     'textDocument': {
+    \         'documentSymbol': {
+    \             'hierarchicalDocumentSymbolSupport': v:true,
+    \         },
+    \     },
+    \ }),
+    \ 'allowlist': lsp_settings#get('gopls', 'allowlist', ['go', 'gomod', 'gohtmltmpl', 'gotexttmpl']),
+    \ 'blocklist': lsp_settings#get('gopls', 'blocklist', []),
+    \ 'config': lsp_settings#get('gopls', 'config', lsp_settings#server_config('gopls')),
+    \ 'workspace_config': lsp_settings#get('gopls', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('gopls', 'semantic_highlight', {}),
+    \ })
+
 augroup vim_lsp_settings_gopls
   au!
-  call lsp_settings#register_server({
-      \ 'name': 'gopls',
-      \ 'cmd': {server_info->lsp_settings#get('gopls', 'cmd', [lsp_settings#exec_path('gopls')]+lsp_settings#get('gopls', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('gopls', 'root_uri', lsp_settings#root_uri('gopls'))},
-      \ 'initialization_options': lsp_settings#get('gopls', 'initialization_options', {
-      \     'completeUnimported': v:true,
-      \     'matcher': 'fuzzy',
-      \     'ui.inlayhint.hints': {
-      \         'assignVariableTypes': v:true,
-      \         'compositeLiteralFields': v:true,
-      \         'compositeLiteralTypes': v:true,
-      \         'constantValues': v:true,
-      \         'functionTypeParameters': v:true,
-      \         'parameterNames': v:true,
-      \         'rangeVariableTypes': v:true,
-      \     },
-      \     'codelenses': {
-      \         'generate': v:true,
-      \         'test': v:true,
-      \         'run_vulncheck_exp': v:true,
-      \     },
-      \ }),
-      \ 'capabilities': lsp_settings#get('gopls', 'capabilities', {
-      \     'textDocument': {
-      \         'documentSymbol': {
-      \             'hierarchicalDocumentSymbolSupport': v:true,
-      \         },
-      \     },
-      \ }),
-      \ 'allowlist': lsp_settings#get('gopls', 'allowlist', ['go', 'gomod', 'gohtmltmpl', 'gotexttmpl']),
-      \ 'blocklist': lsp_settings#get('gopls', 'blocklist', []),
-      \ 'config': lsp_settings#get('gopls', 'config', lsp_settings#server_config('gopls')),
-      \ 'workspace_config': lsp_settings#get('gopls', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('gopls', 'semantic_highlight', {}),
-      \ })
   autocmd User lsp_setup call s:register_command()
 augroup END
 

--- a/settings/gql-language-server.vim
+++ b/settings/gql-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_gql_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'gql-language-server',
       \ 'cmd': {server_info->lsp_settings#get('gql-language-server', 'cmd', [lsp_settings#exec_path('gql-language-server')]+lsp_settings#get('gql-language-server', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('gql-language-server', 'root_uri', lsp_settings#root_uri('gql-language-server'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_gql_language_server
       \ 'config': lsp_settings#get('gql-language-server', 'config', lsp_settings#server_config('gql-language-server')),
       \ 'workspace_config': lsp_settings#get('gql-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('gql-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/gql-language-server.vim
+++ b/settings/gql-language-server.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_gql_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'gql-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('gql-language-server', 'cmd', [lsp_settings#exec_path('gql-language-server')]+lsp_settings#get('gql-language-server', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('gql-language-server', 'root_uri', lsp_settings#root_uri('gql-language-server'))},
-      \ 'initialization_options': lsp_settings#get('gql-language-server', 'initialization_options', {'diagnostics': 'true'}),
-      \ 'allowlist': lsp_settings#get('gql-language-server', 'allowlist', ['graphql']),
-      \ 'blocklist': lsp_settings#get('gql-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('gql-language-server', 'config', lsp_settings#server_config('gql-language-server')),
-      \ 'workspace_config': lsp_settings#get('gql-language-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('gql-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'gql-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('gql-language-server', 'cmd', [lsp_settings#exec_path('gql-language-server')]+lsp_settings#get('gql-language-server', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('gql-language-server', 'root_uri', lsp_settings#root_uri('gql-language-server'))},
+    \ 'initialization_options': lsp_settings#get('gql-language-server', 'initialization_options', {'diagnostics': 'true'}),
+    \ 'allowlist': lsp_settings#get('gql-language-server', 'allowlist', ['graphql']),
+    \ 'blocklist': lsp_settings#get('gql-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('gql-language-server', 'config', lsp_settings#server_config('gql-language-server')),
+    \ 'workspace_config': lsp_settings#get('gql-language-server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('gql-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/graphql-language-server.vim
+++ b/settings/graphql-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_graphql-language-server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'graphql-language-server',
       \ 'cmd': {server_info->lsp_settings#get('graphql-language-server', 'cmd', [lsp_settings#exec_path('graphql-language-server')]+lsp_settings#get('graphql-language-server', 'args', ['server', '--method', 'stream']))},
       \ 'root_uri':{server_info->lsp_settings#get('graphql-language-server', 'root_uri', lsp_settings#root_uri('graphql-language-server'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_graphql-language-server
       \ 'config': lsp_settings#get('graphql-language-server', 'config', lsp_settings#server_config('graphql-language-server')),
       \ 'workspace_config': lsp_settings#get('graphql-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('graphql-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/graphql-language-server.vim
+++ b/settings/graphql-language-server.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_graphql-language-server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'graphql-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('graphql-language-server', 'cmd', [lsp_settings#exec_path('graphql-language-server')]+lsp_settings#get('graphql-language-server', 'args', ['server', '--method', 'stream']))},
-      \ 'root_uri':{server_info->lsp_settings#get('graphql-language-server', 'root_uri', lsp_settings#root_uri('graphql-language-server'))},
-      \ 'initialization_options': lsp_settings#get('graphql-language-server', 'initialization_options', {'diagnostics': 'true'}),
-      \ 'allowlist': lsp_settings#get('graphql-language-server', 'allowlist', ['graphql']),
-      \ 'blocklist': lsp_settings#get('graphql-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('graphql-language-server', 'config', lsp_settings#server_config('graphql-language-server')),
-      \ 'workspace_config': lsp_settings#get('graphql-language-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('graphql-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'graphql-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('graphql-language-server', 'cmd', [lsp_settings#exec_path('graphql-language-server')]+lsp_settings#get('graphql-language-server', 'args', ['server', '--method', 'stream']))},
+    \ 'root_uri':{server_info->lsp_settings#get('graphql-language-server', 'root_uri', lsp_settings#root_uri('graphql-language-server'))},
+    \ 'initialization_options': lsp_settings#get('graphql-language-server', 'initialization_options', {'diagnostics': 'true'}),
+    \ 'allowlist': lsp_settings#get('graphql-language-server', 'allowlist', ['graphql']),
+    \ 'blocklist': lsp_settings#get('graphql-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('graphql-language-server', 'config', lsp_settings#server_config('graphql-language-server')),
+    \ 'workspace_config': lsp_settings#get('graphql-language-server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('graphql-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/groovy-language-server.vim
+++ b/settings/groovy-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_groovy_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'groovy-language-server',
       \ 'cmd': {server_info->lsp_settings#get('groovy-language-server', 'cmd', [lsp_settings#exec_path('groovy-language-server')]+lsp_settings#get('groovy-language-server', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('groovy-language-server', 'root_uri', lsp_settings#root_uri('groovy-language-server'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_groovy_language_server
       \ 'config': lsp_settings#get('groovy-language-server', 'config', lsp_settings#server_config('groovy-language-server')),
       \ 'workspace_config': lsp_settings#get('groovy-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('groovy-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/groovy-language-server.vim
+++ b/settings/groovy-language-server.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_groovy_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'groovy-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('groovy-language-server', 'cmd', [lsp_settings#exec_path('groovy-language-server')]+lsp_settings#get('groovy-language-server', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('groovy-language-server', 'root_uri', lsp_settings#root_uri('groovy-language-server'))},
-      \ 'initialization_options': lsp_settings#get('groovy-language-server', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('groovy-language-server', 'allowlist', ['groovy']),
-      \ 'blocklist': lsp_settings#get('groovy-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('groovy-language-server', 'config', lsp_settings#server_config('groovy-language-server')),
-      \ 'workspace_config': lsp_settings#get('groovy-language-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('groovy-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'groovy-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('groovy-language-server', 'cmd', [lsp_settings#exec_path('groovy-language-server')]+lsp_settings#get('groovy-language-server', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('groovy-language-server', 'root_uri', lsp_settings#root_uri('groovy-language-server'))},
+    \ 'initialization_options': lsp_settings#get('groovy-language-server', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('groovy-language-server', 'allowlist', ['groovy']),
+    \ 'blocklist': lsp_settings#get('groovy-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('groovy-language-server', 'config', lsp_settings#server_config('groovy-language-server')),
+    \ 'workspace_config': lsp_settings#get('groovy-language-server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('groovy-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/haskell-language-server-wrapper.vim
+++ b/settings/haskell-language-server-wrapper.vim
@@ -1,45 +1,42 @@
 " NOTE: For compatibility, this looks up not only
 " haskell-language-server-wrapper's user config but also
 " haskell-language-server's one.
-augroup vim_lsp_settings_haskell_language_server_wrapper
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'haskell-language-server',
-      \ 'cmd': {server_info->
-      \     lsp_settings#get('haskell-language-server-wrapper', 'cmd',
-      \     lsp_settings#get('haskell-language-server', 'cmd',
-      \     [lsp_settings#exec_path('haskell-language-server-wrapper')]+
-      \         lsp_settings#get('haskell-language-server-wrapper', 'args',
-      \         lsp_settings#get('haskell-language-server', 'args',
-      \         ['--lsp']))))},
-      \ 'root_uri': {server_info->
-      \     lsp_settings#get('haskell-language-server-wrapper', 'root_uri',
-      \     lsp_settings#get('haskell-language-server', 'root_uri',
-      \     lsp_settings#get('haskell-language-server-wrapper', 'root_uri_patterns',
-      \     lsp_settings#root_uri('haskell-language-server'))))},
-      \ 'initialization_options':
-      \     lsp_settings#get('haskell-language-server-wrapper', 'initialization_options',
-      \     lsp_settings#get('haskell-language-server', 'initialization_options',
-      \     v:null)),
-      \ 'allowlist':
-      \     lsp_settings#get('haskell-language-server-wrapper', 'allowlist',
-      \     lsp_settings#get('haskell-language-server', 'allowlist',
-      \     ['haskell', 'lhaskell'])),
-      \ 'blocklist':
-      \     lsp_settings#get('haskell-language-server-wrapper', 'blocklist',
-      \     lsp_settings#get('haskell-language-server', 'blocklist',
-      \     [])),
-      \ 'config':
-      \     lsp_settings#get('haskell-language-server-wrapper', 'config',
-      \     lsp_settings#get('haskell-language-server', 'config',
-      \     lsp_settings#server_config('haskell-language-server-wrapper'))),
-      \ 'workspace_config':
-      \     lsp_settings#get('haskell-language-server-wrapper', 'workspace_config',
-      \     lsp_settings#get('haskell-language-server', 'workspace_config',
-      \     {})),
-      \ 'semantic_highlight':
-      \     lsp_settings#get('haskell-language-server-wrapper', 'semantic_highlight',
-      \     lsp_settings#get('haskell-language-server', 'semantic_highlight',
-      \     {})),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'haskell-language-server',
+    \ 'cmd': {server_info->
+    \     lsp_settings#get('haskell-language-server-wrapper', 'cmd',
+    \     lsp_settings#get('haskell-language-server', 'cmd',
+    \     [lsp_settings#exec_path('haskell-language-server-wrapper')]+
+    \         lsp_settings#get('haskell-language-server-wrapper', 'args',
+    \         lsp_settings#get('haskell-language-server', 'args',
+    \         ['--lsp']))))},
+    \ 'root_uri': {server_info->
+    \     lsp_settings#get('haskell-language-server-wrapper', 'root_uri',
+    \     lsp_settings#get('haskell-language-server', 'root_uri',
+    \     lsp_settings#get('haskell-language-server-wrapper', 'root_uri_patterns',
+    \     lsp_settings#root_uri('haskell-language-server'))))},
+    \ 'initialization_options':
+    \     lsp_settings#get('haskell-language-server-wrapper', 'initialization_options',
+    \     lsp_settings#get('haskell-language-server', 'initialization_options',
+    \     v:null)),
+    \ 'allowlist':
+    \     lsp_settings#get('haskell-language-server-wrapper', 'allowlist',
+    \     lsp_settings#get('haskell-language-server', 'allowlist',
+    \     ['haskell', 'lhaskell'])),
+    \ 'blocklist':
+    \     lsp_settings#get('haskell-language-server-wrapper', 'blocklist',
+    \     lsp_settings#get('haskell-language-server', 'blocklist',
+    \     [])),
+    \ 'config':
+    \     lsp_settings#get('haskell-language-server-wrapper', 'config',
+    \     lsp_settings#get('haskell-language-server', 'config',
+    \     lsp_settings#server_config('haskell-language-server-wrapper'))),
+    \ 'workspace_config':
+    \     lsp_settings#get('haskell-language-server-wrapper', 'workspace_config',
+    \     lsp_settings#get('haskell-language-server', 'workspace_config',
+    \     {})),
+    \ 'semantic_highlight':
+    \     lsp_settings#get('haskell-language-server-wrapper', 'semantic_highlight',
+    \     lsp_settings#get('haskell-language-server', 'semantic_highlight',
+    \     {})),
+    \ })

--- a/settings/haskell-language-server-wrapper.vim
+++ b/settings/haskell-language-server-wrapper.vim
@@ -3,7 +3,7 @@
 " haskell-language-server's one.
 augroup vim_lsp_settings_haskell_language_server_wrapper
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'haskell-language-server',
       \ 'cmd': {server_info->
       \     lsp_settings#get('haskell-language-server-wrapper', 'cmd',
@@ -41,5 +41,5 @@ augroup vim_lsp_settings_haskell_language_server_wrapper
       \     lsp_settings#get('haskell-language-server-wrapper', 'semantic_highlight',
       \     lsp_settings#get('haskell-language-server', 'semantic_highlight',
       \     {})),
-      \ }
+      \ })
 augroup END

--- a/settings/helm-ls.vim
+++ b/settings/helm-ls.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_helm_ls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'helm-ls',
       \ 'cmd': {server_info->lsp_settings#get('helm-ls', 'cmd', [lsp_settings#exec_path('helm-ls')]+lsp_settings#get('helm-ls', 'args', ['serve']))},
       \ 'root_uri':{server_info->lsp_settings#get('helm-ls', 'root_uri', lsp_settings#root_uri('helm-ls'))},
@@ -11,5 +11,5 @@ augroup vim_lsp_settings_helm_ls
       \ 'config': lsp_settings#get('helm-ls', 'config', lsp_settings#server_config('helm-ls')),
       \ 'workspace_config': lsp_settings#get('helm-ls', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('helm-ls', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/helm-ls.vim
+++ b/settings/helm-ls.vim
@@ -1,15 +1,12 @@
-augroup vim_lsp_settings_helm_ls
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'helm-ls',
-      \ 'cmd': {server_info->lsp_settings#get('helm-ls', 'cmd', [lsp_settings#exec_path('helm-ls')]+lsp_settings#get('helm-ls', 'args', ['serve']))},
-      \ 'root_uri':{server_info->lsp_settings#get('helm-ls', 'root_uri', lsp_settings#root_uri('helm-ls'))},
-      \ 'initialization_options': lsp_settings#get('helm-ls', 'initialization_options', {}),
-      \ 'capabilities': lsp_settings#get('helm-ls', 'capabilities', {}),
-      \ 'allowlist': lsp_settings#get('helm-ls', 'allowlist', ['helm']),
-      \ 'blocklist': lsp_settings#get('helm-ls', 'blocklist', []),
-      \ 'config': lsp_settings#get('helm-ls', 'config', lsp_settings#server_config('helm-ls')),
-      \ 'workspace_config': lsp_settings#get('helm-ls', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('helm-ls', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'helm-ls',
+    \ 'cmd': {server_info->lsp_settings#get('helm-ls', 'cmd', [lsp_settings#exec_path('helm-ls')]+lsp_settings#get('helm-ls', 'args', ['serve']))},
+    \ 'root_uri':{server_info->lsp_settings#get('helm-ls', 'root_uri', lsp_settings#root_uri('helm-ls'))},
+    \ 'initialization_options': lsp_settings#get('helm-ls', 'initialization_options', {}),
+    \ 'capabilities': lsp_settings#get('helm-ls', 'capabilities', {}),
+    \ 'allowlist': lsp_settings#get('helm-ls', 'allowlist', ['helm']),
+    \ 'blocklist': lsp_settings#get('helm-ls', 'blocklist', []),
+    \ 'config': lsp_settings#get('helm-ls', 'config', lsp_settings#server_config('helm-ls')),
+    \ 'workspace_config': lsp_settings#get('helm-ls', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('helm-ls', 'semantic_highlight', {}),
+    \ })

--- a/settings/herb-language-server.vim
+++ b/settings/herb-language-server.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_herb-language-server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'herb-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('herb-language-server', 'cmd', [lsp_settings#exec_path('herb-language-server')]+lsp_settings#get('herb-language-server', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('herb-language-server', 'root_uri', lsp_settings#root_uri('herb-language-server'))},
-      \ 'initialization_options': lsp_settings#get('herb-language-server', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('herb-language-server', 'allowlist', ['eruby', 'erb']),
-      \ 'blocklist': lsp_settings#get('herb-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('herb-language-server', 'config', lsp_settings#server_config('herb-language-server')),
-      \ 'workspace_config': lsp_settings#get('herb-language-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('herb-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'herb-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('herb-language-server', 'cmd', [lsp_settings#exec_path('herb-language-server')]+lsp_settings#get('herb-language-server', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('herb-language-server', 'root_uri', lsp_settings#root_uri('herb-language-server'))},
+    \ 'initialization_options': lsp_settings#get('herb-language-server', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('herb-language-server', 'allowlist', ['eruby', 'erb']),
+    \ 'blocklist': lsp_settings#get('herb-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('herb-language-server', 'config', lsp_settings#server_config('herb-language-server')),
+    \ 'workspace_config': lsp_settings#get('herb-language-server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('herb-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/herb-language-server.vim
+++ b/settings/herb-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_herb-language-server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'herb-language-server',
       \ 'cmd': {server_info->lsp_settings#get('herb-language-server', 'cmd', [lsp_settings#exec_path('herb-language-server')]+lsp_settings#get('herb-language-server', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('herb-language-server', 'root_uri', lsp_settings#root_uri('herb-language-server'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_herb-language-server
       \ 'config': lsp_settings#get('herb-language-server', 'config', lsp_settings#server_config('herb-language-server')),
       \ 'workspace_config': lsp_settings#get('herb-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('herb-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/hie-wrapper.vim
+++ b/settings/hie-wrapper.vim
@@ -2,7 +2,7 @@
 " but also hie's one.
 augroup vim_lsp_settings_hie_wrapper
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'hie',
       \ 'cmd': {server_info->
       \     lsp_settings#get('hie-wrapper', 'cmd',
@@ -40,5 +40,5 @@ augroup vim_lsp_settings_hie_wrapper
       \     lsp_settings#get('hie-wrapper', 'semantic_highlight',
       \     lsp_settings#get('hie', 'semantic_highlight',
       \     {})),
-      \ }
+      \ })
 augroup END

--- a/settings/hie-wrapper.vim
+++ b/settings/hie-wrapper.vim
@@ -1,44 +1,41 @@
 " NOTE: For compatibility, this looks up not only hie-wrapper's user config
 " but also hie's one.
-augroup vim_lsp_settings_hie_wrapper
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'hie',
-      \ 'cmd': {server_info->
-      \     lsp_settings#get('hie-wrapper', 'cmd',
-      \     lsp_settings#get('hie', 'cmd',
-      \     [lsp_settings#exec_path('hie-wrapper')]+
-      \         lsp_settings#get('hie-wrapper', 'args',
-      \         lsp_settings#get('hie', 'args',
-      \         ['--lsp']))))},
-      \ 'root_uri': {server_info->
-      \     lsp_settings#get('hie-wrapper', 'root_uri',
-      \     lsp_settings#get('hie', 'root_uri',
-      \     lsp_settings#get('hie-wrapper', 'root_uri_patterns',
-      \     lsp_settings#root_uri('hie'))))},
-      \ 'initialization_options':
-      \     lsp_settings#get('hie-wrapper', 'initialization_options',
-      \     lsp_settings#get('hie', 'initialization_options',
-      \     v:null)),
-      \ 'allowlist':
-      \     lsp_settings#get('hie-wrapper', 'allowlist',
-      \     lsp_settings#get('hie', 'allowlist',
-      \     ['haskell', 'lhaskell'])),
-      \ 'blocklist':
-      \     lsp_settings#get('hie-wrapper', 'blocklist',
-      \     lsp_settings#get('hie', 'blocklist',
-      \     [])),
-      \ 'config':
-      \     lsp_settings#get('hie-wrapper', 'config',
-      \     lsp_settings#get('hie', 'config',
-      \     lsp_settings#server_config('hie-wrapper'))),
-      \ 'workspace_config':
-      \     lsp_settings#get('hie-wrapper', 'workspace_config',
-      \     lsp_settings#get('hie', 'workspace_config',
-      \     {})),
-      \ 'semantic_highlight':
-      \     lsp_settings#get('hie-wrapper', 'semantic_highlight',
-      \     lsp_settings#get('hie', 'semantic_highlight',
-      \     {})),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'hie',
+    \ 'cmd': {server_info->
+    \     lsp_settings#get('hie-wrapper', 'cmd',
+    \     lsp_settings#get('hie', 'cmd',
+    \     [lsp_settings#exec_path('hie-wrapper')]+
+    \         lsp_settings#get('hie-wrapper', 'args',
+    \         lsp_settings#get('hie', 'args',
+    \         ['--lsp']))))},
+    \ 'root_uri': {server_info->
+    \     lsp_settings#get('hie-wrapper', 'root_uri',
+    \     lsp_settings#get('hie', 'root_uri',
+    \     lsp_settings#get('hie-wrapper', 'root_uri_patterns',
+    \     lsp_settings#root_uri('hie'))))},
+    \ 'initialization_options':
+    \     lsp_settings#get('hie-wrapper', 'initialization_options',
+    \     lsp_settings#get('hie', 'initialization_options',
+    \     v:null)),
+    \ 'allowlist':
+    \     lsp_settings#get('hie-wrapper', 'allowlist',
+    \     lsp_settings#get('hie', 'allowlist',
+    \     ['haskell', 'lhaskell'])),
+    \ 'blocklist':
+    \     lsp_settings#get('hie-wrapper', 'blocklist',
+    \     lsp_settings#get('hie', 'blocklist',
+    \     [])),
+    \ 'config':
+    \     lsp_settings#get('hie-wrapper', 'config',
+    \     lsp_settings#get('hie', 'config',
+    \     lsp_settings#server_config('hie-wrapper'))),
+    \ 'workspace_config':
+    \     lsp_settings#get('hie-wrapper', 'workspace_config',
+    \     lsp_settings#get('hie', 'workspace_config',
+    \     {})),
+    \ 'semantic_highlight':
+    \     lsp_settings#get('hie-wrapper', 'semantic_highlight',
+    \     lsp_settings#get('hie', 'semantic_highlight',
+    \     {})),
+    \ })

--- a/settings/html-languageserver.vim
+++ b/settings/html-languageserver.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_html_languageserver
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'html-languageserver',
-      \ 'cmd': {server_info->lsp_settings#get('html-languageserver', 'cmd', [lsp_settings#exec_path('html-languageserver')]+lsp_settings#get('html-languageserver', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('html-langserver', 'root_uri', lsp_settings#root_uri('html-languageserver'))},
-      \ 'initialization_options': lsp_settings#get('html-languageserver', 'initialization_options', {'embeddedLanguages': {'css': v:true, 'javascript': v:true}}),
-      \ 'allowlist': lsp_settings#get('html-languageserver', 'allowlist', ['html']),
-      \ 'blocklist': lsp_settings#get('html-languageserver', 'blocklist', []),
-      \ 'config': lsp_settings#get('html-languageserver', 'config', lsp_settings#server_config('html-languageserver')),
-      \ 'workspace_config': lsp_settings#get('html-languageserver', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('html-languageserver', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'html-languageserver',
+    \ 'cmd': {server_info->lsp_settings#get('html-languageserver', 'cmd', [lsp_settings#exec_path('html-languageserver')]+lsp_settings#get('html-languageserver', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('html-langserver', 'root_uri', lsp_settings#root_uri('html-languageserver'))},
+    \ 'initialization_options': lsp_settings#get('html-languageserver', 'initialization_options', {'embeddedLanguages': {'css': v:true, 'javascript': v:true}}),
+    \ 'allowlist': lsp_settings#get('html-languageserver', 'allowlist', ['html']),
+    \ 'blocklist': lsp_settings#get('html-languageserver', 'blocklist', []),
+    \ 'config': lsp_settings#get('html-languageserver', 'config', lsp_settings#server_config('html-languageserver')),
+    \ 'workspace_config': lsp_settings#get('html-languageserver', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('html-languageserver', 'semantic_highlight', {}),
+    \ })

--- a/settings/html-languageserver.vim
+++ b/settings/html-languageserver.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_html_languageserver
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'html-languageserver',
       \ 'cmd': {server_info->lsp_settings#get('html-languageserver', 'cmd', [lsp_settings#exec_path('html-languageserver')]+lsp_settings#get('html-languageserver', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('html-langserver', 'root_uri', lsp_settings#root_uri('html-languageserver'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_html_languageserver
       \ 'config': lsp_settings#get('html-languageserver', 'config', lsp_settings#server_config('html-languageserver')),
       \ 'workspace_config': lsp_settings#get('html-languageserver', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('html-languageserver', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/hyuga.vim
+++ b/settings/hyuga.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_hyuga
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'hyuga',
       \ 'cmd': {server_info->lsp_settings#get('hyuga', 'cmd', [lsp_settings#exec_path('hyuga')]+lsp_settings#get('hyuga', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('hyuga', 'root_uri', lsp_settings#root_uri('hyuga'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_hyuga
       \ 'config': lsp_settings#get('hyuga', 'config', lsp_settings#server_config('hyuga')),
       \ 'workspace_config': lsp_settings#get('hyuga', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('hyuga', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/hyuga.vim
+++ b/settings/hyuga.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_hyuga
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'hyuga',
-      \ 'cmd': {server_info->lsp_settings#get('hyuga', 'cmd', [lsp_settings#exec_path('hyuga')]+lsp_settings#get('hyuga', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('hyuga', 'root_uri', lsp_settings#root_uri('hyuga'))},
-      \ 'initialization_options': lsp_settings#get('hyuga', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('hyuga', 'allowlist', ['hy']),
-      \ 'blocklist': lsp_settings#get('hyuga', 'blocklist', []),
-      \ 'config': lsp_settings#get('hyuga', 'config', lsp_settings#server_config('hyuga')),
-      \ 'workspace_config': lsp_settings#get('hyuga', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('hyuga', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'hyuga',
+    \ 'cmd': {server_info->lsp_settings#get('hyuga', 'cmd', [lsp_settings#exec_path('hyuga')]+lsp_settings#get('hyuga', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('hyuga', 'root_uri', lsp_settings#root_uri('hyuga'))},
+    \ 'initialization_options': lsp_settings#get('hyuga', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('hyuga', 'allowlist', ['hy']),
+    \ 'blocklist': lsp_settings#get('hyuga', 'blocklist', []),
+    \ 'config': lsp_settings#get('hyuga', 'config', lsp_settings#server_config('hyuga')),
+    \ 'workspace_config': lsp_settings#get('hyuga', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('hyuga', 'semantic_highlight', {}),
+    \ })

--- a/settings/intelephense.vim
+++ b/settings/intelephense.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_intelephense_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'intelephense',
       \ 'cmd': {server_info->lsp_settings#get('intelephense', 'cmd', [lsp_settings#exec_path('intelephense')]+lsp_settings#get('intelephense', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('intelephense', 'root_uri', lsp_settings#root_uri('intelephense'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_intelephense_server
       \ 'config': lsp_settings#get('intelephense', 'config', lsp_settings#server_config('intelephense')),
       \ 'workspace_config': lsp_settings#get('intelephense', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('intelephense', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/intelephense.vim
+++ b/settings/intelephense.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_intelephense_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'intelephense',
-      \ 'cmd': {server_info->lsp_settings#get('intelephense', 'cmd', [lsp_settings#exec_path('intelephense')]+lsp_settings#get('intelephense', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('intelephense', 'root_uri', lsp_settings#root_uri('intelephense'))},
-      \ 'initialization_options': lsp_settings#get('intelephense', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('intelephense', 'allowlist', ['php']),
-      \ 'blocklist': lsp_settings#get('intelephense', 'blocklist', []),
-      \ 'config': lsp_settings#get('intelephense', 'config', lsp_settings#server_config('intelephense')),
-      \ 'workspace_config': lsp_settings#get('intelephense', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('intelephense', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'intelephense',
+    \ 'cmd': {server_info->lsp_settings#get('intelephense', 'cmd', [lsp_settings#exec_path('intelephense')]+lsp_settings#get('intelephense', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('intelephense', 'root_uri', lsp_settings#root_uri('intelephense'))},
+    \ 'initialization_options': lsp_settings#get('intelephense', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('intelephense', 'allowlist', ['php']),
+    \ 'blocklist': lsp_settings#get('intelephense', 'blocklist', []),
+    \ 'config': lsp_settings#get('intelephense', 'config', lsp_settings#server_config('intelephense')),
+    \ 'workspace_config': lsp_settings#get('intelephense', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('intelephense', 'semantic_highlight', {}),
+    \ })

--- a/settings/java-language-server.vim
+++ b/settings/java-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_java_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'java-language-server',
       \ 'cmd': {server_info->lsp_settings#get('java-language-server', 'cmd', [lsp_settings#exec_path('java-language-server')]+lsp_settings#get('java-language-server', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('java-language-server', 'root_uri', lsp_settings#root_uri('java-language-server'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_java_language_server
       \ 'config': lsp_settings#get('java-language-server', 'config', lsp_settings#server_config('java-language-server')),
       \ 'workspace_config': lsp_settings#get('java-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('java-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/java-language-server.vim
+++ b/settings/java-language-server.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_java_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'java-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('java-language-server', 'cmd', [lsp_settings#exec_path('java-language-server')]+lsp_settings#get('java-language-server', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('java-language-server', 'root_uri', lsp_settings#root_uri('java-language-server'))},
-      \ 'initialization_options': lsp_settings#get('java-language-server', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('java-language-server', 'allowlist', ['java']),
-      \ 'blocklist': lsp_settings#get('java-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('java-language-server', 'config', lsp_settings#server_config('java-language-server')),
-      \ 'workspace_config': lsp_settings#get('java-language-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('java-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'java-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('java-language-server', 'cmd', [lsp_settings#exec_path('java-language-server')]+lsp_settings#get('java-language-server', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('java-language-server', 'root_uri', lsp_settings#root_uri('java-language-server'))},
+    \ 'initialization_options': lsp_settings#get('java-language-server', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('java-language-server', 'allowlist', ['java']),
+    \ 'blocklist': lsp_settings#get('java-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('java-language-server', 'config', lsp_settings#server_config('java-language-server')),
+    \ 'workspace_config': lsp_settings#get('java-language-server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('java-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/javascript-typescript-stdio.vim
+++ b/settings/javascript-typescript-stdio.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_javascript_typescript_stdio
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'javascript-typescript-stdio',
       \ 'cmd': {server_info->lsp_settings#get('javascript-typescript-stdio', 'cmd', [lsp_settings#exec_path('javascript-typescript-stdio')]+lsp_settings#get('javascript-typescript-stdio', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('javascript-typescript-stdio', 'root_uri', lsp_settings#root_uri('javascript-typescript-stdio'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_javascript_typescript_stdio
       \ 'config': lsp_settings#get('javascript-typescript-stdio', 'config', lsp_settings#server_config('javascript-typescript-stdio')),
       \ 'workspace_config': lsp_settings#get('javascript-typescript-stdio', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('javascript-typescript-stdio', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/javascript-typescript-stdio.vim
+++ b/settings/javascript-typescript-stdio.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_javascript_typescript_stdio
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'javascript-typescript-stdio',
-      \ 'cmd': {server_info->lsp_settings#get('javascript-typescript-stdio', 'cmd', [lsp_settings#exec_path('javascript-typescript-stdio')]+lsp_settings#get('javascript-typescript-stdio', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('javascript-typescript-stdio', 'root_uri', lsp_settings#root_uri('javascript-typescript-stdio'))},
-      \ 'initialization_options': lsp_settings#get('javascript-typescript-stdio', 'initialization_options', {'diagnostics': 'true'}),
-      \ 'allowlist': lsp_settings#get('javascript-typescript-stdio', 'allowlist', ['javascript', 'javascriptreact', 'javascript.jsx']),
-      \ 'blocklist': lsp_settings#get('javascript-typescript-stdio', 'blocklist', []),
-      \ 'config': lsp_settings#get('javascript-typescript-stdio', 'config', lsp_settings#server_config('javascript-typescript-stdio')),
-      \ 'workspace_config': lsp_settings#get('javascript-typescript-stdio', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('javascript-typescript-stdio', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'javascript-typescript-stdio',
+    \ 'cmd': {server_info->lsp_settings#get('javascript-typescript-stdio', 'cmd', [lsp_settings#exec_path('javascript-typescript-stdio')]+lsp_settings#get('javascript-typescript-stdio', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('javascript-typescript-stdio', 'root_uri', lsp_settings#root_uri('javascript-typescript-stdio'))},
+    \ 'initialization_options': lsp_settings#get('javascript-typescript-stdio', 'initialization_options', {'diagnostics': 'true'}),
+    \ 'allowlist': lsp_settings#get('javascript-typescript-stdio', 'allowlist', ['javascript', 'javascriptreact', 'javascript.jsx']),
+    \ 'blocklist': lsp_settings#get('javascript-typescript-stdio', 'blocklist', []),
+    \ 'config': lsp_settings#get('javascript-typescript-stdio', 'config', lsp_settings#server_config('javascript-typescript-stdio')),
+    \ 'workspace_config': lsp_settings#get('javascript-typescript-stdio', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('javascript-typescript-stdio', 'semantic_highlight', {}),
+    \ })

--- a/settings/jedi-language-server.vim
+++ b/settings/jedi-language-server.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_jedi_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'jedi-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('jedi-language-server', 'cmd', [lsp_settings#exec_path('jedi-language-server')]+lsp_settings#get('jedi-language-server', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('jedi-language-server', 'root_uri', lsp_settings#root_uri('jedi-language-server'))},
-      \ 'initialization_options': lsp_settings#get('jedi-language-server', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('jedi-language-server', 'allowlist', ['python']),
-      \ 'blocklist': lsp_settings#get('jedi-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('jedi-language-server', 'config', lsp_settings#server_config('jedi-language-server')),
-      \ 'workspace_config': lsp_settings#get('jedi-language-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('jedi-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'jedi-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('jedi-language-server', 'cmd', [lsp_settings#exec_path('jedi-language-server')]+lsp_settings#get('jedi-language-server', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('jedi-language-server', 'root_uri', lsp_settings#root_uri('jedi-language-server'))},
+    \ 'initialization_options': lsp_settings#get('jedi-language-server', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('jedi-language-server', 'allowlist', ['python']),
+    \ 'blocklist': lsp_settings#get('jedi-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('jedi-language-server', 'config', lsp_settings#server_config('jedi-language-server')),
+    \ 'workspace_config': lsp_settings#get('jedi-language-server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('jedi-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/jedi-language-server.vim
+++ b/settings/jedi-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_jedi_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'jedi-language-server',
       \ 'cmd': {server_info->lsp_settings#get('jedi-language-server', 'cmd', [lsp_settings#exec_path('jedi-language-server')]+lsp_settings#get('jedi-language-server', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('jedi-language-server', 'root_uri', lsp_settings#root_uri('jedi-language-server'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_jedi_language_server
       \ 'config': lsp_settings#get('jedi-language-server', 'config', lsp_settings#server_config('jedi-language-server')),
       \ 'workspace_config': lsp_settings#get('jedi-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('jedi-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/json-languageserver.vim
+++ b/settings/json-languageserver.vim
@@ -1,4 +1,4 @@
-function! Vim_lsp_settings_json_languageserver_capabilities() abort
+function! s:capabilities() abort
   let l:capabilities = lsp#default_get_supported_capabilities('json-languageserver')
   " Override snippetSupport: true for enable completion
   let l:capabilities.textDocument.completion.completionItem.snippetSupport = v:true
@@ -8,18 +8,18 @@ endfunction
 
 augroup vim_lsp_settings_json_languageserver
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'json-languageserver',
       \ 'cmd': {server_info->lsp_settings#get('json-languageserver', 'cmd', [lsp_settings#exec_path('json-languageserver')]+lsp_settings#get('json-languageserver', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('json-languageserver', 'root_uri', lsp_settings#root_uri('json-languageserver'))},
       \ 'initialization_options': lsp_settings#get('json-languageserver', 'initialization_options', {'provideFormatter': v:true}),
-      \ 'capabilities': lsp_settings#get('json-languageserver', 'capabilities', Vim_lsp_settings_json_languageserver_capabilities()),
+      \ 'capabilities': lsp_settings#get('json-languageserver', 'capabilities', s:capabilities()),
       \ 'allowlist': lsp_settings#get('json-languageserver', 'allowlist', ['json', 'jsonc']),
       \ 'blocklist': lsp_settings#get('json-languageserver', 'blocklist', []),
       \ 'config': lsp_settings#get('json-languageserver', 'config', lsp_settings#server_config('json-languageserver')),
       \ 'workspace_config': lsp_settings#get('json-languageserver', 'workspace_config', {name, key->{'json': {'format': {'enable': v:true}, 'schemas': lsp_settings#utils#load_schemas('json-languageserver') + [{'fileMatch':['/vim-lsp-settings/settings.json', '/.vim-lsp-settings/settings.json'], 'url': 'https://mattn.github.io/vim-lsp-settings/local-schema.json'}]}}}),
       \ 'semantic_highlight': lsp_settings#get('json-languageserver', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END
 
 function! s:set_schema(url) abort

--- a/settings/json-languageserver.vim
+++ b/settings/json-languageserver.vim
@@ -30,7 +30,7 @@ function! s:on_lsp_buffer_enabled() abort
   command! -buffer -nargs=1 LspJsonSetSchema call <SID>set_schema(<q-args>)
 endfunction
 
-augroup lsp_install_json
+augroup vim_lsp_settings_json_languageserver
   au!
   autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled()
 augroup END

--- a/settings/json-languageserver.vim
+++ b/settings/json-languageserver.vim
@@ -6,21 +6,18 @@ function! s:capabilities() abort
 endfunction
 
 
-augroup vim_lsp_settings_json_languageserver
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'json-languageserver',
-      \ 'cmd': {server_info->lsp_settings#get('json-languageserver', 'cmd', [lsp_settings#exec_path('json-languageserver')]+lsp_settings#get('json-languageserver', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('json-languageserver', 'root_uri', lsp_settings#root_uri('json-languageserver'))},
-      \ 'initialization_options': lsp_settings#get('json-languageserver', 'initialization_options', {'provideFormatter': v:true}),
-      \ 'capabilities': lsp_settings#get('json-languageserver', 'capabilities', s:capabilities()),
-      \ 'allowlist': lsp_settings#get('json-languageserver', 'allowlist', ['json', 'jsonc']),
-      \ 'blocklist': lsp_settings#get('json-languageserver', 'blocklist', []),
-      \ 'config': lsp_settings#get('json-languageserver', 'config', lsp_settings#server_config('json-languageserver')),
-      \ 'workspace_config': lsp_settings#get('json-languageserver', 'workspace_config', {name, key->{'json': {'format': {'enable': v:true}, 'schemas': lsp_settings#utils#load_schemas('json-languageserver') + [{'fileMatch':['/vim-lsp-settings/settings.json', '/.vim-lsp-settings/settings.json'], 'url': 'https://mattn.github.io/vim-lsp-settings/local-schema.json'}]}}}),
-      \ 'semantic_highlight': lsp_settings#get('json-languageserver', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'json-languageserver',
+    \ 'cmd': {server_info->lsp_settings#get('json-languageserver', 'cmd', [lsp_settings#exec_path('json-languageserver')]+lsp_settings#get('json-languageserver', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('json-languageserver', 'root_uri', lsp_settings#root_uri('json-languageserver'))},
+    \ 'initialization_options': lsp_settings#get('json-languageserver', 'initialization_options', {'provideFormatter': v:true}),
+    \ 'capabilities': lsp_settings#get('json-languageserver', 'capabilities', s:capabilities()),
+    \ 'allowlist': lsp_settings#get('json-languageserver', 'allowlist', ['json', 'jsonc']),
+    \ 'blocklist': lsp_settings#get('json-languageserver', 'blocklist', []),
+    \ 'config': lsp_settings#get('json-languageserver', 'config', lsp_settings#server_config('json-languageserver')),
+    \ 'workspace_config': lsp_settings#get('json-languageserver', 'workspace_config', {name, key->{'json': {'format': {'enable': v:true}, 'schemas': lsp_settings#utils#load_schemas('json-languageserver') + [{'fileMatch':['/vim-lsp-settings/settings.json', '/.vim-lsp-settings/settings.json'], 'url': 'https://mattn.github.io/vim-lsp-settings/local-schema.json'}]}}}),
+    \ 'semantic_highlight': lsp_settings#get('json-languageserver', 'semantic_highlight', {}),
+    \ })
 
 function! s:set_schema(url) abort
   let l:name = fnamemodify(lsp#utils#get_buffer_uri(), ':t')

--- a/settings/jsonnet-language-server.vim
+++ b/settings/jsonnet-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_jsonnet_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'jsonnet-language-server',
       \ 'cmd': {server_info->lsp_settings#get('jsonnet-language-server', 'cmd', [lsp_settings#exec_path('jsonnet-language-server')]+lsp_settings#get('jsonnet-language-server', 'args', ['-t']))},
       \ 'root_uri':{server_info->lsp_settings#get('jsonnet-language-server', 'root_uri', lsp_settings#root_uri('jsonnet-language-server'))},
@@ -12,5 +12,5 @@ augroup vim_lsp_settings_jsonnet_language_server
       \   'jsonnet': {'lint': {'validProperties': []}},
       \ }),
       \ 'semantic_highlight': lsp_settings#get('jsonnet-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/jsonnet-language-server.vim
+++ b/settings/jsonnet-language-server.vim
@@ -1,16 +1,13 @@
-augroup vim_lsp_settings_jsonnet_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'jsonnet-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('jsonnet-language-server', 'cmd', [lsp_settings#exec_path('jsonnet-language-server')]+lsp_settings#get('jsonnet-language-server', 'args', ['-t']))},
-      \ 'root_uri':{server_info->lsp_settings#get('jsonnet-language-server', 'root_uri', lsp_settings#root_uri('jsonnet-language-server'))},
-      \ 'initialization_options': lsp_settings#get('jsonnet-language-server', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('jsonnet-language-server', 'allowlist', ['jsonnet']),
-      \ 'blocklist': lsp_settings#get('jsonnet-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('jsonnet-language-server', 'config', lsp_settings#server_config('jsonnet-language-server')),
-      \ 'workspace_config': lsp_settings#get('jsonnet-language-server', 'workspace_config', {
-      \   'jsonnet': {'lint': {'validProperties': []}},
-      \ }),
-      \ 'semantic_highlight': lsp_settings#get('jsonnet-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'jsonnet-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('jsonnet-language-server', 'cmd', [lsp_settings#exec_path('jsonnet-language-server')]+lsp_settings#get('jsonnet-language-server', 'args', ['-t']))},
+    \ 'root_uri':{server_info->lsp_settings#get('jsonnet-language-server', 'root_uri', lsp_settings#root_uri('jsonnet-language-server'))},
+    \ 'initialization_options': lsp_settings#get('jsonnet-language-server', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('jsonnet-language-server', 'allowlist', ['jsonnet']),
+    \ 'blocklist': lsp_settings#get('jsonnet-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('jsonnet-language-server', 'config', lsp_settings#server_config('jsonnet-language-server')),
+    \ 'workspace_config': lsp_settings#get('jsonnet-language-server', 'workspace_config', {
+    \   'jsonnet': {'lint': {'validProperties': []}},
+    \ }),
+    \ 'semantic_highlight': lsp_settings#get('jsonnet-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/julia-language-server.vim
+++ b/settings/julia-language-server.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_julia_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'julia-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('julia-language-server', 'cmd', [lsp_settings#exec_path('julia-language-server')]+lsp_settings#get('julia-language-server', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('julia-language-server', 'root_uri', lsp_settings#root_uri('julia-language-server'))},
-      \ 'initialization_options': lsp_settings#get('julia-language-server', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('julia-language-server', 'allowlist', ['julia']),
-      \ 'blocklist': lsp_settings#get('julia-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('julia-language-server', 'config', lsp_settings#server_config('julia-language-server')),
-      \ 'workspace_config': lsp_settings#get('julia-language-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('julia-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'julia-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('julia-language-server', 'cmd', [lsp_settings#exec_path('julia-language-server')]+lsp_settings#get('julia-language-server', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('julia-language-server', 'root_uri', lsp_settings#root_uri('julia-language-server'))},
+    \ 'initialization_options': lsp_settings#get('julia-language-server', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('julia-language-server', 'allowlist', ['julia']),
+    \ 'blocklist': lsp_settings#get('julia-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('julia-language-server', 'config', lsp_settings#server_config('julia-language-server')),
+    \ 'workspace_config': lsp_settings#get('julia-language-server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('julia-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/julia-language-server.vim
+++ b/settings/julia-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_julia_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'julia-language-server',
       \ 'cmd': {server_info->lsp_settings#get('julia-language-server', 'cmd', [lsp_settings#exec_path('julia-language-server')]+lsp_settings#get('julia-language-server', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('julia-language-server', 'root_uri', lsp_settings#root_uri('julia-language-server'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_julia_language_server
       \ 'config': lsp_settings#get('julia-language-server', 'config', lsp_settings#server_config('julia-language-server')),
       \ 'workspace_config': lsp_settings#get('julia-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('julia-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/kakehashi.vim
+++ b/settings/kakehashi.vim
@@ -1,8 +1,6 @@
 " Build kakehashi's languages/languageServers dynamically from the language
-" servers vim-lsp-settings would launch on this machine. This must be a
-" global function: LspRegisterServer is defined in autoload/lsp_settings.vim,
-" so script-local identifiers in its arguments do not resolve here.
-function! Vim_lsp_settings_kakehashi_initialization_options() abort
+" servers vim-lsp-settings would launch on this machine.
+function! s:initialization_options() abort
   let l:language_servers = {}
   let l:bridge = {}
   for l:ft in sort(keys(lsp_settings#settings()))
@@ -35,15 +33,15 @@ endfunction
 
 augroup vim_lsp_settings_kakehashi
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'kakehashi',
       \ 'cmd': {server_info->lsp_settings#get('kakehashi', 'cmd', [lsp_settings#exec_path('kakehashi')]+lsp_settings#get('kakehashi', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('kakehashi', 'root_uri', lsp_settings#root_uri('kakehashi'))},
-      \ 'initialization_options': extend(Vim_lsp_settings_kakehashi_initialization_options(), lsp_settings#get('kakehashi', 'initialization_options', {}), 'force'),
+      \ 'initialization_options': extend(s:initialization_options(), lsp_settings#get('kakehashi', 'initialization_options', {}), 'force'),
       \ 'allowlist': lsp_settings#get('kakehashi', 'allowlist', ['*']),
       \ 'blocklist': lsp_settings#get('kakehashi', 'blocklist', []),
       \ 'config': lsp_settings#get('kakehashi', 'config', lsp_settings#server_config('kakehashi')),
       \ 'workspace_config': lsp_settings#get('kakehashi', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('kakehashi', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/kakehashi.vim
+++ b/settings/kakehashi.vim
@@ -31,17 +31,14 @@ function! s:initialization_options() abort
       \ }
 endfunction
 
-augroup vim_lsp_settings_kakehashi
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'kakehashi',
-      \ 'cmd': {server_info->lsp_settings#get('kakehashi', 'cmd', [lsp_settings#exec_path('kakehashi')]+lsp_settings#get('kakehashi', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('kakehashi', 'root_uri', lsp_settings#root_uri('kakehashi'))},
-      \ 'initialization_options': extend(s:initialization_options(), lsp_settings#get('kakehashi', 'initialization_options', {}), 'force'),
-      \ 'allowlist': lsp_settings#get('kakehashi', 'allowlist', ['*']),
-      \ 'blocklist': lsp_settings#get('kakehashi', 'blocklist', []),
-      \ 'config': lsp_settings#get('kakehashi', 'config', lsp_settings#server_config('kakehashi')),
-      \ 'workspace_config': lsp_settings#get('kakehashi', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('kakehashi', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'kakehashi',
+    \ 'cmd': {server_info->lsp_settings#get('kakehashi', 'cmd', [lsp_settings#exec_path('kakehashi')]+lsp_settings#get('kakehashi', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('kakehashi', 'root_uri', lsp_settings#root_uri('kakehashi'))},
+    \ 'initialization_options': extend(s:initialization_options(), lsp_settings#get('kakehashi', 'initialization_options', {}), 'force'),
+    \ 'allowlist': lsp_settings#get('kakehashi', 'allowlist', ['*']),
+    \ 'blocklist': lsp_settings#get('kakehashi', 'blocklist', []),
+    \ 'config': lsp_settings#get('kakehashi', 'config', lsp_settings#server_config('kakehashi')),
+    \ 'workspace_config': lsp_settings#get('kakehashi', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('kakehashi', 'semantic_highlight', {}),
+    \ })

--- a/settings/kotlin-language-server.vim
+++ b/settings/kotlin-language-server.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_kotlin_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'kotlin-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('kotlin-language-server', 'cmd', [lsp_settings#exec_path('kotlin-language-server')]+lsp_settings#get('kotlin-language-server', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('kotlin-language-server', 'root_uri', lsp_settings#root_uri('kotlin-language-server'))},
-      \ 'initialization_options': lsp_settings#get('kotlin-language-server', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('kotlin-language-server', 'allowlist', ['kotlin']),
-      \ 'blocklist': lsp_settings#get('kotlin-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('kotlin-language-server', 'config', lsp_settings#server_config('kotlin-language-server')),
-      \ 'workspace_config': lsp_settings#get('kotlin-language-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('kotlin-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'kotlin-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('kotlin-language-server', 'cmd', [lsp_settings#exec_path('kotlin-language-server')]+lsp_settings#get('kotlin-language-server', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('kotlin-language-server', 'root_uri', lsp_settings#root_uri('kotlin-language-server'))},
+    \ 'initialization_options': lsp_settings#get('kotlin-language-server', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('kotlin-language-server', 'allowlist', ['kotlin']),
+    \ 'blocklist': lsp_settings#get('kotlin-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('kotlin-language-server', 'config', lsp_settings#server_config('kotlin-language-server')),
+    \ 'workspace_config': lsp_settings#get('kotlin-language-server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('kotlin-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/kotlin-language-server.vim
+++ b/settings/kotlin-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_kotlin_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'kotlin-language-server',
       \ 'cmd': {server_info->lsp_settings#get('kotlin-language-server', 'cmd', [lsp_settings#exec_path('kotlin-language-server')]+lsp_settings#get('kotlin-language-server', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('kotlin-language-server', 'root_uri', lsp_settings#root_uri('kotlin-language-server'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_kotlin_language_server
       \ 'config': lsp_settings#get('kotlin-language-server', 'config', lsp_settings#server_config('kotlin-language-server')),
       \ 'workspace_config': lsp_settings#get('kotlin-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('kotlin-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/kotlin-lsp.vim
+++ b/settings/kotlin-lsp.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_kotlin_lsp
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'kotlin-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('kotlin-lsp', 'cmd', [lsp_settings#exec_path('kotlin-lsp')]+lsp_settings#get('kotlin-lsp', 'args', ["--stdio"]))},
-      \ 'root_uri':{server_info->lsp_settings#get('kotlin-lsp', 'root_uri', lsp_settings#root_uri('kotlin-lsp'))},
-      \ 'initialization_options': lsp_settings#get('kotlin-lsp', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('kotlin-lsp', 'allowlist', ['kotlin']),
-      \ 'blocklist': lsp_settings#get('kotlin-lsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('kotlin-lsp', 'config', lsp_settings#server_config('kotlin-lsp')),
-      \ 'workspace_config': lsp_settings#get('kotlin-lsp', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('kotlin-lsp', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'kotlin-lsp',
+    \ 'cmd': {server_info->lsp_settings#get('kotlin-lsp', 'cmd', [lsp_settings#exec_path('kotlin-lsp')]+lsp_settings#get('kotlin-lsp', 'args', ["--stdio"]))},
+    \ 'root_uri':{server_info->lsp_settings#get('kotlin-lsp', 'root_uri', lsp_settings#root_uri('kotlin-lsp'))},
+    \ 'initialization_options': lsp_settings#get('kotlin-lsp', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('kotlin-lsp', 'allowlist', ['kotlin']),
+    \ 'blocklist': lsp_settings#get('kotlin-lsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('kotlin-lsp', 'config', lsp_settings#server_config('kotlin-lsp')),
+    \ 'workspace_config': lsp_settings#get('kotlin-lsp', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('kotlin-lsp', 'semantic_highlight', {}),
+    \ })

--- a/settings/kotlin-lsp.vim
+++ b/settings/kotlin-lsp.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_kotlin_lsp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'kotlin-lsp',
       \ 'cmd': {server_info->lsp_settings#get('kotlin-lsp', 'cmd', [lsp_settings#exec_path('kotlin-lsp')]+lsp_settings#get('kotlin-lsp', 'args', ["--stdio"]))},
       \ 'root_uri':{server_info->lsp_settings#get('kotlin-lsp', 'root_uri', lsp_settings#root_uri('kotlin-lsp'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_kotlin_lsp
       \ 'config': lsp_settings#get('kotlin-lsp', 'config', lsp_settings#server_config('kotlin-lsp')),
       \ 'workspace_config': lsp_settings#get('kotlin-lsp', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('kotlin-lsp', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/lemminx.vim
+++ b/settings/lemminx.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_lemminx
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'lemminx',
       \ 'cmd': {server_info->lsp_settings#get('lemminx', 'cmd', [lsp_settings#exec_path('lemminx')]+lsp_settings#get('lemminx', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('lemminx', 'root_uri', lsp_settings#root_uri('lemminx'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_lemminx
       \ 'config': lsp_settings#get('lemminx', 'config', lsp_settings#server_config('lemminx')),
       \ 'workspace_config': lsp_settings#get('lemminx', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('lemminx', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/lemminx.vim
+++ b/settings/lemminx.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_lemminx
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'lemminx',
-      \ 'cmd': {server_info->lsp_settings#get('lemminx', 'cmd', [lsp_settings#exec_path('lemminx')]+lsp_settings#get('lemminx', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('lemminx', 'root_uri', lsp_settings#root_uri('lemminx'))},
-      \ 'initialization_options': lsp_settings#get('lemminx', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('lemminx', 'allowlist', ['xml']),
-      \ 'blocklist': lsp_settings#get('lemminx', 'blocklist', []),
-      \ 'config': lsp_settings#get('lemminx', 'config', lsp_settings#server_config('lemminx')),
-      \ 'workspace_config': lsp_settings#get('lemminx', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('lemminx', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'lemminx',
+    \ 'cmd': {server_info->lsp_settings#get('lemminx', 'cmd', [lsp_settings#exec_path('lemminx')]+lsp_settings#get('lemminx', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('lemminx', 'root_uri', lsp_settings#root_uri('lemminx'))},
+    \ 'initialization_options': lsp_settings#get('lemminx', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('lemminx', 'allowlist', ['xml']),
+    \ 'blocklist': lsp_settings#get('lemminx', 'blocklist', []),
+    \ 'config': lsp_settings#get('lemminx', 'config', lsp_settings#server_config('lemminx')),
+    \ 'workspace_config': lsp_settings#get('lemminx', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('lemminx', 'semantic_highlight', {}),
+    \ })

--- a/settings/markdown-oxide.vim
+++ b/settings/markdown-oxide.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_markdown-oxide
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'markdown-oxide',
       \ 'cmd': {server_info->lsp_settings#get('markdown-oxide', 'cmd', [lsp_settings#exec_path('markdown-oxide')]+lsp_settings#get('markdown-oxide', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('markdown-oxide', 'root_uri', lsp_settings#root_uri('markdown-oxide'))},
@@ -30,5 +30,5 @@ augroup vim_lsp_settings_markdown-oxide
       \   },
       \ }),
       \ 'semantic_highlight': lsp_settings#get('markdown-oxide', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/markdown-oxide.vim
+++ b/settings/markdown-oxide.vim
@@ -1,34 +1,31 @@
-augroup vim_lsp_settings_markdown-oxide
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'markdown-oxide',
-      \ 'cmd': {server_info->lsp_settings#get('markdown-oxide', 'cmd', [lsp_settings#exec_path('markdown-oxide')]+lsp_settings#get('markdown-oxide', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('markdown-oxide', 'root_uri', lsp_settings#root_uri('markdown-oxide'))},
-      \ 'initialization_options': lsp_settings#get('markdown-oxide', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('markdown-oxide', 'allowlist', ['markdown']),
-      \ 'blocklist': lsp_settings#get('markdown-oxide', 'blocklist', []),
-      \ 'config': lsp_settings#get('markdown-oxide', 'config', lsp_settings#server_config('markdown-oxide')),
-      \ 'workspace_config': lsp_settings#get('markdown-oxide', 'workspace_config', {}),
-      \ 'capabilities': lsp_settings#get('markdown-oxide', 'capabilities', {
-      \   'workspace': {
-      \     'didChangeWatchedFiles': {
-      \       'dynamicRegistration': v:true,
-      \     },
-      \   },
-      \   'textDocument': {
-      \     'completion': {
-      \       'contextSupport': v:true,
-      \       'completionItem': {
-      \         'snippetSupport': v:true,
-      \         'documentationFormat': ['markdown', 'plaintext'],
-      \         'preselectSupport': v:true,
-      \         'insertReplaceSupport': v:true,
-      \         'deprecatedSupport': v:true,
-      \         'commitCharactersSupport': v:true,
-      \       },
-      \     },
-      \   },
-      \ }),
-      \ 'semantic_highlight': lsp_settings#get('markdown-oxide', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'markdown-oxide',
+    \ 'cmd': {server_info->lsp_settings#get('markdown-oxide', 'cmd', [lsp_settings#exec_path('markdown-oxide')]+lsp_settings#get('markdown-oxide', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('markdown-oxide', 'root_uri', lsp_settings#root_uri('markdown-oxide'))},
+    \ 'initialization_options': lsp_settings#get('markdown-oxide', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('markdown-oxide', 'allowlist', ['markdown']),
+    \ 'blocklist': lsp_settings#get('markdown-oxide', 'blocklist', []),
+    \ 'config': lsp_settings#get('markdown-oxide', 'config', lsp_settings#server_config('markdown-oxide')),
+    \ 'workspace_config': lsp_settings#get('markdown-oxide', 'workspace_config', {}),
+    \ 'capabilities': lsp_settings#get('markdown-oxide', 'capabilities', {
+    \   'workspace': {
+    \     'didChangeWatchedFiles': {
+    \       'dynamicRegistration': v:true,
+    \     },
+    \   },
+    \   'textDocument': {
+    \     'completion': {
+    \       'contextSupport': v:true,
+    \       'completionItem': {
+    \         'snippetSupport': v:true,
+    \         'documentationFormat': ['markdown', 'plaintext'],
+    \         'preselectSupport': v:true,
+    \         'insertReplaceSupport': v:true,
+    \         'deprecatedSupport': v:true,
+    \         'commitCharactersSupport': v:true,
+    \       },
+    \     },
+    \   },
+    \ }),
+    \ 'semantic_highlight': lsp_settings#get('markdown-oxide', 'semantic_highlight', {}),
+    \ })

--- a/settings/marksman.vim
+++ b/settings/marksman.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_marksman
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'marksman',
-      \ 'cmd': {server_info->lsp_settings#get('marksman', 'cmd', [lsp_settings#exec_path('marksman')]+lsp_settings#get('marksman', 'args', ['server']))},
-      \ 'root_uri':{server_info->lsp_settings#get('marksman', 'root_uri', lsp_settings#root_uri('marksman'))},
-      \ 'initialization_options': lsp_settings#get('marksman', 'initialization_options', {'diagnostics': 'true'}),
-      \ 'allowlist': lsp_settings#get('marksman', 'allowlist', ['markdown']),
-      \ 'blocklist': lsp_settings#get('marksman', 'blocklist', []),
-      \ 'config': lsp_settings#get('marksman', 'config', lsp_settings#server_config('marksman')),
-      \ 'workspace_config': lsp_settings#get('marksman', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('marksman', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'marksman',
+    \ 'cmd': {server_info->lsp_settings#get('marksman', 'cmd', [lsp_settings#exec_path('marksman')]+lsp_settings#get('marksman', 'args', ['server']))},
+    \ 'root_uri':{server_info->lsp_settings#get('marksman', 'root_uri', lsp_settings#root_uri('marksman'))},
+    \ 'initialization_options': lsp_settings#get('marksman', 'initialization_options', {'diagnostics': 'true'}),
+    \ 'allowlist': lsp_settings#get('marksman', 'allowlist', ['markdown']),
+    \ 'blocklist': lsp_settings#get('marksman', 'blocklist', []),
+    \ 'config': lsp_settings#get('marksman', 'config', lsp_settings#server_config('marksman')),
+    \ 'workspace_config': lsp_settings#get('marksman', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('marksman', 'semantic_highlight', {}),
+    \ })

--- a/settings/marksman.vim
+++ b/settings/marksman.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_marksman
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'marksman',
       \ 'cmd': {server_info->lsp_settings#get('marksman', 'cmd', [lsp_settings#exec_path('marksman')]+lsp_settings#get('marksman', 'args', ['server']))},
       \ 'root_uri':{server_info->lsp_settings#get('marksman', 'root_uri', lsp_settings#root_uri('marksman'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_marksman
       \ 'config': lsp_settings#get('marksman', 'config', lsp_settings#server_config('marksman')),
       \ 'workspace_config': lsp_settings#get('marksman', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('marksman', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/metals.vim
+++ b/settings/metals.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_metals
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'metals',
       \ 'cmd': {server_info->lsp_settings#get('metals', 'cmd', [lsp_settings#exec_path('metals')]+lsp_settings#get('metals', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('metals', 'root_uri', lsp_settings#root_uri('metals'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_metals
       \ 'config': lsp_settings#get('metals', 'config', lsp_settings#server_config('metals')),
       \ 'workspace_config': lsp_settings#get('metals', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('metals', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/metals.vim
+++ b/settings/metals.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_metals
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'metals',
-      \ 'cmd': {server_info->lsp_settings#get('metals', 'cmd', [lsp_settings#exec_path('metals')]+lsp_settings#get('metals', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('metals', 'root_uri', lsp_settings#root_uri('metals'))},
-      \ 'initialization_options': lsp_settings#get('metals', 'initialization_options', {'isHttpEnabled': 'true'}),
-      \ 'allowlist': lsp_settings#get('metals', 'allowlist', ['scala', 'sbt']),
-      \ 'blocklist': lsp_settings#get('metals', 'blocklist', []),
-      \ 'config': lsp_settings#get('metals', 'config', lsp_settings#server_config('metals')),
-      \ 'workspace_config': lsp_settings#get('metals', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('metals', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'metals',
+    \ 'cmd': {server_info->lsp_settings#get('metals', 'cmd', [lsp_settings#exec_path('metals')]+lsp_settings#get('metals', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('metals', 'root_uri', lsp_settings#root_uri('metals'))},
+    \ 'initialization_options': lsp_settings#get('metals', 'initialization_options', {'isHttpEnabled': 'true'}),
+    \ 'allowlist': lsp_settings#get('metals', 'allowlist', ['scala', 'sbt']),
+    \ 'blocklist': lsp_settings#get('metals', 'blocklist', []),
+    \ 'config': lsp_settings#get('metals', 'config', lsp_settings#server_config('metals')),
+    \ 'workspace_config': lsp_settings#get('metals', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('metals', 'semantic_highlight', {}),
+    \ })

--- a/settings/monastery.vim
+++ b/settings/monastery.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_monastery
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'monastery',
       \ 'cmd': {server_info->lsp_settings#get('monastery', 'cmd', [lsp_settings#exec_path('monastery')]+lsp_settings#get('monastery', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('monastery', 'root_uri', lsp_settings#root_uri('monastery'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_monastery
       \ 'config': lsp_settings#get('monastery', 'config', lsp_settings#server_config('monastery')),
       \ 'workspace_config': lsp_settings#get('monastery', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('monastery', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/monastery.vim
+++ b/settings/monastery.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_monastery
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'monastery',
-      \ 'cmd': {server_info->lsp_settings#get('monastery', 'cmd', [lsp_settings#exec_path('monastery')]+lsp_settings#get('monastery', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('monastery', 'root_uri', lsp_settings#root_uri('monastery'))},
-      \ 'initialization_options': lsp_settings#get('monastery', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('monastery', 'allowlist', ['perl']),
-      \ 'blocklist': lsp_settings#get('monastery', 'blocklist', []),
-      \ 'config': lsp_settings#get('monastery', 'config', lsp_settings#server_config('monastery')),
-      \ 'workspace_config': lsp_settings#get('monastery', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('monastery', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'monastery',
+    \ 'cmd': {server_info->lsp_settings#get('monastery', 'cmd', [lsp_settings#exec_path('monastery')]+lsp_settings#get('monastery', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('monastery', 'root_uri', lsp_settings#root_uri('monastery'))},
+    \ 'initialization_options': lsp_settings#get('monastery', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('monastery', 'allowlist', ['perl']),
+    \ 'blocklist': lsp_settings#get('monastery', 'blocklist', []),
+    \ 'config': lsp_settings#get('monastery', 'config', lsp_settings#server_config('monastery')),
+    \ 'workspace_config': lsp_settings#get('monastery', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('monastery', 'semantic_highlight', {}),
+    \ })

--- a/settings/moonbit-lsp.vim
+++ b/settings/moonbit-lsp.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_moonbit_lsp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'moonbit-lsp',
       \ 'cmd': {server_info->lsp_settings#get('moonbit-lsp', 'cmd', [lsp_settings#exec_path('moonbit-lsp')]+lsp_settings#get('moonbit-lsp', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('moonbit-lsp', 'root_uri', lsp_settings#root_uri('moonbit-lsp'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_moonbit_lsp
       \ 'config': lsp_settings#get('moonbit-lsp', 'config', lsp_settings#server_config('moonbit-lsp')),
       \ 'workspace_config': lsp_settings#get('moonbit-lsp', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('moonbit-lsp', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/moonbit-lsp.vim
+++ b/settings/moonbit-lsp.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_moonbit_lsp
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'moonbit-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('moonbit-lsp', 'cmd', [lsp_settings#exec_path('moonbit-lsp')]+lsp_settings#get('moonbit-lsp', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('moonbit-lsp', 'root_uri', lsp_settings#root_uri('moonbit-lsp'))},
-      \ 'initialization_options': lsp_settings#get('moonbit-lsp', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('moonbit-lsp', 'allowlist', ['moonbit']),
-      \ 'blocklist': lsp_settings#get('moonbit-lsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('moonbit-lsp', 'config', lsp_settings#server_config('moonbit-lsp')),
-      \ 'workspace_config': lsp_settings#get('moonbit-lsp', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('moonbit-lsp', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'moonbit-lsp',
+    \ 'cmd': {server_info->lsp_settings#get('moonbit-lsp', 'cmd', [lsp_settings#exec_path('moonbit-lsp')]+lsp_settings#get('moonbit-lsp', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('moonbit-lsp', 'root_uri', lsp_settings#root_uri('moonbit-lsp'))},
+    \ 'initialization_options': lsp_settings#get('moonbit-lsp', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('moonbit-lsp', 'allowlist', ['moonbit']),
+    \ 'blocklist': lsp_settings#get('moonbit-lsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('moonbit-lsp', 'config', lsp_settings#server_config('moonbit-lsp')),
+    \ 'workspace_config': lsp_settings#get('moonbit-lsp', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('moonbit-lsp', 'semantic_highlight', {}),
+    \ })

--- a/settings/mozuku-lsp.vim
+++ b/settings/mozuku-lsp.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_mozuku_lsp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'mozuku-lsp',
       \ 'cmd': {server_info->lsp_settings#get('mozuku-lsp', 'cmd', [lsp_settings#exec_path('mozuku-lsp')]+lsp_settings#get('mozuku-lsp', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('mozuku-lsp', 'root_uri', lsp_settings#root_uri('mozuku-lsp'))},
@@ -10,7 +10,7 @@ augroup vim_lsp_settings_mozuku_lsp
       \ 'config': lsp_settings#get('mozuku-lsp', 'config', lsp_settings#server_config('mozuku-lsp')),
       \ 'workspace_config': lsp_settings#get('mozuku-lsp', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('mozuku-lsp', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END
 
 function! s:on_mozuku_semanticHighlight(data) abort

--- a/settings/mozuku-lsp.vim
+++ b/settings/mozuku-lsp.vim
@@ -22,7 +22,7 @@ function! s:on_lsp_buffer_enabled() abort
   "   \ )
 endfunction
 
-augroup lsp_install_mozuku_lspl
+augroup vim_lsp_settings_mozuku_lsp
   au!
   autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled()
 augroup END

--- a/settings/mozuku-lsp.vim
+++ b/settings/mozuku-lsp.vim
@@ -1,17 +1,14 @@
-augroup vim_lsp_settings_mozuku_lsp
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'mozuku-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('mozuku-lsp', 'cmd', [lsp_settings#exec_path('mozuku-lsp')]+lsp_settings#get('mozuku-lsp', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('mozuku-lsp', 'root_uri', lsp_settings#root_uri('mozuku-lsp'))},
-      \ 'initialization_options': lsp_settings#get('mozuku-lsp', 'initialization_options', {"analysis": {"enableCaboCha": v:true}}),
-      \ 'allowlist': lsp_settings#get('mozuku-lsp', 'allowlist', ['*']),
-      \ 'blocklist': lsp_settings#get('mozuku-lsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('mozuku-lsp', 'config', lsp_settings#server_config('mozuku-lsp')),
-      \ 'workspace_config': lsp_settings#get('mozuku-lsp', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('mozuku-lsp', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'mozuku-lsp',
+    \ 'cmd': {server_info->lsp_settings#get('mozuku-lsp', 'cmd', [lsp_settings#exec_path('mozuku-lsp')]+lsp_settings#get('mozuku-lsp', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('mozuku-lsp', 'root_uri', lsp_settings#root_uri('mozuku-lsp'))},
+    \ 'initialization_options': lsp_settings#get('mozuku-lsp', 'initialization_options', {"analysis": {"enableCaboCha": v:true}}),
+    \ 'allowlist': lsp_settings#get('mozuku-lsp', 'allowlist', ['*']),
+    \ 'blocklist': lsp_settings#get('mozuku-lsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('mozuku-lsp', 'config', lsp_settings#server_config('mozuku-lsp')),
+    \ 'workspace_config': lsp_settings#get('mozuku-lsp', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('mozuku-lsp', 'semantic_highlight', {}),
+    \ })
 
 function! s:on_mozuku_semanticHighlight(data) abort
   let g:hoge = a:data

--- a/settings/nil.vim
+++ b/settings/nil.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_nil
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'nil',
-      \ 'cmd': {server_info->lsp_settings#get('nil', 'cmd', lsp_settings#exec_path('nil'))},
-      \ 'root_uri':{server_info->lsp_settings#get('nil', 'root_uri', lsp_settings#root_uri('nil'))},
-      \ 'initialization_options': lsp_settings#get('nil', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('nil', 'allowlist', ['nix']),
-      \ 'blocklist': lsp_settings#get('nil', 'blocklist', []),
-      \ 'config': lsp_settings#get('nil', 'config', lsp_settings#server_config('nil')),
-      \ 'workspace_config': lsp_settings#get('nil', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('nil', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'nil',
+    \ 'cmd': {server_info->lsp_settings#get('nil', 'cmd', lsp_settings#exec_path('nil'))},
+    \ 'root_uri':{server_info->lsp_settings#get('nil', 'root_uri', lsp_settings#root_uri('nil'))},
+    \ 'initialization_options': lsp_settings#get('nil', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('nil', 'allowlist', ['nix']),
+    \ 'blocklist': lsp_settings#get('nil', 'blocklist', []),
+    \ 'config': lsp_settings#get('nil', 'config', lsp_settings#server_config('nil')),
+    \ 'workspace_config': lsp_settings#get('nil', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('nil', 'semantic_highlight', {}),
+    \ })

--- a/settings/nil.vim
+++ b/settings/nil.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_nil
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'nil',
       \ 'cmd': {server_info->lsp_settings#get('nil', 'cmd', lsp_settings#exec_path('nil'))},
       \ 'root_uri':{server_info->lsp_settings#get('nil', 'root_uri', lsp_settings#root_uri('nil'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_nil
       \ 'config': lsp_settings#get('nil', 'config', lsp_settings#server_config('nil')),
       \ 'workspace_config': lsp_settings#get('nil', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('nil', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/nimlsp.vim
+++ b/settings/nimlsp.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_nimlsp
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'nimlsp',
-      \ 'cmd': {server_info->lsp_settings#get('nimlsp', 'cmd', [lsp_settings#exec_path('nimlsp')]+lsp_settings#get('nimlsp', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('nimlsp', 'root_uri', lsp_settings#root_uri('nimlsp'))},
-      \ 'initialization_options': lsp_settings#get('nimlsp', 'initialization_options', {'diagnostics': 'true'}),
-      \ 'allowlist': lsp_settings#get('nimlsp', 'allowlist', ['nim']),
-      \ 'blocklist': lsp_settings#get('nimlsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('nimlsp', 'config', lsp_settings#server_config('nimlsp')),
-      \ 'workspace_config': lsp_settings#get('nimlsp', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('nimlsp', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'nimlsp',
+    \ 'cmd': {server_info->lsp_settings#get('nimlsp', 'cmd', [lsp_settings#exec_path('nimlsp')]+lsp_settings#get('nimlsp', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('nimlsp', 'root_uri', lsp_settings#root_uri('nimlsp'))},
+    \ 'initialization_options': lsp_settings#get('nimlsp', 'initialization_options', {'diagnostics': 'true'}),
+    \ 'allowlist': lsp_settings#get('nimlsp', 'allowlist', ['nim']),
+    \ 'blocklist': lsp_settings#get('nimlsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('nimlsp', 'config', lsp_settings#server_config('nimlsp')),
+    \ 'workspace_config': lsp_settings#get('nimlsp', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('nimlsp', 'semantic_highlight', {}),
+    \ })

--- a/settings/nimlsp.vim
+++ b/settings/nimlsp.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_nimlsp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'nimlsp',
       \ 'cmd': {server_info->lsp_settings#get('nimlsp', 'cmd', [lsp_settings#exec_path('nimlsp')]+lsp_settings#get('nimlsp', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('nimlsp', 'root_uri', lsp_settings#root_uri('nimlsp'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_nimlsp
       \ 'config': lsp_settings#get('nimlsp', 'config', lsp_settings#server_config('nimlsp')),
       \ 'workspace_config': lsp_settings#get('nimlsp', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('nimlsp', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/nixd.vim
+++ b/settings/nixd.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_nixd
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'nixd',
       \ 'cmd': {server_info->lsp_settings#get('nixd', 'cmd', lsp_settings#exec_path('nixd'))},
       \ 'root_uri':{server_info->lsp_settings#get('nid', 'root_uri', lsp_settings#root_uri('nixd'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_nixd
       \ 'config': lsp_settings#get('nixd', 'config', lsp_settings#server_config('nixd')),
       \ 'workspace_config': lsp_settings#get('nixd', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('nixd', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/nixd.vim
+++ b/settings/nixd.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_nixd
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'nixd',
-      \ 'cmd': {server_info->lsp_settings#get('nixd', 'cmd', lsp_settings#exec_path('nixd'))},
-      \ 'root_uri':{server_info->lsp_settings#get('nid', 'root_uri', lsp_settings#root_uri('nixd'))},
-      \ 'initialization_options': lsp_settings#get('nixd', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('nixd', 'allowlist', ['nix']),
-      \ 'blocklist': lsp_settings#get('nixd', 'blocklist', []),
-      \ 'config': lsp_settings#get('nixd', 'config', lsp_settings#server_config('nixd')),
-      \ 'workspace_config': lsp_settings#get('nixd', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('nixd', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'nixd',
+    \ 'cmd': {server_info->lsp_settings#get('nixd', 'cmd', lsp_settings#exec_path('nixd'))},
+    \ 'root_uri':{server_info->lsp_settings#get('nid', 'root_uri', lsp_settings#root_uri('nixd'))},
+    \ 'initialization_options': lsp_settings#get('nixd', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('nixd', 'allowlist', ['nix']),
+    \ 'blocklist': lsp_settings#get('nixd', 'blocklist', []),
+    \ 'config': lsp_settings#get('nixd', 'config', lsp_settings#server_config('nixd')),
+    \ 'workspace_config': lsp_settings#get('nixd', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('nixd', 'semantic_highlight', {}),
+    \ })

--- a/settings/ntt.vim
+++ b/settings/ntt.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_ntt
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'ntt',
-      \ 'cmd': {server_info->lsp_settings#get('ntt', 'cmd', [lsp_settings#exec_path('ntt')]+lsp_settings#get('ntt', 'args', ['langserver']))},
-      \ 'root_uri':{server_info->lsp_settings#get('ntt', 'root_uri', lsp_settings#root_uri('ntt'))},
-      \ 'initialization_options': lsp_settings#get('ntt', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('ntt', 'allowlist', ['ttcn3', 'ttcn']),
-      \ 'blocklist': lsp_settings#get('ntt', 'blocklist', []),
-      \ 'config': lsp_settings#get('ntt', 'config', lsp_settings#server_config('ntt')),
-      \ 'workspace_config': lsp_settings#get('ntt', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('ntt', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'ntt',
+    \ 'cmd': {server_info->lsp_settings#get('ntt', 'cmd', [lsp_settings#exec_path('ntt')]+lsp_settings#get('ntt', 'args', ['langserver']))},
+    \ 'root_uri':{server_info->lsp_settings#get('ntt', 'root_uri', lsp_settings#root_uri('ntt'))},
+    \ 'initialization_options': lsp_settings#get('ntt', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('ntt', 'allowlist', ['ttcn3', 'ttcn']),
+    \ 'blocklist': lsp_settings#get('ntt', 'blocklist', []),
+    \ 'config': lsp_settings#get('ntt', 'config', lsp_settings#server_config('ntt')),
+    \ 'workspace_config': lsp_settings#get('ntt', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('ntt', 'semantic_highlight', {}),
+    \ })

--- a/settings/ntt.vim
+++ b/settings/ntt.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_ntt
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'ntt',
       \ 'cmd': {server_info->lsp_settings#get('ntt', 'cmd', [lsp_settings#exec_path('ntt')]+lsp_settings#get('ntt', 'args', ['langserver']))},
       \ 'root_uri':{server_info->lsp_settings#get('ntt', 'root_uri', lsp_settings#root_uri('ntt'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_ntt
       \ 'config': lsp_settings#get('ntt', 'config', lsp_settings#server_config('ntt')),
       \ 'workspace_config': lsp_settings#get('ntt', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('ntt', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/ocaml-lsp.vim
+++ b/settings/ocaml-lsp.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_ocaml_lsp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'ocaml-lsp',
       \ 'cmd': {server_info->lsp_settings#get('ocaml-lsp', 'cmd', [lsp_settings#exec_path('ocaml-lsp')]+lsp_settings#get('ocaml-lsp', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('ocaml-lsp', 'root_uri', lsp_settings#root_uri('ocaml-lsp'))},
@@ -10,6 +10,6 @@ augroup vim_lsp_settings_ocaml_lsp
       \ 'config': lsp_settings#get('ocaml-lsp', 'config', lsp_settings#server_config('ocaml-lsp')),
       \ 'workspace_config': lsp_settings#get('ocaml-lsp', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('ocaml-lsp', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END
 

--- a/settings/ocaml-lsp.vim
+++ b/settings/ocaml-lsp.vim
@@ -1,15 +1,12 @@
-augroup vim_lsp_settings_ocaml_lsp
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'ocaml-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('ocaml-lsp', 'cmd', [lsp_settings#exec_path('ocaml-lsp')]+lsp_settings#get('ocaml-lsp', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('ocaml-lsp', 'root_uri', lsp_settings#root_uri('ocaml-lsp'))},
-      \ 'initialization_options': lsp_settings#get('ocaml-lsp', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('ocaml-lsp', 'allowlist', ['ocaml']),
-      \ 'blocklist': lsp_settings#get('ocaml-lsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('ocaml-lsp', 'config', lsp_settings#server_config('ocaml-lsp')),
-      \ 'workspace_config': lsp_settings#get('ocaml-lsp', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('ocaml-lsp', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'ocaml-lsp',
+    \ 'cmd': {server_info->lsp_settings#get('ocaml-lsp', 'cmd', [lsp_settings#exec_path('ocaml-lsp')]+lsp_settings#get('ocaml-lsp', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('ocaml-lsp', 'root_uri', lsp_settings#root_uri('ocaml-lsp'))},
+    \ 'initialization_options': lsp_settings#get('ocaml-lsp', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('ocaml-lsp', 'allowlist', ['ocaml']),
+    \ 'blocklist': lsp_settings#get('ocaml-lsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('ocaml-lsp', 'config', lsp_settings#server_config('ocaml-lsp')),
+    \ 'workspace_config': lsp_settings#get('ocaml-lsp', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('ocaml-lsp', 'semantic_highlight', {}),
+    \ })
 

--- a/settings/ols.vim
+++ b/settings/ols.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_ols
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'ols',
-      \ 'cmd': {server_info->lsp_settings#get('ols', 'cmd', [lsp_settings#exec_path('ols')]+lsp_settings#get('ols', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('ols', 'root_uri', lsp_settings#root_uri('ols'))},
-      \ 'initialization_options': lsp_settings#get('ols', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('ols', 'allowlist', ['odin']),
-      \ 'blocklist': lsp_settings#get('ols', 'blocklist', []),
-      \ 'config': lsp_settings#get('ols', 'config', lsp_settings#server_config('ols')),
-      \ 'workspace_config': lsp_settings#get('ols', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('ols', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'ols',
+    \ 'cmd': {server_info->lsp_settings#get('ols', 'cmd', [lsp_settings#exec_path('ols')]+lsp_settings#get('ols', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('ols', 'root_uri', lsp_settings#root_uri('ols'))},
+    \ 'initialization_options': lsp_settings#get('ols', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('ols', 'allowlist', ['odin']),
+    \ 'blocklist': lsp_settings#get('ols', 'blocklist', []),
+    \ 'config': lsp_settings#get('ols', 'config', lsp_settings#server_config('ols')),
+    \ 'workspace_config': lsp_settings#get('ols', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('ols', 'semantic_highlight', {}),
+    \ })

--- a/settings/ols.vim
+++ b/settings/ols.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_ols
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'ols',
       \ 'cmd': {server_info->lsp_settings#get('ols', 'cmd', [lsp_settings#exec_path('ols')]+lsp_settings#get('ols', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('ols', 'root_uri', lsp_settings#root_uri('ols'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_ols
       \ 'config': lsp_settings#get('ols', 'config', lsp_settings#server_config('ols')),
       \ 'workspace_config': lsp_settings#get('ols', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('ols', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/omnisharp-lsp.vim
+++ b/settings/omnisharp-lsp.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_omnisharp_lsp
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'omnisharp-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('omnisharp-lsp', 'cmd', [lsp_settings#exec_path('omnisharp-lsp')]+lsp_settings#get('omnisharp-lsp', 'args', ['-lsp']))},
-      \ 'root_uri':{server_info->lsp_settings#get('omnisharp-lsp', 'root_uri', lsp_settings#root_uri('omnisharp-lsp'))},
-      \ 'initialization_options': lsp_settings#get('omnisharp-lsp', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('omnisharp-lsp', 'allowlist', ['cs']),
-      \ 'blocklist': lsp_settings#get('omnisharp-lsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('omnisharp-lsp', 'config', lsp_settings#server_config('omnisharp-lsp')),
-      \ 'workspace_config': lsp_settings#get('omnisharp-lsp', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('omnisharp-lsp', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'omnisharp-lsp',
+    \ 'cmd': {server_info->lsp_settings#get('omnisharp-lsp', 'cmd', [lsp_settings#exec_path('omnisharp-lsp')]+lsp_settings#get('omnisharp-lsp', 'args', ['-lsp']))},
+    \ 'root_uri':{server_info->lsp_settings#get('omnisharp-lsp', 'root_uri', lsp_settings#root_uri('omnisharp-lsp'))},
+    \ 'initialization_options': lsp_settings#get('omnisharp-lsp', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('omnisharp-lsp', 'allowlist', ['cs']),
+    \ 'blocklist': lsp_settings#get('omnisharp-lsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('omnisharp-lsp', 'config', lsp_settings#server_config('omnisharp-lsp')),
+    \ 'workspace_config': lsp_settings#get('omnisharp-lsp', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('omnisharp-lsp', 'semantic_highlight', {}),
+    \ })

--- a/settings/omnisharp-lsp.vim
+++ b/settings/omnisharp-lsp.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_omnisharp_lsp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'omnisharp-lsp',
       \ 'cmd': {server_info->lsp_settings#get('omnisharp-lsp', 'cmd', [lsp_settings#exec_path('omnisharp-lsp')]+lsp_settings#get('omnisharp-lsp', 'args', ['-lsp']))},
       \ 'root_uri':{server_info->lsp_settings#get('omnisharp-lsp', 'root_uri', lsp_settings#root_uri('omnisharp-lsp'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_omnisharp_lsp
       \ 'config': lsp_settings#get('omnisharp-lsp', 'config', lsp_settings#server_config('omnisharp-lsp')),
       \ 'workspace_config': lsp_settings#get('omnisharp-lsp', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('omnisharp-lsp', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/openscad-lsp.vim
+++ b/settings/openscad-lsp.vim
@@ -1,18 +1,15 @@
-augroup vim_lsp_settings_openscad_lsp
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'openscad-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('openscad-lsp', 'cmd', [lsp_settings#exec_path('openscad-lsp')]+lsp_settings#get('openscad-lsp', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('openscad-lsp', 'root_uri', lsp_settings#root_uri('openscad-lsp'))},
-      \ 'initialization_options': lsp_settings#get('openscad-lsp', 'initialization_options', {
-      \     'completion': {
-      \         'autoimport': { 'enable': v:true },
-      \     },
-      \ }),
-      \ 'allowlist': lsp_settings#get('openscad-lsp', 'allowlist', ['openscad']),
-      \ 'blocklist': lsp_settings#get('openscad-lsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('openscad-lsp', 'config', lsp_settings#server_config('openscad-lsp')),
-      \ 'workspace_config': lsp_settings#get('openscad-lsp', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('openscad-lsp', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'openscad-lsp',
+    \ 'cmd': {server_info->lsp_settings#get('openscad-lsp', 'cmd', [lsp_settings#exec_path('openscad-lsp')]+lsp_settings#get('openscad-lsp', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('openscad-lsp', 'root_uri', lsp_settings#root_uri('openscad-lsp'))},
+    \ 'initialization_options': lsp_settings#get('openscad-lsp', 'initialization_options', {
+    \     'completion': {
+    \         'autoimport': { 'enable': v:true },
+    \     },
+    \ }),
+    \ 'allowlist': lsp_settings#get('openscad-lsp', 'allowlist', ['openscad']),
+    \ 'blocklist': lsp_settings#get('openscad-lsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('openscad-lsp', 'config', lsp_settings#server_config('openscad-lsp')),
+    \ 'workspace_config': lsp_settings#get('openscad-lsp', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('openscad-lsp', 'semantic_highlight', {}),
+    \ })

--- a/settings/openscad-lsp.vim
+++ b/settings/openscad-lsp.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_openscad_lsp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'openscad-lsp',
       \ 'cmd': {server_info->lsp_settings#get('openscad-lsp', 'cmd', [lsp_settings#exec_path('openscad-lsp')]+lsp_settings#get('openscad-lsp', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('openscad-lsp', 'root_uri', lsp_settings#root_uri('openscad-lsp'))},
@@ -14,5 +14,5 @@ augroup vim_lsp_settings_openscad_lsp
       \ 'config': lsp_settings#get('openscad-lsp', 'config', lsp_settings#server_config('openscad-lsp')),
       \ 'workspace_config': lsp_settings#get('openscad-lsp', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('openscad-lsp', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/oxfmt.vim
+++ b/settings/oxfmt.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_oxfmt
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'oxfmt',
       \ 'cmd': {server_info->lsp_settings#get('oxfmt', 'cmd', [lsp_settings#exec_path('oxfmt')]+lsp_settings#get('oxfmt', 'args', ['--lsp']))},
       \ 'root_uri':{server_info->lsp_settings#get('oxfmt', 'root_uri', lsp_settings#root_uri('oxfmt'))},
@@ -14,5 +14,5 @@ augroup vim_lsp_settings_oxfmt
       \   },
       \ }),
       \ 'semantic_highlight': lsp_settings#get('oxfmt', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/oxfmt.vim
+++ b/settings/oxfmt.vim
@@ -1,18 +1,15 @@
-augroup vim_lsp_settings_oxfmt
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'oxfmt',
-      \ 'cmd': {server_info->lsp_settings#get('oxfmt', 'cmd', [lsp_settings#exec_path('oxfmt')]+lsp_settings#get('oxfmt', 'args', ['--lsp']))},
-      \ 'root_uri':{server_info->lsp_settings#get('oxfmt', 'root_uri', lsp_settings#root_uri('oxfmt'))},
-      \ 'initialization_options': lsp_settings#get('oxfmt', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('oxfmt', 'allowlist', ['typescript', 'javascript', 'typescriptreact', 'javascriptreact', 'vue', 'svelte', 'astro']),
-      \ 'blocklist': lsp_settings#get('oxfmt', 'blocklist', []),
-      \ 'config': lsp_settings#get('oxfmt', 'config', {}),
-      \ 'workspace_config': lsp_settings#get('oxfmt', 'workspace_config', {
-      \   'oxc_language_server': {
-      \     'fmt.experimental': v:true,
-      \   },
-      \ }),
-      \ 'semantic_highlight': lsp_settings#get('oxfmt', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'oxfmt',
+    \ 'cmd': {server_info->lsp_settings#get('oxfmt', 'cmd', [lsp_settings#exec_path('oxfmt')]+lsp_settings#get('oxfmt', 'args', ['--lsp']))},
+    \ 'root_uri':{server_info->lsp_settings#get('oxfmt', 'root_uri', lsp_settings#root_uri('oxfmt'))},
+    \ 'initialization_options': lsp_settings#get('oxfmt', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('oxfmt', 'allowlist', ['typescript', 'javascript', 'typescriptreact', 'javascriptreact', 'vue', 'svelte', 'astro']),
+    \ 'blocklist': lsp_settings#get('oxfmt', 'blocklist', []),
+    \ 'config': lsp_settings#get('oxfmt', 'config', {}),
+    \ 'workspace_config': lsp_settings#get('oxfmt', 'workspace_config', {
+    \   'oxc_language_server': {
+    \     'fmt.experimental': v:true,
+    \   },
+    \ }),
+    \ 'semantic_highlight': lsp_settings#get('oxfmt', 'semantic_highlight', {}),
+    \ })

--- a/settings/oxlint.vim
+++ b/settings/oxlint.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_oxlint
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'oxlint',
-      \ 'cmd': {server_info->lsp_settings#get('oxlint', 'cmd', [lsp_settings#exec_path('oxlint')]+lsp_settings#get('oxlint', 'args', ['--lsp']))},
-      \ 'root_uri':{server_info->lsp_settings#get('oxlint', 'root_uri', lsp_settings#root_uri('oxlint'))},
-      \ 'initialization_options': lsp_settings#get('oxlint', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('oxlint', 'allowlist', ['typescript', 'javascript', 'typescriptreact', 'javascriptreact', 'vue', 'svelte', 'astro']),
-      \ 'blocklist': lsp_settings#get('oxlint', 'blocklist', []),
-      \ 'config': lsp_settings#get('oxlint', 'config', {}),
-      \ 'workspace_config': lsp_settings#get('oxlint', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('oxlint', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'oxlint',
+    \ 'cmd': {server_info->lsp_settings#get('oxlint', 'cmd', [lsp_settings#exec_path('oxlint')]+lsp_settings#get('oxlint', 'args', ['--lsp']))},
+    \ 'root_uri':{server_info->lsp_settings#get('oxlint', 'root_uri', lsp_settings#root_uri('oxlint'))},
+    \ 'initialization_options': lsp_settings#get('oxlint', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('oxlint', 'allowlist', ['typescript', 'javascript', 'typescriptreact', 'javascriptreact', 'vue', 'svelte', 'astro']),
+    \ 'blocklist': lsp_settings#get('oxlint', 'blocklist', []),
+    \ 'config': lsp_settings#get('oxlint', 'config', {}),
+    \ 'workspace_config': lsp_settings#get('oxlint', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('oxlint', 'semantic_highlight', {}),
+    \ })

--- a/settings/oxlint.vim
+++ b/settings/oxlint.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_oxlint
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'oxlint',
       \ 'cmd': {server_info->lsp_settings#get('oxlint', 'cmd', [lsp_settings#exec_path('oxlint')]+lsp_settings#get('oxlint', 'args', ['--lsp']))},
       \ 'root_uri':{server_info->lsp_settings#get('oxlint', 'root_uri', lsp_settings#root_uri('oxlint'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_oxlint
       \ 'config': lsp_settings#get('oxlint', 'config', {}),
       \ 'workspace_config': lsp_settings#get('oxlint', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('oxlint', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/package-version-server.vim
+++ b/settings/package-version-server.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_package_version_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'package-version-server',
-      \ 'cmd': {server_info->lsp_settings#get('package-version-server', 'cmd', [lsp_settings#exec_path('package-version-server')]+lsp_settings#get('package-version-server', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('package-version-server', 'root_uri', lsp_settings#root_uri('package-version-server'))},
-      \ 'initialization_options': lsp_settings#get('package-version-server', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('package-version-server', 'allowlist', ['json']),
-      \ 'blocklist': lsp_settings#get('package-version-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('package-version-server', 'config', lsp_settings#server_config('package-version-server')),
-      \ 'workspace_config': lsp_settings#get('package-version-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('package-version-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'package-version-server',
+    \ 'cmd': {server_info->lsp_settings#get('package-version-server', 'cmd', [lsp_settings#exec_path('package-version-server')]+lsp_settings#get('package-version-server', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('package-version-server', 'root_uri', lsp_settings#root_uri('package-version-server'))},
+    \ 'initialization_options': lsp_settings#get('package-version-server', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('package-version-server', 'allowlist', ['json']),
+    \ 'blocklist': lsp_settings#get('package-version-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('package-version-server', 'config', lsp_settings#server_config('package-version-server')),
+    \ 'workspace_config': lsp_settings#get('package-version-server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('package-version-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/package-version-server.vim
+++ b/settings/package-version-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_package_version_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'package-version-server',
       \ 'cmd': {server_info->lsp_settings#get('package-version-server', 'cmd', [lsp_settings#exec_path('package-version-server')]+lsp_settings#get('package-version-server', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('package-version-server', 'root_uri', lsp_settings#root_uri('package-version-server'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_package_version_server
       \ 'config': lsp_settings#get('package-version-server', 'config', lsp_settings#server_config('package-version-server')),
       \ 'workspace_config': lsp_settings#get('package-version-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('package-version-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/perl-languageserver.vim
+++ b/settings/perl-languageserver.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_perl_languageserver
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'perl-languageserver',
-      \ 'cmd': {server_info->lsp_settings#get('perl-languageserver', 'cmd', ['perl', '-MPerl::LanguageServer', '-e', 'Perl::LanguageServer->run']+lsp_settings#get('perl-languageserver', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('perl-languageserver', 'root_uri', lsp_settings#root_uri('perl-languageserver'))},
-      \ 'initialization_options': lsp_settings#get('perl-languageserver', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('perl-languageserver', 'allowlist', ['perl']),
-      \ 'blocklist': lsp_settings#get('perl-languageserver', 'blocklist', []),
-      \ 'config': lsp_settings#get('perl-languageserver', 'config', lsp_settings#server_config('perl-languageserver')),
-      \ 'workspace_config': lsp_settings#get('perl-languageserver', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('perl-languageserver', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'perl-languageserver',
+    \ 'cmd': {server_info->lsp_settings#get('perl-languageserver', 'cmd', ['perl', '-MPerl::LanguageServer', '-e', 'Perl::LanguageServer->run']+lsp_settings#get('perl-languageserver', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('perl-languageserver', 'root_uri', lsp_settings#root_uri('perl-languageserver'))},
+    \ 'initialization_options': lsp_settings#get('perl-languageserver', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('perl-languageserver', 'allowlist', ['perl']),
+    \ 'blocklist': lsp_settings#get('perl-languageserver', 'blocklist', []),
+    \ 'config': lsp_settings#get('perl-languageserver', 'config', lsp_settings#server_config('perl-languageserver')),
+    \ 'workspace_config': lsp_settings#get('perl-languageserver', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('perl-languageserver', 'semantic_highlight', {}),
+    \ })

--- a/settings/perl-languageserver.vim
+++ b/settings/perl-languageserver.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_perl_languageserver
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'perl-languageserver',
       \ 'cmd': {server_info->lsp_settings#get('perl-languageserver', 'cmd', ['perl', '-MPerl::LanguageServer', '-e', 'Perl::LanguageServer->run']+lsp_settings#get('perl-languageserver', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('perl-languageserver', 'root_uri', lsp_settings#root_uri('perl-languageserver'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_perl_languageserver
       \ 'config': lsp_settings#get('perl-languageserver', 'config', lsp_settings#server_config('perl-languageserver')),
       \ 'workspace_config': lsp_settings#get('perl-languageserver', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('perl-languageserver', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/perlnavigator.vim
+++ b/settings/perlnavigator.vim
@@ -1,15 +1,16 @@
+call lsp_settings#register_server({
+    \ 'name': 'perlnavigator',
+    \ 'cmd': {server_info->lsp_settings#get('perlnavigator', 'cmd', [lsp_settings#exec_path('perlnavigator')]+lsp_settings#get('perlnavigator', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('perlnavigator', 'root_uri', lsp_settings#root_uri('perlnavigator'))},
+    \ 'initialization_options': lsp_settings#get('perlnavigator', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('perlnavigator', 'allowlist', ['perl']),
+    \ 'blocklist': lsp_settings#get('perlnavigator', 'blocklist', []),
+    \ 'config': lsp_settings#get('perlnavigator', 'config', lsp_settings#server_config('perlnavigator')),
+    \ 'workspace_config': lsp_settings#get('perlnavigator', 'workspace_config', {'perlnavigator': { 'perlPath': 'perl', 'enableWarnings': v:true, 'perltidyProfile': '', 'perlcriticProfile': '', 'perlcriticEnabled': v:true, 'severity5': 'warning', 'severity4': 'info', 'severity3': 'hint', 'severity2': 'hint', 'severity1': 'hint', 'includePaths': ['lib'], 'logging': v:false, 'trace': { 'server': 'verbose' }}}),
+    \ 'semantic_highlight': lsp_settings#get('perlnavigator', 'semantic_highlight', {}),
+    \ })
+
 augroup vim_lsp_settings_perlnavigator
   au!
-  call lsp_settings#register_server({
-      \ 'name': 'perlnavigator',
-      \ 'cmd': {server_info->lsp_settings#get('perlnavigator', 'cmd', [lsp_settings#exec_path('perlnavigator')]+lsp_settings#get('perlnavigator', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('perlnavigator', 'root_uri', lsp_settings#root_uri('perlnavigator'))},
-      \ 'initialization_options': lsp_settings#get('perlnavigator', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('perlnavigator', 'allowlist', ['perl']),
-      \ 'blocklist': lsp_settings#get('perlnavigator', 'blocklist', []),
-      \ 'config': lsp_settings#get('perlnavigator', 'config', lsp_settings#server_config('perlnavigator')),
-      \ 'workspace_config': lsp_settings#get('perlnavigator', 'workspace_config', {'perlnavigator': { 'perlPath': 'perl', 'enableWarnings': v:true, 'perltidyProfile': '', 'perlcriticProfile': '', 'perlcriticEnabled': v:true, 'severity5': 'warning', 'severity4': 'info', 'severity3': 'hint', 'severity2': 'hint', 'severity1': 'hint', 'includePaths': ['lib'], 'logging': v:false, 'trace': { 'server': 'verbose' }}}),
-      \ 'semantic_highlight': lsp_settings#get('perlnavigator', 'semantic_highlight', {}),
-      \ })
   autocmd User lsp_setup let g:lsp_experimental_workspace_folders = 1
 augroup END

--- a/settings/perlnavigator.vim
+++ b/settings/perlnavigator.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_perlnavigator
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'perlnavigator',
       \ 'cmd': {server_info->lsp_settings#get('perlnavigator', 'cmd', [lsp_settings#exec_path('perlnavigator')]+lsp_settings#get('perlnavigator', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('perlnavigator', 'root_uri', lsp_settings#root_uri('perlnavigator'))},
@@ -10,6 +10,6 @@ augroup vim_lsp_settings_perlnavigator
       \ 'config': lsp_settings#get('perlnavigator', 'config', lsp_settings#server_config('perlnavigator')),
       \ 'workspace_config': lsp_settings#get('perlnavigator', 'workspace_config', {'perlnavigator': { 'perlPath': 'perl', 'enableWarnings': v:true, 'perltidyProfile': '', 'perlcriticProfile': '', 'perlcriticEnabled': v:true, 'severity5': 'warning', 'severity4': 'info', 'severity3': 'hint', 'severity2': 'hint', 'severity1': 'hint', 'includePaths': ['lib'], 'logging': v:false, 'trace': { 'server': 'verbose' }}}),
       \ 'semantic_highlight': lsp_settings#get('perlnavigator', 'semantic_highlight', {}),
-      \ }
+      \ })
   autocmd User lsp_setup let g:lsp_experimental_workspace_folders = 1
 augroup END

--- a/settings/plpgsql-lsp.vim
+++ b/settings/plpgsql-lsp.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_plpgsql_lsp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'plpgsql-lsp',
       \ 'cmd': {server_info->lsp_settings#get('plpgsql-lsp', 'cmd', [lsp_settings#exec_path('plpgsql-lsp')]+lsp_settings#get('plpgsql-lsp', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('plpgsql-lsp', 'root_uri', lsp_settings#root_uri('plpgsql-lsp'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_plpgsql_lsp
       \ 'config': lsp_settings#get('plpgsql-lsp', 'config', lsp_settings#server_config('plpgsql-lsp')),
       \ 'workspace_config': lsp_settings#get('plpgsql-lsp', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('plpgsql-lsp', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/plpgsql-lsp.vim
+++ b/settings/plpgsql-lsp.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_plpgsql_lsp
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'plpgsql-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('plpgsql-lsp', 'cmd', [lsp_settings#exec_path('plpgsql-lsp')]+lsp_settings#get('plpgsql-lsp', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('plpgsql-lsp', 'root_uri', lsp_settings#root_uri('plpgsql-lsp'))},
-      \ 'initialization_options': lsp_settings#get('plpgsql-lsp', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('plpgsql-lsp', 'allowlist', ['sql']),
-      \ 'blocklist': lsp_settings#get('plpgsql-lsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('plpgsql-lsp', 'config', lsp_settings#server_config('plpgsql-lsp')),
-      \ 'workspace_config': lsp_settings#get('plpgsql-lsp', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('plpgsql-lsp', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'plpgsql-lsp',
+    \ 'cmd': {server_info->lsp_settings#get('plpgsql-lsp', 'cmd', [lsp_settings#exec_path('plpgsql-lsp')]+lsp_settings#get('plpgsql-lsp', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('plpgsql-lsp', 'root_uri', lsp_settings#root_uri('plpgsql-lsp'))},
+    \ 'initialization_options': lsp_settings#get('plpgsql-lsp', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('plpgsql-lsp', 'allowlist', ['sql']),
+    \ 'blocklist': lsp_settings#get('plpgsql-lsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('plpgsql-lsp', 'config', lsp_settings#server_config('plpgsql-lsp')),
+    \ 'workspace_config': lsp_settings#get('plpgsql-lsp', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('plpgsql-lsp', 'semantic_highlight', {}),
+    \ })

--- a/settings/powershell-languageserver.vim
+++ b/settings/powershell-languageserver.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_powershell_languageserver
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'powershell-languageserver',
       \ 'cmd': {server_info->lsp_settings#get('powershell-languageserver', 'cmd', [lsp_settings#exec_path('powershell-languageserver')]+lsp_settings#get('powershell-languageserver', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('powershell-languageserver', 'root_uri', lsp_settings#root_uri('powershell-languageserver'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_powershell_languageserver
       \ 'config': lsp_settings#get('powershell-languageserver', 'config', lsp_settings#server_config('powershell-languageserver')),
       \ 'workspace_config': lsp_settings#get('powershell-languageserver', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('powershell-languageserver', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/powershell-languageserver.vim
+++ b/settings/powershell-languageserver.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_powershell_languageserver
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'powershell-languageserver',
-      \ 'cmd': {server_info->lsp_settings#get('powershell-languageserver', 'cmd', [lsp_settings#exec_path('powershell-languageserver')]+lsp_settings#get('powershell-languageserver', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('powershell-languageserver', 'root_uri', lsp_settings#root_uri('powershell-languageserver'))},
-      \ 'initialization_options': lsp_settings#get('powershell-languageserver', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('powershell-languageserver', 'allowlist', ['ps1']),
-      \ 'blocklist': lsp_settings#get('powershell-languageserver', 'blocklist', []),
-      \ 'config': lsp_settings#get('powershell-languageserver', 'config', lsp_settings#server_config('powershell-languageserver')),
-      \ 'workspace_config': lsp_settings#get('powershell-languageserver', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('powershell-languageserver', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'powershell-languageserver',
+    \ 'cmd': {server_info->lsp_settings#get('powershell-languageserver', 'cmd', [lsp_settings#exec_path('powershell-languageserver')]+lsp_settings#get('powershell-languageserver', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('powershell-languageserver', 'root_uri', lsp_settings#root_uri('powershell-languageserver'))},
+    \ 'initialization_options': lsp_settings#get('powershell-languageserver', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('powershell-languageserver', 'allowlist', ['ps1']),
+    \ 'blocklist': lsp_settings#get('powershell-languageserver', 'blocklist', []),
+    \ 'config': lsp_settings#get('powershell-languageserver', 'config', lsp_settings#server_config('powershell-languageserver')),
+    \ 'workspace_config': lsp_settings#get('powershell-languageserver', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('powershell-languageserver', 'semantic_highlight', {}),
+    \ })

--- a/settings/prisma-language-server.vim
+++ b/settings/prisma-language-server.vim
@@ -1,18 +1,15 @@
-augroup vim_lsp_settings_prisma_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'prisma-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('prisma-language-server', 'cmd', [lsp_settings#exec_path('prisma-language-server')]+lsp_settings#get('prisma-language-server', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('prisma-language-server', 'root_uri', lsp_settings#root_uri('prisma-language-server'))},
-      \ 'initialization_options': lsp_settings#get('prisma-language-server', 'initialization_options', {'diagnostics': 'true'}),
-      \ 'allowlist': lsp_settings#get('prisma', 'allowlist', ['prisma']),
-      \ 'blocklist': lsp_settings#get('prisma-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('prisma-language-server', 'config', lsp_settings#server_config('prisma-language-server')),
-      \ 'workspace_config': lsp_settings#get('prisma-language-server', 'workspace_config', {
-      \   'prisma': {
-      \     'prismaFmtBinPath': {c->!empty(c) ? c : lsp_settings#servers_dir() . '/prisma-language-server/prisma-fmt'}(lsp_settings#exec_path('prisma-fmt')),
-      \   }
-      \ }),
-      \ 'semantic_highlight': lsp_settings#get('prisma-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'prisma-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('prisma-language-server', 'cmd', [lsp_settings#exec_path('prisma-language-server')]+lsp_settings#get('prisma-language-server', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('prisma-language-server', 'root_uri', lsp_settings#root_uri('prisma-language-server'))},
+    \ 'initialization_options': lsp_settings#get('prisma-language-server', 'initialization_options', {'diagnostics': 'true'}),
+    \ 'allowlist': lsp_settings#get('prisma', 'allowlist', ['prisma']),
+    \ 'blocklist': lsp_settings#get('prisma-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('prisma-language-server', 'config', lsp_settings#server_config('prisma-language-server')),
+    \ 'workspace_config': lsp_settings#get('prisma-language-server', 'workspace_config', {
+    \   'prisma': {
+    \     'prismaFmtBinPath': {c->!empty(c) ? c : lsp_settings#servers_dir() . '/prisma-language-server/prisma-fmt'}(lsp_settings#exec_path('prisma-fmt')),
+    \   }
+    \ }),
+    \ 'semantic_highlight': lsp_settings#get('prisma-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/prisma-language-server.vim
+++ b/settings/prisma-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_prisma_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'prisma-language-server',
       \ 'cmd': {server_info->lsp_settings#get('prisma-language-server', 'cmd', [lsp_settings#exec_path('prisma-language-server')]+lsp_settings#get('prisma-language-server', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('prisma-language-server', 'root_uri', lsp_settings#root_uri('prisma-language-server'))},
@@ -14,5 +14,5 @@ augroup vim_lsp_settings_prisma_language_server
       \   }
       \ }),
       \ 'semantic_highlight': lsp_settings#get('prisma-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/prolog-lsp_server.vim
+++ b/settings/prolog-lsp_server.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_prolog_lsp_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'prolog-lsp_server',
-      \ 'cmd': {server_info->lsp_settings#get('prolog-lsp_server', 'cmd', [lsp_settings#exec_path('prolog-lsp_server')]+lsp_settings#get('prolog-lsp_server', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('prolog-lsp_server', 'root_uri', lsp_settings#root_uri('prolog-lsp_server'))},
-      \ 'initialization_options': lsp_settings#get('prolog-lsp_server', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('prolog-lsp_server', 'allowlist', ['prolog']),
-      \ 'blocklist': lsp_settings#get('prolog-lsp_server', 'blocklist', []),
-      \ 'config': lsp_settings#get('prolog-lsp_server', 'config', lsp_settings#server_config('prolog-lsp_server')),
-      \ 'workspace_config': lsp_settings#get('prolog-lsp_server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('prolog-lsp_server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'prolog-lsp_server',
+    \ 'cmd': {server_info->lsp_settings#get('prolog-lsp_server', 'cmd', [lsp_settings#exec_path('prolog-lsp_server')]+lsp_settings#get('prolog-lsp_server', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('prolog-lsp_server', 'root_uri', lsp_settings#root_uri('prolog-lsp_server'))},
+    \ 'initialization_options': lsp_settings#get('prolog-lsp_server', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('prolog-lsp_server', 'allowlist', ['prolog']),
+    \ 'blocklist': lsp_settings#get('prolog-lsp_server', 'blocklist', []),
+    \ 'config': lsp_settings#get('prolog-lsp_server', 'config', lsp_settings#server_config('prolog-lsp_server')),
+    \ 'workspace_config': lsp_settings#get('prolog-lsp_server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('prolog-lsp_server', 'semantic_highlight', {}),
+    \ })

--- a/settings/prolog-lsp_server.vim
+++ b/settings/prolog-lsp_server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_prolog_lsp_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'prolog-lsp_server',
       \ 'cmd': {server_info->lsp_settings#get('prolog-lsp_server', 'cmd', [lsp_settings#exec_path('prolog-lsp_server')]+lsp_settings#get('prolog-lsp_server', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('prolog-lsp_server', 'root_uri', lsp_settings#root_uri('prolog-lsp_server'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_prolog_lsp_server
       \ 'config': lsp_settings#get('prolog-lsp_server', 'config', lsp_settings#server_config('prolog-lsp_server')),
       \ 'workspace_config': lsp_settings#get('prolog-lsp_server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('prolog-lsp_server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/psalm-language-server.vim
+++ b/settings/psalm-language-server.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_psalm_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'psalm-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('psalm-language-server', 'cmd', [lsp_settings#exec_path('psalm-language-server')]+lsp_settings#get('psalm-language-server', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('psalm-language-server', 'root_uri', lsp_settings#root_uri('psalm-language-server'))},
-      \ 'initialization_options': lsp_settings#get('psalm-language-server', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('psalm-language-server', 'allowlist', ['php']),
-      \ 'blocklist': lsp_settings#get('psalm-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('psalm-language-server', 'config', lsp_settings#server_config('psalm-language-server')),
-      \ 'workspace_config': lsp_settings#get('psalm-language-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('psalm-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'psalm-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('psalm-language-server', 'cmd', [lsp_settings#exec_path('psalm-language-server')]+lsp_settings#get('psalm-language-server', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('psalm-language-server', 'root_uri', lsp_settings#root_uri('psalm-language-server'))},
+    \ 'initialization_options': lsp_settings#get('psalm-language-server', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('psalm-language-server', 'allowlist', ['php']),
+    \ 'blocklist': lsp_settings#get('psalm-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('psalm-language-server', 'config', lsp_settings#server_config('psalm-language-server')),
+    \ 'workspace_config': lsp_settings#get('psalm-language-server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('psalm-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/psalm-language-server.vim
+++ b/settings/psalm-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_psalm_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'psalm-language-server',
       \ 'cmd': {server_info->lsp_settings#get('psalm-language-server', 'cmd', [lsp_settings#exec_path('psalm-language-server')]+lsp_settings#get('psalm-language-server', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('psalm-language-server', 'root_uri', lsp_settings#root_uri('psalm-language-server'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_psalm_language_server
       \ 'config': lsp_settings#get('psalm-language-server', 'config', lsp_settings#server_config('psalm-language-server')),
       \ 'workspace_config': lsp_settings#get('psalm-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('psalm-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/puppet-ls.vim
+++ b/settings/puppet-ls.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_puppet-ls
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'puppet-ls',
-      \ 'cmd': {server_info->lsp_settings#get('puppet-ls', 'cmd', [lsp_settings#exec_path('puppet-ls')]+lsp_settings#get('puppet-ls', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('puppet-ls', 'root_uri', lsp_settings#root_uri('puppet-ls'))},
-      \ 'initialization_options': lsp_settings#get('puppet-ls', 'initialization_options', {'diagnostics': 'false'}),
-      \ 'allowlist': lsp_settings#get('puppet-ls', 'allowlist', ['puppet']),
-      \ 'blocklist': lsp_settings#get('puppet-ls', 'blocklist', []),
-      \ 'config': lsp_settings#get('puppet-ls', 'config', lsp_settings#server_config('puppet-ls')),
-      \ 'workspace_config': lsp_settings#get('puppet-ls', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('puppet-ls', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'puppet-ls',
+    \ 'cmd': {server_info->lsp_settings#get('puppet-ls', 'cmd', [lsp_settings#exec_path('puppet-ls')]+lsp_settings#get('puppet-ls', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('puppet-ls', 'root_uri', lsp_settings#root_uri('puppet-ls'))},
+    \ 'initialization_options': lsp_settings#get('puppet-ls', 'initialization_options', {'diagnostics': 'false'}),
+    \ 'allowlist': lsp_settings#get('puppet-ls', 'allowlist', ['puppet']),
+    \ 'blocklist': lsp_settings#get('puppet-ls', 'blocklist', []),
+    \ 'config': lsp_settings#get('puppet-ls', 'config', lsp_settings#server_config('puppet-ls')),
+    \ 'workspace_config': lsp_settings#get('puppet-ls', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('puppet-ls', 'semantic_highlight', {}),
+    \ })

--- a/settings/puppet-ls.vim
+++ b/settings/puppet-ls.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_puppet-ls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'puppet-ls',
       \ 'cmd': {server_info->lsp_settings#get('puppet-ls', 'cmd', [lsp_settings#exec_path('puppet-ls')]+lsp_settings#get('puppet-ls', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('puppet-ls', 'root_uri', lsp_settings#root_uri('puppet-ls'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_puppet-ls
       \ 'config': lsp_settings#get('puppet-ls', 'config', lsp_settings#server_config('puppet-ls')),
       \ 'workspace_config': lsp_settings#get('puppet-ls', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('puppet-ls', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/purescript-language-server.vim
+++ b/settings/purescript-language-server.vim
@@ -3,7 +3,7 @@ function! s:GetUri(file)
 endfunction
 
 
-function! Vim_lsp_settings_purescript_get_root_uri() abort
+function! s:get_root_uri() abort
     let spago = s:GetUri('spago.dhall')
     if !empty(spago) | return spago | endif
     let flake = s:GetUri('flake.nix')
@@ -13,15 +13,15 @@ endfunction
 
 augroup vim_lsp_settings_purescript_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'purescript-language-server',
       \ 'cmd': {server_info->lsp_settings#get('purescript-language-server', 'cmd', [lsp_settings#exec_path('purescript-language-server')]+lsp_settings#get('purescript-language-server', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('purescript-language-server', 'root_uri', Vim_lsp_settings_purescript_get_root_uri())},
+      \ 'root_uri':{server_info->lsp_settings#get('purescript-language-server', 'root_uri', s:get_root_uri())},
       \ 'initialization_options': lsp_settings#get('purescript-language-server', 'initialization_options', {}),
       \ 'allowlist': lsp_settings#get('purescript-language-server', 'allowlist', ['purescript']),
       \ 'blocklist': lsp_settings#get('purescript-language-server', 'blocklist', []),
       \ 'config': lsp_settings#get('purescript-language-server', 'config', lsp_settings#server_config('purescript-language-server')),
       \ 'workspace_config': lsp_settings#get('purescript-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('purescript-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/purescript-language-server.vim
+++ b/settings/purescript-language-server.vim
@@ -11,17 +11,14 @@ function! s:get_root_uri() abort
     return lsp_settings#root_uri('purescript-language-server')
 endfunction
 
-augroup vim_lsp_settings_purescript_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'purescript-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('purescript-language-server', 'cmd', [lsp_settings#exec_path('purescript-language-server')]+lsp_settings#get('purescript-language-server', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('purescript-language-server', 'root_uri', s:get_root_uri())},
-      \ 'initialization_options': lsp_settings#get('purescript-language-server', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('purescript-language-server', 'allowlist', ['purescript']),
-      \ 'blocklist': lsp_settings#get('purescript-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('purescript-language-server', 'config', lsp_settings#server_config('purescript-language-server')),
-      \ 'workspace_config': lsp_settings#get('purescript-language-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('purescript-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'purescript-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('purescript-language-server', 'cmd', [lsp_settings#exec_path('purescript-language-server')]+lsp_settings#get('purescript-language-server', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('purescript-language-server', 'root_uri', s:get_root_uri())},
+    \ 'initialization_options': lsp_settings#get('purescript-language-server', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('purescript-language-server', 'allowlist', ['purescript']),
+    \ 'blocklist': lsp_settings#get('purescript-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('purescript-language-server', 'config', lsp_settings#server_config('purescript-language-server')),
+    \ 'workspace_config': lsp_settings#get('purescript-language-server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('purescript-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/pyls-all.vim
+++ b/settings/pyls-all.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_pyls_all
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'pyls-all',
       \ 'cmd': {server_info->lsp_settings#get('pyls-all', 'cmd', [lsp_settings#exec_path('pyls-all')]+lsp_settings#get('pyls-all', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('pyls-all', 'root_uri', lsp_settings#root_uri('pyls-all'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_pyls_all
       \ 'config': lsp_settings#get('pyls-all', 'config', lsp_settings#server_config('pyls-all')),
       \ 'workspace_config': lsp_settings#get('pyls-all', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('pyls-all', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/pyls-all.vim
+++ b/settings/pyls-all.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_pyls_all
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'pyls-all',
-      \ 'cmd': {server_info->lsp_settings#get('pyls-all', 'cmd', [lsp_settings#exec_path('pyls-all')]+lsp_settings#get('pyls-all', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('pyls-all', 'root_uri', lsp_settings#root_uri('pyls-all'))},
-      \ 'initialization_options': lsp_settings#get('pyls-all', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('pyls-all', 'allowlist', ['python']),
-      \ 'blocklist': lsp_settings#get('pyls-all', 'blocklist', []),
-      \ 'config': lsp_settings#get('pyls-all', 'config', lsp_settings#server_config('pyls-all')),
-      \ 'workspace_config': lsp_settings#get('pyls-all', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('pyls-all', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'pyls-all',
+    \ 'cmd': {server_info->lsp_settings#get('pyls-all', 'cmd', [lsp_settings#exec_path('pyls-all')]+lsp_settings#get('pyls-all', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('pyls-all', 'root_uri', lsp_settings#root_uri('pyls-all'))},
+    \ 'initialization_options': lsp_settings#get('pyls-all', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('pyls-all', 'allowlist', ['python']),
+    \ 'blocklist': lsp_settings#get('pyls-all', 'blocklist', []),
+    \ 'config': lsp_settings#get('pyls-all', 'config', lsp_settings#server_config('pyls-all')),
+    \ 'workspace_config': lsp_settings#get('pyls-all', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('pyls-all', 'semantic_highlight', {}),
+    \ })

--- a/settings/pyls-ms.vim
+++ b/settings/pyls-ms.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_pyls_ms
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'pyls-ms',
       \ 'cmd': {server_info->lsp_settings#get('pyls-ms', 'cmd', [lsp_settings#exec_path('pyls-ms')]+lsp_settings#get('pyls-ms', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('pyls-ms', 'root_uri', lsp_settings#root_uri('pyls-ms'))},
@@ -31,5 +31,5 @@ augroup vim_lsp_settings_pyls_ms
       \   },
       \ }),
       \ 'semantic_highlight': lsp_settings#get('pyls-ms', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/pyls-ms.vim
+++ b/settings/pyls-ms.vim
@@ -1,35 +1,32 @@
-augroup vim_lsp_settings_pyls_ms
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'pyls-ms',
-      \ 'cmd': {server_info->lsp_settings#get('pyls-ms', 'cmd', [lsp_settings#exec_path('pyls-ms')]+lsp_settings#get('pyls-ms', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('pyls-ms', 'root_uri', lsp_settings#root_uri('pyls-ms'))},
-      \ 'initialization_options': lsp_settings#get('pyls-ms', 'initialization_options', {
-      \   'analysisUpdates': v:true,
-      \   'asyncStartup': v:true,
-      \   'displayOptions': {},
-      \   'interpreter': {
-      \      'properties': {
-      \        'InterpreterPath': lsp_settings#get('pyls-ms', 'python-path', {key, name->exepath('python')}),
-      \        'UseDefaultDatabase': v:true,
-      \        'Version': lsp_settings#get('pyls-ms', 'python-ver', {key, name->trim(matchstr(system(
-      \          lsp_settings#utils#shellescape(lsp_settings#get('pyls-ms', 'python-path', {key, name->exepath('python')})) . ' -V'
-      \        ), '\s\zs\S\+'))}),
-      \      },
-      \    },
-      \  }),
-      \ 'allowlist': lsp_settings#get('pyls-ms', 'allowlist', ['python']),
-      \ 'blocklist': lsp_settings#get('pyls-ms', 'blocklist', []),
-      \ 'config': lsp_settings#get('pyls-ms', 'config', lsp_settings#server_config('pyls-ms')),
-      \ 'workspace_config': lsp_settings#get('pyls-ms', 'workspace_config', {
-      \   'python': {
-      \     'analysis': {
-      \       'errors': [],
-      \       'info': [],
-      \       'disabled': [],
-      \     },
-      \   },
-      \ }),
-      \ 'semantic_highlight': lsp_settings#get('pyls-ms', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'pyls-ms',
+    \ 'cmd': {server_info->lsp_settings#get('pyls-ms', 'cmd', [lsp_settings#exec_path('pyls-ms')]+lsp_settings#get('pyls-ms', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('pyls-ms', 'root_uri', lsp_settings#root_uri('pyls-ms'))},
+    \ 'initialization_options': lsp_settings#get('pyls-ms', 'initialization_options', {
+    \   'analysisUpdates': v:true,
+    \   'asyncStartup': v:true,
+    \   'displayOptions': {},
+    \   'interpreter': {
+    \      'properties': {
+    \        'InterpreterPath': lsp_settings#get('pyls-ms', 'python-path', {key, name->exepath('python')}),
+    \        'UseDefaultDatabase': v:true,
+    \        'Version': lsp_settings#get('pyls-ms', 'python-ver', {key, name->trim(matchstr(system(
+    \          lsp_settings#utils#shellescape(lsp_settings#get('pyls-ms', 'python-path', {key, name->exepath('python')})) . ' -V'
+    \        ), '\s\zs\S\+'))}),
+    \      },
+    \    },
+    \  }),
+    \ 'allowlist': lsp_settings#get('pyls-ms', 'allowlist', ['python']),
+    \ 'blocklist': lsp_settings#get('pyls-ms', 'blocklist', []),
+    \ 'config': lsp_settings#get('pyls-ms', 'config', lsp_settings#server_config('pyls-ms')),
+    \ 'workspace_config': lsp_settings#get('pyls-ms', 'workspace_config', {
+    \   'python': {
+    \     'analysis': {
+    \       'errors': [],
+    \       'info': [],
+    \       'disabled': [],
+    \     },
+    \   },
+    \ }),
+    \ 'semantic_highlight': lsp_settings#get('pyls-ms', 'semantic_highlight', {}),
+    \ })

--- a/settings/pyls.vim
+++ b/settings/pyls.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_pyls
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'pyls',
-      \ 'cmd': {server_info->lsp_settings#get('pyls', 'cmd', [lsp_settings#exec_path('pyls')]+lsp_settings#get('pyls', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('pyls', 'root_uri', lsp_settings#root_uri('pyls'))},
-      \ 'initialization_options': lsp_settings#get('pyls', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('pyls', 'allowlist', ['python']),
-      \ 'blocklist': lsp_settings#get('pyls', 'blocklist', []),
-      \ 'config': lsp_settings#get('pyls', 'config', lsp_settings#server_config('pyls')),
-      \ 'workspace_config': lsp_settings#get('pyls', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('pyls', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'pyls',
+    \ 'cmd': {server_info->lsp_settings#get('pyls', 'cmd', [lsp_settings#exec_path('pyls')]+lsp_settings#get('pyls', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('pyls', 'root_uri', lsp_settings#root_uri('pyls'))},
+    \ 'initialization_options': lsp_settings#get('pyls', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('pyls', 'allowlist', ['python']),
+    \ 'blocklist': lsp_settings#get('pyls', 'blocklist', []),
+    \ 'config': lsp_settings#get('pyls', 'config', lsp_settings#server_config('pyls')),
+    \ 'workspace_config': lsp_settings#get('pyls', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('pyls', 'semantic_highlight', {}),
+    \ })

--- a/settings/pyls.vim
+++ b/settings/pyls.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_pyls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'pyls',
       \ 'cmd': {server_info->lsp_settings#get('pyls', 'cmd', [lsp_settings#exec_path('pyls')]+lsp_settings#get('pyls', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('pyls', 'root_uri', lsp_settings#root_uri('pyls'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_pyls
       \ 'config': lsp_settings#get('pyls', 'config', lsp_settings#server_config('pyls')),
       \ 'workspace_config': lsp_settings#get('pyls', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('pyls', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/pylsp-all.vim
+++ b/settings/pylsp-all.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_pylsp_all
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'pylsp-all',
-      \ 'cmd': {server_info->lsp_settings#get('pylsp-all', 'cmd', [lsp_settings#exec_path('pylsp-all')]+lsp_settings#get('pylsp-all', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('pylsp-all', 'root_uri', lsp_settings#root_uri('pylsp-all'))},
-      \ 'initialization_options': lsp_settings#get('pylsp-all', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('pylsp-all', 'allowlist', ['python']),
-      \ 'blocklist': lsp_settings#get('pylsp-all', 'blocklist', []),
-      \ 'config': lsp_settings#get('pylsp-all', 'config', lsp_settings#server_config('pylsp-all')),
-      \ 'workspace_config': lsp_settings#get('pylsp-all', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('pylsp-all', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'pylsp-all',
+    \ 'cmd': {server_info->lsp_settings#get('pylsp-all', 'cmd', [lsp_settings#exec_path('pylsp-all')]+lsp_settings#get('pylsp-all', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('pylsp-all', 'root_uri', lsp_settings#root_uri('pylsp-all'))},
+    \ 'initialization_options': lsp_settings#get('pylsp-all', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('pylsp-all', 'allowlist', ['python']),
+    \ 'blocklist': lsp_settings#get('pylsp-all', 'blocklist', []),
+    \ 'config': lsp_settings#get('pylsp-all', 'config', lsp_settings#server_config('pylsp-all')),
+    \ 'workspace_config': lsp_settings#get('pylsp-all', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('pylsp-all', 'semantic_highlight', {}),
+    \ })

--- a/settings/pylsp-all.vim
+++ b/settings/pylsp-all.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_pylsp_all
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'pylsp-all',
       \ 'cmd': {server_info->lsp_settings#get('pylsp-all', 'cmd', [lsp_settings#exec_path('pylsp-all')]+lsp_settings#get('pylsp-all', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('pylsp-all', 'root_uri', lsp_settings#root_uri('pylsp-all'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_pylsp_all
       \ 'config': lsp_settings#get('pylsp-all', 'config', lsp_settings#server_config('pylsp-all')),
       \ 'workspace_config': lsp_settings#get('pylsp-all', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('pylsp-all', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/pylsp.vim
+++ b/settings/pylsp.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_pylsp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'pylsp',
       \ 'cmd': {server_info->lsp_settings#get('pylsp', 'cmd', [lsp_settings#exec_path('pylsp')]+lsp_settings#get('pylsp', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('pylsp', 'root_uri', lsp_settings#root_uri('pylsp'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_pylsp
       \ 'config': lsp_settings#get('pylsp', 'config', lsp_settings#server_config('pylsp')),
       \ 'workspace_config': lsp_settings#get('pylsp', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('pylsp', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/pylsp.vim
+++ b/settings/pylsp.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_pylsp
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'pylsp',
-      \ 'cmd': {server_info->lsp_settings#get('pylsp', 'cmd', [lsp_settings#exec_path('pylsp')]+lsp_settings#get('pylsp', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('pylsp', 'root_uri', lsp_settings#root_uri('pylsp'))},
-      \ 'initialization_options': lsp_settings#get('pylsp', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('pylsp', 'allowlist', ['python']),
-      \ 'blocklist': lsp_settings#get('pylsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('pylsp', 'config', lsp_settings#server_config('pylsp')),
-      \ 'workspace_config': lsp_settings#get('pylsp', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('pylsp', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'pylsp',
+    \ 'cmd': {server_info->lsp_settings#get('pylsp', 'cmd', [lsp_settings#exec_path('pylsp')]+lsp_settings#get('pylsp', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('pylsp', 'root_uri', lsp_settings#root_uri('pylsp'))},
+    \ 'initialization_options': lsp_settings#get('pylsp', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('pylsp', 'allowlist', ['python']),
+    \ 'blocklist': lsp_settings#get('pylsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('pylsp', 'config', lsp_settings#server_config('pylsp')),
+    \ 'workspace_config': lsp_settings#get('pylsp', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('pylsp', 'semantic_highlight', {}),
+    \ })

--- a/settings/pylyzer.vim
+++ b/settings/pylyzer.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_pylyzer
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'pylyzer',
-      \ 'cmd': {server_info->lsp_settings#get('pylyzer', 'cmd', [lsp_settings#exec_path('pylyzer')]+lsp_settings#get('pylyzer', 'args', ['--server']))},
-      \ 'root_uri':{server_info->lsp_settings#get('pylyzer', 'root_uri', lsp_settings#root_uri('pylyzer'))},
-      \ 'initialization_options': lsp_settings#get('pylyzer', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('pylyzer', 'allowlist', ['python']),
-      \ 'blocklist': lsp_settings#get('pylyzer', 'blocklist', []),
-      \ 'config': lsp_settings#get('pylyzer', 'config', lsp_settings#server_config('pylyzer')),
-      \ 'workspace_config': lsp_settings#get('pylyzer', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('pylyzer', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'pylyzer',
+    \ 'cmd': {server_info->lsp_settings#get('pylyzer', 'cmd', [lsp_settings#exec_path('pylyzer')]+lsp_settings#get('pylyzer', 'args', ['--server']))},
+    \ 'root_uri':{server_info->lsp_settings#get('pylyzer', 'root_uri', lsp_settings#root_uri('pylyzer'))},
+    \ 'initialization_options': lsp_settings#get('pylyzer', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('pylyzer', 'allowlist', ['python']),
+    \ 'blocklist': lsp_settings#get('pylyzer', 'blocklist', []),
+    \ 'config': lsp_settings#get('pylyzer', 'config', lsp_settings#server_config('pylyzer')),
+    \ 'workspace_config': lsp_settings#get('pylyzer', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('pylyzer', 'semantic_highlight', {}),
+    \ })

--- a/settings/pylyzer.vim
+++ b/settings/pylyzer.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_pylyzer
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'pylyzer',
       \ 'cmd': {server_info->lsp_settings#get('pylyzer', 'cmd', [lsp_settings#exec_path('pylyzer')]+lsp_settings#get('pylyzer', 'args', ['--server']))},
       \ 'root_uri':{server_info->lsp_settings#get('pylyzer', 'root_uri', lsp_settings#root_uri('pylyzer'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_pylyzer
       \ 'config': lsp_settings#get('pylyzer', 'config', lsp_settings#server_config('pylyzer')),
       \ 'workspace_config': lsp_settings#get('pylyzer', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('pylyzer', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/pyrefly.vim
+++ b/settings/pyrefly.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_pyrefly
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'pyrefly',
       \ 'cmd': {server_info->lsp_settings#get('pyrefly', 'cmd', [lsp_settings#exec_path('pyrefly')]+lsp_settings#get('pyrefly', 'args', ['lsp']))},
       \ 'root_uri':{server_info->lsp_settings#get('pyrefly', 'root_uri', lsp_settings#root_uri('pyrefly'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_pyrefly
       \ 'config': lsp_settings#get('pyrefly', 'config', lsp_settings#server_config('pyrefly')),
       \ 'workspace_config': lsp_settings#get('pyrefly', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('pyrefly', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/pyrefly.vim
+++ b/settings/pyrefly.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_pyrefly
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'pyrefly',
-      \ 'cmd': {server_info->lsp_settings#get('pyrefly', 'cmd', [lsp_settings#exec_path('pyrefly')]+lsp_settings#get('pyrefly', 'args', ['lsp']))},
-      \ 'root_uri':{server_info->lsp_settings#get('pyrefly', 'root_uri', lsp_settings#root_uri('pyrefly'))},
-      \ 'initialization_options': lsp_settings#get('pyrefly', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('pyrefly', 'allowlist', ['python']),
-      \ 'blocklist': lsp_settings#get('pyrefly', 'blocklist', []),
-      \ 'config': lsp_settings#get('pyrefly', 'config', lsp_settings#server_config('pyrefly')),
-      \ 'workspace_config': lsp_settings#get('pyrefly', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('pyrefly', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'pyrefly',
+    \ 'cmd': {server_info->lsp_settings#get('pyrefly', 'cmd', [lsp_settings#exec_path('pyrefly')]+lsp_settings#get('pyrefly', 'args', ['lsp']))},
+    \ 'root_uri':{server_info->lsp_settings#get('pyrefly', 'root_uri', lsp_settings#root_uri('pyrefly'))},
+    \ 'initialization_options': lsp_settings#get('pyrefly', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('pyrefly', 'allowlist', ['python']),
+    \ 'blocklist': lsp_settings#get('pyrefly', 'blocklist', []),
+    \ 'config': lsp_settings#get('pyrefly', 'config', lsp_settings#server_config('pyrefly')),
+    \ 'workspace_config': lsp_settings#get('pyrefly', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('pyrefly', 'semantic_highlight', {}),
+    \ })

--- a/settings/pyright-langserver.vim
+++ b/settings/pyright-langserver.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_pyright_langserver
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'pyright-langserver',
       \ 'cmd': {server_info->lsp_settings#get('pyright-langserver', 'cmd', [lsp_settings#exec_path('pyright-langserver')]+lsp_settings#get('pyright-langserver', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('pyright-langserver', 'root_uri', lsp_settings#root_uri('pyright-langserver'))},
@@ -16,5 +16,5 @@ augroup vim_lsp_settings_pyright_langserver
       \   },
       \ }),
       \ 'semantic_highlight': lsp_settings#get('pyright-langserver', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/pyright-langserver.vim
+++ b/settings/pyright-langserver.vim
@@ -1,20 +1,17 @@
-augroup vim_lsp_settings_pyright_langserver
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'pyright-langserver',
-      \ 'cmd': {server_info->lsp_settings#get('pyright-langserver', 'cmd', [lsp_settings#exec_path('pyright-langserver')]+lsp_settings#get('pyright-langserver', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('pyright-langserver', 'root_uri', lsp_settings#root_uri('pyright-langserver'))},
-      \ 'initialization_options': lsp_settings#get('pyright-langserver', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('pyright-langserver', 'allowlist', ['python']),
-      \ 'blocklist': lsp_settings#get('pyright-langserver', 'blocklist', []),
-      \ 'config': lsp_settings#get('pyright-langserver', 'config', lsp_settings#server_config('pyright-langserver')),
-      \ 'workspace_config': lsp_settings#get('pyright-langserver', 'workspace_config', {
-      \   'python': {
-      \     'analysis': {
-      \       'useLibraryCodeForTypes': v:true
-      \     },
-      \   },
-      \ }),
-      \ 'semantic_highlight': lsp_settings#get('pyright-langserver', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'pyright-langserver',
+    \ 'cmd': {server_info->lsp_settings#get('pyright-langserver', 'cmd', [lsp_settings#exec_path('pyright-langserver')]+lsp_settings#get('pyright-langserver', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('pyright-langserver', 'root_uri', lsp_settings#root_uri('pyright-langserver'))},
+    \ 'initialization_options': lsp_settings#get('pyright-langserver', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('pyright-langserver', 'allowlist', ['python']),
+    \ 'blocklist': lsp_settings#get('pyright-langserver', 'blocklist', []),
+    \ 'config': lsp_settings#get('pyright-langserver', 'config', lsp_settings#server_config('pyright-langserver')),
+    \ 'workspace_config': lsp_settings#get('pyright-langserver', 'workspace_config', {
+    \   'python': {
+    \     'analysis': {
+    \       'useLibraryCodeForTypes': v:true
+    \     },
+    \   },
+    \ }),
+    \ 'semantic_highlight': lsp_settings#get('pyright-langserver', 'semantic_highlight', {}),
+    \ })

--- a/settings/qmlls.vim
+++ b/settings/qmlls.vim
@@ -1,11 +1,8 @@
-augroup vim_lsp_settings_qmlls
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'qmlls',
-      \ 'cmd': {server_info->lsp_settings#get('qmlls', 'cmd', [lsp_settings#exec_path('qmlls')])+lsp_settings#get('qmlls', 'args', ['-E'])},
-      \ 'root_uri':{server_info->lsp_settings#get('qmlls', 'root_uri', lsp_settings#root_uri('qmlls'))},
-      \ 'allowlist': lsp_settings#get('qmlls', 'allowlist', ['qml', 'qmljs']),
-      \ 'blocklist': lsp_settings#get('qmlls', 'blocklist', []),
-      \ 'config': lsp_settings#get('qmlls', 'config', lsp_settings#server_config('pyls-all')),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'qmlls',
+    \ 'cmd': {server_info->lsp_settings#get('qmlls', 'cmd', [lsp_settings#exec_path('qmlls')])+lsp_settings#get('qmlls', 'args', ['-E'])},
+    \ 'root_uri':{server_info->lsp_settings#get('qmlls', 'root_uri', lsp_settings#root_uri('qmlls'))},
+    \ 'allowlist': lsp_settings#get('qmlls', 'allowlist', ['qml', 'qmljs']),
+    \ 'blocklist': lsp_settings#get('qmlls', 'blocklist', []),
+    \ 'config': lsp_settings#get('qmlls', 'config', lsp_settings#server_config('pyls-all')),
+    \ })

--- a/settings/qmlls.vim
+++ b/settings/qmlls.vim
@@ -1,11 +1,11 @@
 augroup vim_lsp_settings_qmlls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'qmlls',
       \ 'cmd': {server_info->lsp_settings#get('qmlls', 'cmd', [lsp_settings#exec_path('qmlls')])+lsp_settings#get('qmlls', 'args', ['-E'])},
       \ 'root_uri':{server_info->lsp_settings#get('qmlls', 'root_uri', lsp_settings#root_uri('qmlls'))},
       \ 'allowlist': lsp_settings#get('qmlls', 'allowlist', ['qml', 'qmljs']),
       \ 'blocklist': lsp_settings#get('qmlls', 'blocklist', []),
       \ 'config': lsp_settings#get('qmlls', 'config', lsp_settings#server_config('pyls-all')),
-      \ }
+      \ })
 augroup END

--- a/settings/r-languageserver.vim
+++ b/settings/r-languageserver.vim
@@ -1,15 +1,12 @@
-augroup vim_lsp_settings_r_languageserver
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'r-languageserver',
-      \ 'cmd': {server_info->lsp_settings#get('r-languageserver', 'cmd', ['R', '--slave', '-e', 'languageserver::run()']+lsp_settings#get('r-languageserver', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('r-languageserver', 'root_uri', lsp_settings#root_uri('r-languageserver'))},
-      \ 'initialization_options': lsp_settings#get('r-languageserver', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('r-languageserver', 'allowlist', ['r']),
-      \ 'blocklist': lsp_settings#get('r-languageserver', 'blocklist', []),
-      \ 'config': lsp_settings#get('r-languageserver', 'config', lsp_settings#server_config('r-languageserver')),
-      \ 'workspace_config': lsp_settings#get('r-languageserver', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('r-languageserver', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'r-languageserver',
+    \ 'cmd': {server_info->lsp_settings#get('r-languageserver', 'cmd', ['R', '--slave', '-e', 'languageserver::run()']+lsp_settings#get('r-languageserver', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('r-languageserver', 'root_uri', lsp_settings#root_uri('r-languageserver'))},
+    \ 'initialization_options': lsp_settings#get('r-languageserver', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('r-languageserver', 'allowlist', ['r']),
+    \ 'blocklist': lsp_settings#get('r-languageserver', 'blocklist', []),
+    \ 'config': lsp_settings#get('r-languageserver', 'config', lsp_settings#server_config('r-languageserver')),
+    \ 'workspace_config': lsp_settings#get('r-languageserver', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('r-languageserver', 'semantic_highlight', {}),
+    \ })
 

--- a/settings/r-languageserver.vim
+++ b/settings/r-languageserver.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_r_languageserver
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'r-languageserver',
       \ 'cmd': {server_info->lsp_settings#get('r-languageserver', 'cmd', ['R', '--slave', '-e', 'languageserver::run()']+lsp_settings#get('r-languageserver', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('r-languageserver', 'root_uri', lsp_settings#root_uri('r-languageserver'))},
@@ -10,6 +10,6 @@ augroup vim_lsp_settings_r_languageserver
       \ 'config': lsp_settings#get('r-languageserver', 'config', lsp_settings#server_config('r-languageserver')),
       \ 'workspace_config': lsp_settings#get('r-languageserver', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('r-languageserver', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END
 

--- a/settings/racket-lsp.vim
+++ b/settings/racket-lsp.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_racket_lsp
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'racket-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('racket-lsp', 'cmd', [lsp_settings#exec_path('racket-lsp')]+lsp_settings#get('racket-lsp', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('racket-lsp', 'root_uri', lsp_settings#root_uri('racket-lsp'))},
-      \ 'initialization_options': lsp_settings#get('racket-lsp', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('racket-lsp', 'allowlist', ['racket']),
-      \ 'blocklist': lsp_settings#get('racket-lsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('racket-lsp', 'config', lsp_settings#server_config('racket-lsp')),
-      \ 'workspace_config': lsp_settings#get('racket-lsp', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('racket-lsp', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'racket-lsp',
+    \ 'cmd': {server_info->lsp_settings#get('racket-lsp', 'cmd', [lsp_settings#exec_path('racket-lsp')]+lsp_settings#get('racket-lsp', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('racket-lsp', 'root_uri', lsp_settings#root_uri('racket-lsp'))},
+    \ 'initialization_options': lsp_settings#get('racket-lsp', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('racket-lsp', 'allowlist', ['racket']),
+    \ 'blocklist': lsp_settings#get('racket-lsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('racket-lsp', 'config', lsp_settings#server_config('racket-lsp')),
+    \ 'workspace_config': lsp_settings#get('racket-lsp', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('racket-lsp', 'semantic_highlight', {}),
+    \ })

--- a/settings/racket-lsp.vim
+++ b/settings/racket-lsp.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_racket_lsp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'racket-lsp',
       \ 'cmd': {server_info->lsp_settings#get('racket-lsp', 'cmd', [lsp_settings#exec_path('racket-lsp')]+lsp_settings#get('racket-lsp', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('racket-lsp', 'root_uri', lsp_settings#root_uri('racket-lsp'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_racket_lsp
       \ 'config': lsp_settings#get('racket-lsp', 'config', lsp_settings#server_config('racket-lsp')),
       \ 'workspace_config': lsp_settings#get('racket-lsp', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('racket-lsp', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/reason-language-server.vim
+++ b/settings/reason-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_reason_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'reason-language-server',
       \ 'cmd': {server_info->lsp_settings#get('reason-language-server', 'cmd', [lsp_settings#exec_path('reason-language-server')]+lsp_settings#get('reason-language-server', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('reason-language-server', 'root_uri', lsp_settings#root_uri('reason-language-server'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_reason_language_server
       \ 'config': lsp_settings#get('reason-language-server', 'config', lsp_settings#server_config('reason-language-server')),
       \ 'workspace_config': lsp_settings#get('reason-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('reason-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/reason-language-server.vim
+++ b/settings/reason-language-server.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_reason_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'reason-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('reason-language-server', 'cmd', [lsp_settings#exec_path('reason-language-server')]+lsp_settings#get('reason-language-server', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('reason-language-server', 'root_uri', lsp_settings#root_uri('reason-language-server'))},
-      \ 'initialization_options': lsp_settings#get('reason-language-server', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('reason-language-server', 'allowlist', ['reason']),
-      \ 'blocklist': lsp_settings#get('reason-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('reason-language-server', 'config', lsp_settings#server_config('reason-language-server')),
-      \ 'workspace_config': lsp_settings#get('reason-language-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('reason-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'reason-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('reason-language-server', 'cmd', [lsp_settings#exec_path('reason-language-server')]+lsp_settings#get('reason-language-server', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('reason-language-server', 'root_uri', lsp_settings#root_uri('reason-language-server'))},
+    \ 'initialization_options': lsp_settings#get('reason-language-server', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('reason-language-server', 'allowlist', ['reason']),
+    \ 'blocklist': lsp_settings#get('reason-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('reason-language-server', 'config', lsp_settings#server_config('reason-language-server')),
+    \ 'workspace_config': lsp_settings#get('reason-language-server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('reason-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/remark-language-server.vim
+++ b/settings/remark-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_remark_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
         \ 'name': 'remark-language-server',
         \ 'cmd': {server_info->lsp_settings#get('remark-language-server', 'cmd', [lsp_settings#exec_path('remark-language-server')]+lsp_settings#get('remark-language-server', 'args', ['--stdio']))},
         \ 'root_uri':{server_info->lsp_settings#get('remark-language-server', 'root_uri', lsp_settings#root_uri('remark-language-server'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_remark_language_server
         \ 'config': lsp_settings#get('remark-language-server', 'config', lsp_settings#server_config('remark-language-server')),
         \ 'workspace_config': lsp_settings#get('remark-language-server', 'workspace_config', {}),
         \ 'semantic_highlight': lsp_settings#get('remark-language-server', 'semantic_highlight', {}),
-        \ }
+        \ })
 augroup END

--- a/settings/remark-language-server.vim
+++ b/settings/remark-language-server.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_remark_language_server
-  au!
-  call lsp_settings#register_server({
-        \ 'name': 'remark-language-server',
-        \ 'cmd': {server_info->lsp_settings#get('remark-language-server', 'cmd', [lsp_settings#exec_path('remark-language-server')]+lsp_settings#get('remark-language-server', 'args', ['--stdio']))},
-        \ 'root_uri':{server_info->lsp_settings#get('remark-language-server', 'root_uri', lsp_settings#root_uri('remark-language-server'))},
-        \ 'initialization_options': lsp_settings#get('remark-language-server', 'initialization_options', v:null),
-        \ 'allowlist': lsp_settings#get('remark-language-server', 'allowlist', []),
-        \ 'blocklist': lsp_settings#get('remark-language-server', 'blocklist', []),
-        \ 'config': lsp_settings#get('remark-language-server', 'config', lsp_settings#server_config('remark-language-server')),
-        \ 'workspace_config': lsp_settings#get('remark-language-server', 'workspace_config', {}),
-        \ 'semantic_highlight': lsp_settings#get('remark-language-server', 'semantic_highlight', {}),
-        \ })
-augroup END
+call lsp_settings#register_server({
+      \ 'name': 'remark-language-server',
+      \ 'cmd': {server_info->lsp_settings#get('remark-language-server', 'cmd', [lsp_settings#exec_path('remark-language-server')]+lsp_settings#get('remark-language-server', 'args', ['--stdio']))},
+      \ 'root_uri':{server_info->lsp_settings#get('remark-language-server', 'root_uri', lsp_settings#root_uri('remark-language-server'))},
+      \ 'initialization_options': lsp_settings#get('remark-language-server', 'initialization_options', v:null),
+      \ 'allowlist': lsp_settings#get('remark-language-server', 'allowlist', []),
+      \ 'blocklist': lsp_settings#get('remark-language-server', 'blocklist', []),
+      \ 'config': lsp_settings#get('remark-language-server', 'config', lsp_settings#server_config('remark-language-server')),
+      \ 'workspace_config': lsp_settings#get('remark-language-server', 'workspace_config', {}),
+      \ 'semantic_highlight': lsp_settings#get('remark-language-server', 'semantic_highlight', {}),
+      \ })

--- a/settings/rls.vim
+++ b/settings/rls.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_rls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'rls',
       \ 'cmd': {server_info->lsp_settings#get('rls', 'cmd', [lsp_settings#exec_path('rls')]+lsp_settings#get('rls', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('rls', 'root_uri', lsp_settings#root_uri('rls'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_rls
       \ 'config': lsp_settings#get('rls', 'config', lsp_settings#server_config('rls')),
       \ 'workspace_config': lsp_settings#get('rls', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('rls', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/rls.vim
+++ b/settings/rls.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_rls
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'rls',
-      \ 'cmd': {server_info->lsp_settings#get('rls', 'cmd', [lsp_settings#exec_path('rls')]+lsp_settings#get('rls', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('rls', 'root_uri', lsp_settings#root_uri('rls'))},
-      \ 'initialization_options': lsp_settings#get('rls', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('rls', 'allowlist', ['rust']),
-      \ 'blocklist': lsp_settings#get('rls', 'blocklist', []),
-      \ 'config': lsp_settings#get('rls', 'config', lsp_settings#server_config('rls')),
-      \ 'workspace_config': lsp_settings#get('rls', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('rls', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'rls',
+    \ 'cmd': {server_info->lsp_settings#get('rls', 'cmd', [lsp_settings#exec_path('rls')]+lsp_settings#get('rls', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('rls', 'root_uri', lsp_settings#root_uri('rls'))},
+    \ 'initialization_options': lsp_settings#get('rls', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('rls', 'allowlist', ['rust']),
+    \ 'blocklist': lsp_settings#get('rls', 'blocklist', []),
+    \ 'config': lsp_settings#get('rls', 'config', lsp_settings#server_config('rls')),
+    \ 'workspace_config': lsp_settings#get('rls', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('rls', 'semantic_highlight', {}),
+    \ })

--- a/settings/rnix-lsp.vim
+++ b/settings/rnix-lsp.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_rnix_lsp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'rnix-lsp',
       \ 'cmd': {server_info->lsp_settings#get('rnix-lsp', 'cmd', lsp_settings#exec_path('rnix-lsp'))},
       \ 'root_uri':{server_info->lsp_settings#get('rnix-lsp', 'root_uri', lsp_settings#root_uri('rnix-lsp'))},
@@ -11,5 +11,5 @@ augroup vim_lsp_settings_rnix_lsp
       \ 'workspace_config': lsp_settings#get('rnix-lsp', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('rnix-lsp', 'semantic_highlight', {}),
       \ 'deprecated': v:true,
-      \ }
+      \ })
 augroup END

--- a/settings/rnix-lsp.vim
+++ b/settings/rnix-lsp.vim
@@ -1,15 +1,12 @@
-augroup vim_lsp_settings_rnix_lsp
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'rnix-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('rnix-lsp', 'cmd', lsp_settings#exec_path('rnix-lsp'))},
-      \ 'root_uri':{server_info->lsp_settings#get('rnix-lsp', 'root_uri', lsp_settings#root_uri('rnix-lsp'))},
-      \ 'initialization_options': lsp_settings#get('rnix-lsp', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('rnix-lsp', 'allowlist', ['nix']),
-      \ 'blocklist': lsp_settings#get('rnix-lsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('rnix-lsp', 'config', lsp_settings#server_config('rnix-lsp')),
-      \ 'workspace_config': lsp_settings#get('rnix-lsp', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('rnix-lsp', 'semantic_highlight', {}),
-      \ 'deprecated': v:true,
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'rnix-lsp',
+    \ 'cmd': {server_info->lsp_settings#get('rnix-lsp', 'cmd', lsp_settings#exec_path('rnix-lsp'))},
+    \ 'root_uri':{server_info->lsp_settings#get('rnix-lsp', 'root_uri', lsp_settings#root_uri('rnix-lsp'))},
+    \ 'initialization_options': lsp_settings#get('rnix-lsp', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('rnix-lsp', 'allowlist', ['nix']),
+    \ 'blocklist': lsp_settings#get('rnix-lsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('rnix-lsp', 'config', lsp_settings#server_config('rnix-lsp')),
+    \ 'workspace_config': lsp_settings#get('rnix-lsp', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('rnix-lsp', 'semantic_highlight', {}),
+    \ 'deprecated': v:true,
+    \ })

--- a/settings/rome.vim
+++ b/settings/rome.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_rome
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'rome',
       \ 'cmd': {server_info->lsp_settings#get('rome', 'cmd', [lsp_settings#exec_path('rome')]+lsp_settings#get('rome', 'args', ['lsp']))},
       \ 'root_uri':{server_info->lsp#utils#path_to_uri(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), '.config/'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_rome
       \ 'config': lsp_settings#get('rome', 'config', {}),
       \ 'workspace_config': lsp_settings#get('rome', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('rome', 'semantic_highlight', {}),
-      \}
+      \})
 augroup END

--- a/settings/rome.vim
+++ b/settings/rome.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_rome
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'rome',
-      \ 'cmd': {server_info->lsp_settings#get('rome', 'cmd', [lsp_settings#exec_path('rome')]+lsp_settings#get('rome', 'args', ['lsp']))},
-      \ 'root_uri':{server_info->lsp#utils#path_to_uri(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), '.config/'))},
-      \ 'initialization_options': lsp_settings#get('rome', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('rome', 'allowlist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact', 'typescript.tsx', 'json']),
-      \ 'blocklist': lsp_settings#get('rome', 'blocklist', []),
-      \ 'config': lsp_settings#get('rome', 'config', {}),
-      \ 'workspace_config': lsp_settings#get('rome', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('rome', 'semantic_highlight', {}),
-      \})
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'rome',
+    \ 'cmd': {server_info->lsp_settings#get('rome', 'cmd', [lsp_settings#exec_path('rome')]+lsp_settings#get('rome', 'args', ['lsp']))},
+    \ 'root_uri':{server_info->lsp#utils#path_to_uri(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), '.config/'))},
+    \ 'initialization_options': lsp_settings#get('rome', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('rome', 'allowlist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact', 'typescript.tsx', 'json']),
+    \ 'blocklist': lsp_settings#get('rome', 'blocklist', []),
+    \ 'config': lsp_settings#get('rome', 'config', {}),
+    \ 'workspace_config': lsp_settings#get('rome', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('rome', 'semantic_highlight', {}),
+    \})

--- a/settings/rubocop-lsp-mode.vim
+++ b/settings/rubocop-lsp-mode.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_rubocop_vim_ls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'rubocop-lsp-mode',
       \ 'cmd': {server_info->lsp_settings#get('rubocop-lsp-mode', 'cmd', [lsp_settings#exec_path('rubocop-lsp-mode'), lsp#utils#uri_to_path(lsp_settings#root_uri('rubocop-lsp-mode')), '--lsp'])+lsp_settings#get('rubocop-lsp-mode', 'args', [])},
       \ 'root_uri':{server_info->lsp_settings#get('rubocop-lsp-mode', 'root_uri', lsp_settings#root_uri('rubocop-lsp-mode'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_rubocop_vim_ls
       \ 'config': lsp_settings#get('rubocop-lsp-mode', 'config', lsp_settings#server_config('rubocop-lsp-mode')),
       \ 'workspace_config': lsp_settings#get('rubocop-lsp-mode', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('rubocop-lsp-mode', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/rubocop-lsp-mode.vim
+++ b/settings/rubocop-lsp-mode.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_rubocop_vim_ls
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'rubocop-lsp-mode',
-      \ 'cmd': {server_info->lsp_settings#get('rubocop-lsp-mode', 'cmd', [lsp_settings#exec_path('rubocop-lsp-mode'), lsp#utils#uri_to_path(lsp_settings#root_uri('rubocop-lsp-mode')), '--lsp'])+lsp_settings#get('rubocop-lsp-mode', 'args', [])},
-      \ 'root_uri':{server_info->lsp_settings#get('rubocop-lsp-mode', 'root_uri', lsp_settings#root_uri('rubocop-lsp-mode'))},
-      \ 'initialization_options': lsp_settings#get('rubocop-lsp-mode', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('rubocop-lsp-mode', 'allowlist', ['ruby']),
-      \ 'blocklist': lsp_settings#get('rubocop-lsp-mode', 'blocklist', []),
-      \ 'config': lsp_settings#get('rubocop-lsp-mode', 'config', lsp_settings#server_config('rubocop-lsp-mode')),
-      \ 'workspace_config': lsp_settings#get('rubocop-lsp-mode', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('rubocop-lsp-mode', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'rubocop-lsp-mode',
+    \ 'cmd': {server_info->lsp_settings#get('rubocop-lsp-mode', 'cmd', [lsp_settings#exec_path('rubocop-lsp-mode'), lsp#utils#uri_to_path(lsp_settings#root_uri('rubocop-lsp-mode')), '--lsp'])+lsp_settings#get('rubocop-lsp-mode', 'args', [])},
+    \ 'root_uri':{server_info->lsp_settings#get('rubocop-lsp-mode', 'root_uri', lsp_settings#root_uri('rubocop-lsp-mode'))},
+    \ 'initialization_options': lsp_settings#get('rubocop-lsp-mode', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('rubocop-lsp-mode', 'allowlist', ['ruby']),
+    \ 'blocklist': lsp_settings#get('rubocop-lsp-mode', 'blocklist', []),
+    \ 'config': lsp_settings#get('rubocop-lsp-mode', 'config', lsp_settings#server_config('rubocop-lsp-mode')),
+    \ 'workspace_config': lsp_settings#get('rubocop-lsp-mode', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('rubocop-lsp-mode', 'semantic_highlight', {}),
+    \ })

--- a/settings/ruby-lsp.vim
+++ b/settings/ruby-lsp.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_ruby_lsp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'ruby-lsp',
       \ 'cmd': {server_info->lsp_settings#get('ruby-lsp', 'cmd', [lsp_settings#exec_path('ruby-lsp')]+lsp_settings#get('ruby-lsp', 'args', ['stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('ruby-lsp', 'root_uri', lsp_settings#root_uri('ruby-lsp'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_ruby_lsp
       \ 'config': lsp_settings#get('ruby-lsp', 'config', lsp_settings#server_config('ruby-lsp')),
       \ 'workspace_config': lsp_settings#get('ruby-lsp', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('ruby-lsp', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/ruby-lsp.vim
+++ b/settings/ruby-lsp.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_ruby_lsp
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'ruby-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('ruby-lsp', 'cmd', [lsp_settings#exec_path('ruby-lsp')]+lsp_settings#get('ruby-lsp', 'args', ['stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('ruby-lsp', 'root_uri', lsp_settings#root_uri('ruby-lsp'))},
-      \ 'initialization_options': lsp_settings#get('ruby-lsp', 'initialization_options', {'diagnostics': 'true'}),
-      \ 'allowlist': lsp_settings#get('ruby-lsp', 'allowlist', ['ruby']),
-      \ 'blocklist': lsp_settings#get('ruby-lsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('ruby-lsp', 'config', lsp_settings#server_config('ruby-lsp')),
-      \ 'workspace_config': lsp_settings#get('ruby-lsp', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('ruby-lsp', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'ruby-lsp',
+    \ 'cmd': {server_info->lsp_settings#get('ruby-lsp', 'cmd', [lsp_settings#exec_path('ruby-lsp')]+lsp_settings#get('ruby-lsp', 'args', ['stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('ruby-lsp', 'root_uri', lsp_settings#root_uri('ruby-lsp'))},
+    \ 'initialization_options': lsp_settings#get('ruby-lsp', 'initialization_options', {'diagnostics': 'true'}),
+    \ 'allowlist': lsp_settings#get('ruby-lsp', 'allowlist', ['ruby']),
+    \ 'blocklist': lsp_settings#get('ruby-lsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('ruby-lsp', 'config', lsp_settings#server_config('ruby-lsp')),
+    \ 'workspace_config': lsp_settings#get('ruby-lsp', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('ruby-lsp', 'semantic_highlight', {}),
+    \ })

--- a/settings/ruby_language_server.vim
+++ b/settings/ruby_language_server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_ruby_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'ruby_language_server',
       \ 'cmd': {server_info->lsp_settings#get('ruby_language_server', 'cmd', [lsp_settings#exec_path('ruby_language_server')]+lsp_settings#get('ruby_language_server', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('ruby_language_server', 'root_uri', lsp_settings#root_uri('ruby_language_server'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_ruby_language_server
       \ 'config': lsp_settings#get('ruby_language_server', 'config', lsp_settings#server_config('ruby_language_server')),
       \ 'workspace_config': lsp_settings#get('ruby_language_server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('ruby_language_server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/ruby_language_server.vim
+++ b/settings/ruby_language_server.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_ruby_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'ruby_language_server',
-      \ 'cmd': {server_info->lsp_settings#get('ruby_language_server', 'cmd', [lsp_settings#exec_path('ruby_language_server')]+lsp_settings#get('ruby_language_server', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('ruby_language_server', 'root_uri', lsp_settings#root_uri('ruby_language_server'))},
-      \ 'initialization_options': lsp_settings#get('ruby_language_server', 'initialization_options', {'diagnostics': 'false'}),
-      \ 'allowlist': lsp_settings#get('ruby_language_server', 'allowlist', ['ruby']),
-      \ 'blocklist': lsp_settings#get('ruby_language_server', 'blocklist', []),
-      \ 'config': lsp_settings#get('ruby_language_server', 'config', lsp_settings#server_config('ruby_language_server')),
-      \ 'workspace_config': lsp_settings#get('ruby_language_server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('ruby_language_server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'ruby_language_server',
+    \ 'cmd': {server_info->lsp_settings#get('ruby_language_server', 'cmd', [lsp_settings#exec_path('ruby_language_server')]+lsp_settings#get('ruby_language_server', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('ruby_language_server', 'root_uri', lsp_settings#root_uri('ruby_language_server'))},
+    \ 'initialization_options': lsp_settings#get('ruby_language_server', 'initialization_options', {'diagnostics': 'false'}),
+    \ 'allowlist': lsp_settings#get('ruby_language_server', 'allowlist', ['ruby']),
+    \ 'blocklist': lsp_settings#get('ruby_language_server', 'blocklist', []),
+    \ 'config': lsp_settings#get('ruby_language_server', 'config', lsp_settings#server_config('ruby_language_server')),
+    \ 'workspace_config': lsp_settings#get('ruby_language_server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('ruby_language_server', 'semantic_highlight', {}),
+    \ })

--- a/settings/ruff-lsp.vim
+++ b/settings/ruff-lsp.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_ruff_lsp
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'ruff-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('ruff-lsp', 'cmd', [lsp_settings#exec_path('ruff-lsp')]+lsp_settings#get('ruff-lsp', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('ruff-lsp', 'root_uri', lsp_settings#root_uri('ruff-lsp'))},
-      \ 'initialization_options': lsp_settings#get('ruff-lsp', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('ruff-lsp', 'allowlist', ['python']),
-      \ 'blocklist': lsp_settings#get('ruff-lsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('ruff-lsp', 'config', lsp_settings#server_config('ruff-lsp')),
-      \ 'workspace_config': lsp_settings#get('ruff-lsp', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('ruff-lsp', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'ruff-lsp',
+    \ 'cmd': {server_info->lsp_settings#get('ruff-lsp', 'cmd', [lsp_settings#exec_path('ruff-lsp')]+lsp_settings#get('ruff-lsp', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('ruff-lsp', 'root_uri', lsp_settings#root_uri('ruff-lsp'))},
+    \ 'initialization_options': lsp_settings#get('ruff-lsp', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('ruff-lsp', 'allowlist', ['python']),
+    \ 'blocklist': lsp_settings#get('ruff-lsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('ruff-lsp', 'config', lsp_settings#server_config('ruff-lsp')),
+    \ 'workspace_config': lsp_settings#get('ruff-lsp', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('ruff-lsp', 'semantic_highlight', {}),
+    \ })

--- a/settings/ruff-lsp.vim
+++ b/settings/ruff-lsp.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_ruff_lsp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'ruff-lsp',
       \ 'cmd': {server_info->lsp_settings#get('ruff-lsp', 'cmd', [lsp_settings#exec_path('ruff-lsp')]+lsp_settings#get('ruff-lsp', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('ruff-lsp', 'root_uri', lsp_settings#root_uri('ruff-lsp'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_ruff_lsp
       \ 'config': lsp_settings#get('ruff-lsp', 'config', lsp_settings#server_config('ruff-lsp')),
       \ 'workspace_config': lsp_settings#get('ruff-lsp', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('ruff-lsp', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/ruff.vim
+++ b/settings/ruff.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_ruff
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'ruff',
-      \ 'cmd': {server_info->lsp_settings#get('ruff', 'cmd', [lsp_settings#exec_path('ruff')]+lsp_settings#get('ruff', 'args', ['server']))},
-      \ 'root_uri':{server_info->lsp_settings#get('ruff', 'root_uri', lsp_settings#root_uri('ruff'))},
-      \ 'initialization_options': lsp_settings#get('ruff', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('ruff', 'allowlist', ['python']),
-      \ 'blocklist': lsp_settings#get('ruff', 'blocklist', []),
-      \ 'config': lsp_settings#get('ruff', 'config', lsp_settings#server_config('ruff')),
-      \ 'workspace_config': lsp_settings#get('ruff', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('ruff', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'ruff',
+    \ 'cmd': {server_info->lsp_settings#get('ruff', 'cmd', [lsp_settings#exec_path('ruff')]+lsp_settings#get('ruff', 'args', ['server']))},
+    \ 'root_uri':{server_info->lsp_settings#get('ruff', 'root_uri', lsp_settings#root_uri('ruff'))},
+    \ 'initialization_options': lsp_settings#get('ruff', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('ruff', 'allowlist', ['python']),
+    \ 'blocklist': lsp_settings#get('ruff', 'blocklist', []),
+    \ 'config': lsp_settings#get('ruff', 'config', lsp_settings#server_config('ruff')),
+    \ 'workspace_config': lsp_settings#get('ruff', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('ruff', 'semantic_highlight', {}),
+    \ })

--- a/settings/ruff.vim
+++ b/settings/ruff.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_ruff
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'ruff',
       \ 'cmd': {server_info->lsp_settings#get('ruff', 'cmd', [lsp_settings#exec_path('ruff')]+lsp_settings#get('ruff', 'args', ['server']))},
       \ 'root_uri':{server_info->lsp_settings#get('ruff', 'root_uri', lsp_settings#root_uri('ruff'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_ruff
       \ 'config': lsp_settings#get('ruff', 'config', lsp_settings#server_config('ruff')),
       \ 'workspace_config': lsp_settings#get('ruff', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('ruff', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/rust-analyzer.vim
+++ b/settings/rust-analyzer.vim
@@ -1,20 +1,21 @@
+call lsp_settings#register_server({
+    \ 'name': 'rust-analyzer',
+    \ 'cmd': {server_info->lsp_settings#get('rust-analyzer', 'cmd', [lsp_settings#exec_path('rust-analyzer')]+lsp_settings#get('rust-analyzer', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('rust-analyzer', 'root_uri', lsp_settings#root_uri('rust-analyzer'))},
+    \ 'initialization_options': lsp_settings#get('rust-analyzer', 'initialization_options', {
+    \     'completion': {
+    \         'autoimport': { 'enable': v:true },
+    \     },
+    \ }),
+    \ 'allowlist': lsp_settings#get('rust-analyzer', 'allowlist', ['rust']),
+    \ 'blocklist': lsp_settings#get('rust-analyzer', 'blocklist', []),
+    \ 'config': lsp_settings#get('rust-analyzer', 'config', lsp_settings#server_config('rust-analyzer')),
+    \ 'workspace_config': lsp_settings#get('rust-analyzer', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('rust-analyzer', 'semantic_highlight', {}),
+    \ })
+
 augroup vim_lsp_settings_rust_analyzer
   au!
-  call lsp_settings#register_server({
-      \ 'name': 'rust-analyzer',
-      \ 'cmd': {server_info->lsp_settings#get('rust-analyzer', 'cmd', [lsp_settings#exec_path('rust-analyzer')]+lsp_settings#get('rust-analyzer', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('rust-analyzer', 'root_uri', lsp_settings#root_uri('rust-analyzer'))},
-      \ 'initialization_options': lsp_settings#get('rust-analyzer', 'initialization_options', {
-      \     'completion': {
-      \         'autoimport': { 'enable': v:true },
-      \     },
-      \ }),
-      \ 'allowlist': lsp_settings#get('rust-analyzer', 'allowlist', ['rust']),
-      \ 'blocklist': lsp_settings#get('rust-analyzer', 'blocklist', []),
-      \ 'config': lsp_settings#get('rust-analyzer', 'config', lsp_settings#server_config('rust-analyzer')),
-      \ 'workspace_config': lsp_settings#get('rust-analyzer', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('rust-analyzer', 'semantic_highlight', {}),
-      \ })
   autocmd User lsp_setup call s:register_command()
   autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled()
 augroup END

--- a/settings/rust-analyzer.vim
+++ b/settings/rust-analyzer.vim
@@ -278,7 +278,7 @@ endfunction
 function! s:register_command() abort
   if get(s:, 'setup') | return | endif
   let s:setup = 1
-  augroup vimlsp_settings_rust_analyzer
+  augroup vim_lsp_settings_rust_analyzer_commands
     au!
   augroup END
   if exists('*lsp#register_command')

--- a/settings/rust-analyzer.vim
+++ b/settings/rust-analyzer.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_rust_analyzer
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'rust-analyzer',
       \ 'cmd': {server_info->lsp_settings#get('rust-analyzer', 'cmd', [lsp_settings#exec_path('rust-analyzer')]+lsp_settings#get('rust-analyzer', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('rust-analyzer', 'root_uri', lsp_settings#root_uri('rust-analyzer'))},
@@ -14,7 +14,7 @@ augroup vim_lsp_settings_rust_analyzer
       \ 'config': lsp_settings#get('rust-analyzer', 'config', lsp_settings#server_config('rust-analyzer')),
       \ 'workspace_config': lsp_settings#get('rust-analyzer', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('rust-analyzer', 'semantic_highlight', {}),
-      \ }
+      \ })
   autocmd User lsp_setup call s:register_command()
   autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled()
 augroup END

--- a/settings/serve-d.vim
+++ b/settings/serve-d.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_serve_d
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'serve-d',
       \ 'cmd': {server_info->lsp_settings#get('serve-d', 'cmd', [lsp_settings#exec_path('serve-d')]+lsp_settings#get('serve-d', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('serve-d', 'root_uri', lsp_settings#root_uri('serve-d'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_serve_d
       \ 'config': lsp_settings#get('serve-d', 'config', lsp_settings#server_config('serve-d')),
       \ 'workspace_config': lsp_settings#get('serve-d', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('serve-d', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/serve-d.vim
+++ b/settings/serve-d.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_serve_d
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'serve-d',
-      \ 'cmd': {server_info->lsp_settings#get('serve-d', 'cmd', [lsp_settings#exec_path('serve-d')]+lsp_settings#get('serve-d', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('serve-d', 'root_uri', lsp_settings#root_uri('serve-d'))},
-      \ 'initialization_options': lsp_settings#get('serve-d', 'initialization_options', {'diagnostics': 'true'}),
-      \ 'allowlist': lsp_settings#get('serve-d', 'allowlist', ['d']),
-      \ 'blocklist': lsp_settings#get('serve-d', 'blocklist', []),
-      \ 'config': lsp_settings#get('serve-d', 'config', lsp_settings#server_config('serve-d')),
-      \ 'workspace_config': lsp_settings#get('serve-d', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('serve-d', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'serve-d',
+    \ 'cmd': {server_info->lsp_settings#get('serve-d', 'cmd', [lsp_settings#exec_path('serve-d')]+lsp_settings#get('serve-d', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('serve-d', 'root_uri', lsp_settings#root_uri('serve-d'))},
+    \ 'initialization_options': lsp_settings#get('serve-d', 'initialization_options', {'diagnostics': 'true'}),
+    \ 'allowlist': lsp_settings#get('serve-d', 'allowlist', ['d']),
+    \ 'blocklist': lsp_settings#get('serve-d', 'blocklist', []),
+    \ 'config': lsp_settings#get('serve-d', 'config', lsp_settings#server_config('serve-d')),
+    \ 'workspace_config': lsp_settings#get('serve-d', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('serve-d', 'semantic_highlight', {}),
+    \ })

--- a/settings/slp.vim
+++ b/settings/slp.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_slp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'slp',
       \ 'cmd': {server_info->lsp_settings#get('slp', 'cmd', [lsp_settings#exec_path('slp')]+lsp_settings#get('slp', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('slp', 'root_uri', lsp_settings#root_uri('slp'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_slp
       \ 'config': lsp_settings#get('slp', 'config', lsp_settings#server_config('slp')),
       \ 'workspace_config': lsp_settings#get('slp', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('slp', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/slp.vim
+++ b/settings/slp.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_slp
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'slp',
-      \ 'cmd': {server_info->lsp_settings#get('slp', 'cmd', [lsp_settings#exec_path('slp')]+lsp_settings#get('slp', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('slp', 'root_uri', lsp_settings#root_uri('slp'))},
-      \ 'initialization_options': lsp_settings#get('slp', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('slp', 'allowlist', ['perl']),
-      \ 'blocklist': lsp_settings#get('slp', 'blocklist', []),
-      \ 'config': lsp_settings#get('slp', 'config', lsp_settings#server_config('slp')),
-      \ 'workspace_config': lsp_settings#get('slp', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('slp', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'slp',
+    \ 'cmd': {server_info->lsp_settings#get('slp', 'cmd', [lsp_settings#exec_path('slp')]+lsp_settings#get('slp', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('slp', 'root_uri', lsp_settings#root_uri('slp'))},
+    \ 'initialization_options': lsp_settings#get('slp', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('slp', 'allowlist', ['perl']),
+    \ 'blocklist': lsp_settings#get('slp', 'blocklist', []),
+    \ 'config': lsp_settings#get('slp', 'config', lsp_settings#server_config('slp')),
+    \ 'workspace_config': lsp_settings#get('slp', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('slp', 'semantic_highlight', {}),
+    \ })

--- a/settings/solargraph.vim
+++ b/settings/solargraph.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_solargraph
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'solargraph',
       \ 'cmd': {server_info->lsp_settings#get('solargraph', 'cmd', [lsp_settings#exec_path('solargraph')]+lsp_settings#get('solargraph', 'args', ['stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('solargraph', 'root_uri', lsp_settings#root_uri('solargraph'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_solargraph
       \ 'config': lsp_settings#get('solargraph', 'config', lsp_settings#server_config('solargraph')),
       \ 'workspace_config': lsp_settings#get('solargraph', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('solargraph', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/solargraph.vim
+++ b/settings/solargraph.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_solargraph
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'solargraph',
-      \ 'cmd': {server_info->lsp_settings#get('solargraph', 'cmd', [lsp_settings#exec_path('solargraph')]+lsp_settings#get('solargraph', 'args', ['stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('solargraph', 'root_uri', lsp_settings#root_uri('solargraph'))},
-      \ 'initialization_options': lsp_settings#get('solargraph', 'initialization_options', {'diagnostics': 'true'}),
-      \ 'allowlist': lsp_settings#get('solargraph', 'allowlist', ['ruby']),
-      \ 'blocklist': lsp_settings#get('solargraph', 'blocklist', []),
-      \ 'config': lsp_settings#get('solargraph', 'config', lsp_settings#server_config('solargraph')),
-      \ 'workspace_config': lsp_settings#get('solargraph', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('solargraph', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'solargraph',
+    \ 'cmd': {server_info->lsp_settings#get('solargraph', 'cmd', [lsp_settings#exec_path('solargraph')]+lsp_settings#get('solargraph', 'args', ['stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('solargraph', 'root_uri', lsp_settings#root_uri('solargraph'))},
+    \ 'initialization_options': lsp_settings#get('solargraph', 'initialization_options', {'diagnostics': 'true'}),
+    \ 'allowlist': lsp_settings#get('solargraph', 'allowlist', ['ruby']),
+    \ 'blocklist': lsp_settings#get('solargraph', 'blocklist', []),
+    \ 'config': lsp_settings#get('solargraph', 'config', lsp_settings#server_config('solargraph')),
+    \ 'workspace_config': lsp_settings#get('solargraph', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('solargraph', 'semantic_highlight', {}),
+    \ })

--- a/settings/sorbet.vim
+++ b/settings/sorbet.vim
@@ -8,17 +8,14 @@ function! Vim_lsp_get_watchman_flag()
   return '--disable-watchman'
 endfunction
 
-augroup vim_lsp_settings_sorbet
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'sorbet',
-      \ 'cmd': {server_info->lsp_settings#get('sorbet', 'cmd', [lsp_settings#exec_path('sorbet'), lsp#utils#uri_to_path(lsp_settings#root_uri('sorbet')), '--lsp', Vim_lsp_get_watchman_flag()])+lsp_settings#get('sorbet', 'args', [])},
-      \ 'root_uri':{server_info->lsp_settings#get('sorbet', 'root_uri', lsp_settings#root_uri('sorbet'))},
-      \ 'initialization_options': lsp_settings#get('sorbet', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('sorbet', 'allowlist', ['ruby']),
-      \ 'blocklist': lsp_settings#get('sorbet', 'blocklist', []),
-      \ 'config': lsp_settings#get('sorbet', 'config', lsp_settings#server_config('sorbet')),
-      \ 'workspace_config': lsp_settings#get('sorbet', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('sorbet', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'sorbet',
+    \ 'cmd': {server_info->lsp_settings#get('sorbet', 'cmd', [lsp_settings#exec_path('sorbet'), lsp#utils#uri_to_path(lsp_settings#root_uri('sorbet')), '--lsp', Vim_lsp_get_watchman_flag()])+lsp_settings#get('sorbet', 'args', [])},
+    \ 'root_uri':{server_info->lsp_settings#get('sorbet', 'root_uri', lsp_settings#root_uri('sorbet'))},
+    \ 'initialization_options': lsp_settings#get('sorbet', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('sorbet', 'allowlist', ['ruby']),
+    \ 'blocklist': lsp_settings#get('sorbet', 'blocklist', []),
+    \ 'config': lsp_settings#get('sorbet', 'config', lsp_settings#server_config('sorbet')),
+    \ 'workspace_config': lsp_settings#get('sorbet', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('sorbet', 'semantic_highlight', {}),
+    \ })

--- a/settings/sorbet.vim
+++ b/settings/sorbet.vim
@@ -10,7 +10,7 @@ endfunction
 
 augroup vim_lsp_settings_sorbet
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'sorbet',
       \ 'cmd': {server_info->lsp_settings#get('sorbet', 'cmd', [lsp_settings#exec_path('sorbet'), lsp#utils#uri_to_path(lsp_settings#root_uri('sorbet')), '--lsp', Vim_lsp_get_watchman_flag()])+lsp_settings#get('sorbet', 'args', [])},
       \ 'root_uri':{server_info->lsp_settings#get('sorbet', 'root_uri', lsp_settings#root_uri('sorbet'))},
@@ -20,5 +20,5 @@ augroup vim_lsp_settings_sorbet
       \ 'config': lsp_settings#get('sorbet', 'config', lsp_settings#server_config('sorbet')),
       \ 'workspace_config': lsp_settings#get('sorbet', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('sorbet', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/sourcekit-lsp.vim
+++ b/settings/sourcekit-lsp.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_sourcekit_lsp
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'sourcekit-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('sourcekit-lsp', 'cmd', [lsp_settings#exec_path('sourcekit-lsp')]+lsp_settings#get('sourcekit-lsp', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('sourcekit-lsp', 'root_uri', lsp_settings#root_uri('sourcekit-lsp'))},
-      \ 'initialization_options': lsp_settings#get('sourcekit-lsp', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('sourcekit-lsp', 'allowlist', ['swift']),
-      \ 'blocklist': lsp_settings#get('sourcekit-lsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('sourcekit-lsp', 'config', lsp_settings#server_config('sourcekit-lsp')),
-      \ 'workspace_config': lsp_settings#get('sourcekit-lsp', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('sourcekit-lsp', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'sourcekit-lsp',
+    \ 'cmd': {server_info->lsp_settings#get('sourcekit-lsp', 'cmd', [lsp_settings#exec_path('sourcekit-lsp')]+lsp_settings#get('sourcekit-lsp', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('sourcekit-lsp', 'root_uri', lsp_settings#root_uri('sourcekit-lsp'))},
+    \ 'initialization_options': lsp_settings#get('sourcekit-lsp', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('sourcekit-lsp', 'allowlist', ['swift']),
+    \ 'blocklist': lsp_settings#get('sourcekit-lsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('sourcekit-lsp', 'config', lsp_settings#server_config('sourcekit-lsp')),
+    \ 'workspace_config': lsp_settings#get('sourcekit-lsp', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('sourcekit-lsp', 'semantic_highlight', {}),
+    \ })

--- a/settings/sourcekit-lsp.vim
+++ b/settings/sourcekit-lsp.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_sourcekit_lsp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'sourcekit-lsp',
       \ 'cmd': {server_info->lsp_settings#get('sourcekit-lsp', 'cmd', [lsp_settings#exec_path('sourcekit-lsp')]+lsp_settings#get('sourcekit-lsp', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('sourcekit-lsp', 'root_uri', lsp_settings#root_uri('sourcekit-lsp'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_sourcekit_lsp
       \ 'config': lsp_settings#get('sourcekit-lsp', 'config', lsp_settings#server_config('sourcekit-lsp')),
       \ 'workspace_config': lsp_settings#get('sourcekit-lsp', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('sourcekit-lsp', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/sql-language-server.vim
+++ b/settings/sql-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_sql_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'sql-language-server',
       \ 'cmd': {server_info->lsp_settings#get('sql-language-server', 'cmd', [lsp_settings#exec_path('sql-language-server')]+lsp_settings#get('sql-language-server', 'args', ['up', '--method', 'stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('sql-language-server', 'root_uri', lsp_settings#root_uri('sql-language-server'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_sql_language_server
       \ 'config': lsp_settings#get('sql-language-server', 'config', lsp_settings#server_config('sql-language-server')),
       \ 'workspace_config': lsp_settings#get('sql-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('sql-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/sql-language-server.vim
+++ b/settings/sql-language-server.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_sql_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'sql-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('sql-language-server', 'cmd', [lsp_settings#exec_path('sql-language-server')]+lsp_settings#get('sql-language-server', 'args', ['up', '--method', 'stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('sql-language-server', 'root_uri', lsp_settings#root_uri('sql-language-server'))},
-      \ 'initialization_options': lsp_settings#get('sql-language-server', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('sql-language-server', 'allowlist', ['sql']),
-      \ 'blocklist': lsp_settings#get('sql-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('sql-language-server', 'config', lsp_settings#server_config('sql-language-server')),
-      \ 'workspace_config': lsp_settings#get('sql-language-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('sql-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'sql-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('sql-language-server', 'cmd', [lsp_settings#exec_path('sql-language-server')]+lsp_settings#get('sql-language-server', 'args', ['up', '--method', 'stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('sql-language-server', 'root_uri', lsp_settings#root_uri('sql-language-server'))},
+    \ 'initialization_options': lsp_settings#get('sql-language-server', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('sql-language-server', 'allowlist', ['sql']),
+    \ 'blocklist': lsp_settings#get('sql-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('sql-language-server', 'config', lsp_settings#server_config('sql-language-server')),
+    \ 'workspace_config': lsp_settings#get('sql-language-server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('sql-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/sqls.vim
+++ b/settings/sqls.vim
@@ -34,7 +34,7 @@ function! s:on_lsp_buffer_enabled() abort
   command! -buffer LspSQLQuery call <SID>sqls_query()
 endfunction
 
-augroup lsp_install_sqls
+augroup vim_lsp_settings_sqls
   au!
   autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled()
 augroup END

--- a/settings/sqls.vim
+++ b/settings/sqls.vim
@@ -1,17 +1,14 @@
-augroup vim_lsp_settings_sqls
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'sqls',
-      \ 'cmd': {server_info->lsp_settings#get('sqls', 'cmd', [lsp_settings#exec_path('sqls')]+lsp_settings#get('sqls', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('sqls', 'root_uri', lsp_settings#root_uri('sqls'))},
-      \ 'initialization_options': lsp_settings#get('sqls', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('sqls', 'allowlist', ['sql']),
-      \ 'blocklist': lsp_settings#get('sqls', 'blocklist', []),
-      \ 'config': lsp_settings#get('sqls', 'config', lsp_settings#server_config('sqls')),
-      \ 'workspace_config': lsp_settings#get('sqls', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('sqls', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'sqls',
+    \ 'cmd': {server_info->lsp_settings#get('sqls', 'cmd', [lsp_settings#exec_path('sqls')]+lsp_settings#get('sqls', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('sqls', 'root_uri', lsp_settings#root_uri('sqls'))},
+    \ 'initialization_options': lsp_settings#get('sqls', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('sqls', 'allowlist', ['sql']),
+    \ 'blocklist': lsp_settings#get('sqls', 'blocklist', []),
+    \ 'config': lsp_settings#get('sqls', 'config', lsp_settings#server_config('sqls')),
+    \ 'workspace_config': lsp_settings#get('sqls', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('sqls', 'semantic_highlight', {}),
+    \ })
 
 function! s:sqls_query() abort
   call lsp#send_request('sqls', {

--- a/settings/sqls.vim
+++ b/settings/sqls.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_sqls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'sqls',
       \ 'cmd': {server_info->lsp_settings#get('sqls', 'cmd', [lsp_settings#exec_path('sqls')]+lsp_settings#get('sqls', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('sqls', 'root_uri', lsp_settings#root_uri('sqls'))},
@@ -10,7 +10,7 @@ augroup vim_lsp_settings_sqls
       \ 'config': lsp_settings#get('sqls', 'config', lsp_settings#server_config('sqls')),
       \ 'workspace_config': lsp_settings#get('sqls', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('sqls', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END
 
 function! s:sqls_query() abort

--- a/settings/starpls.vim
+++ b/settings/starpls.vim
@@ -1,15 +1,12 @@
-augroup vim_lsp_settings_starpls
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'starpls',
-      \ 'cmd': {server_info->lsp_settings#get('starpls', 'cmd', [lsp_settings#exec_path('starpls')]+lsp_settings#get('starpls', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('starpls', 'root_uri', lsp_settings#root_uri('starpls'))},
-      \ 'initialization_options': lsp_settings#get('starpls', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('starpls', 'allowlist', ['bzl', 'starlark']),
-      \ 'blocklist': lsp_settings#get('starpls', 'blocklist', []),
-      \ 'config': lsp_settings#get('starpls', 'config', lsp_settings#server_config('starpls')),
-      \ 'workspace_config': lsp_settings#get('starpls', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('starpls', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'starpls',
+    \ 'cmd': {server_info->lsp_settings#get('starpls', 'cmd', [lsp_settings#exec_path('starpls')]+lsp_settings#get('starpls', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('starpls', 'root_uri', lsp_settings#root_uri('starpls'))},
+    \ 'initialization_options': lsp_settings#get('starpls', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('starpls', 'allowlist', ['bzl', 'starlark']),
+    \ 'blocklist': lsp_settings#get('starpls', 'blocklist', []),
+    \ 'config': lsp_settings#get('starpls', 'config', lsp_settings#server_config('starpls')),
+    \ 'workspace_config': lsp_settings#get('starpls', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('starpls', 'semantic_highlight', {}),
+    \ })
 

--- a/settings/starpls.vim
+++ b/settings/starpls.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_starpls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'starpls',
       \ 'cmd': {server_info->lsp_settings#get('starpls', 'cmd', [lsp_settings#exec_path('starpls')]+lsp_settings#get('starpls', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('starpls', 'root_uri', lsp_settings#root_uri('starpls'))},
@@ -10,6 +10,6 @@ augroup vim_lsp_settings_starpls
       \ 'config': lsp_settings#get('starpls', 'config', lsp_settings#server_config('starpls')),
       \ 'workspace_config': lsp_settings#get('starpls', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('starpls', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END
 

--- a/settings/steep.vim
+++ b/settings/steep.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_steep
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'steep',
-      \ 'cmd': {server_info->lsp_settings#get('steep', 'cmd', [lsp_settings#exec_path('steep'), 'langserver', printf('--steepfile=%s', lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'Steepfile'))]+lsp_settings#get('steep', 'args', []))},
-      \ 'root_uri': {server_info->lsp#utils#path_to_uri(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), 'Steepfile'))},
-      \ 'initialization_options': lsp_settings#get('steep', 'initialization_options', {'diagnostics': 'true'}),
-      \ 'allowlist': lsp_settings#get('steep', 'allowlist', {x->empty(lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'Steepfile')) ? [] : ['ruby']}),
-      \ 'blocklist': lsp_settings#get('steep', 'blocklist', []),
-      \ 'config': lsp_settings#get('steep', 'config', lsp_settings#server_config('steep')),
-      \ 'workspace_config': lsp_settings#get('steep', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('steep', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'steep',
+    \ 'cmd': {server_info->lsp_settings#get('steep', 'cmd', [lsp_settings#exec_path('steep'), 'langserver', printf('--steepfile=%s', lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'Steepfile'))]+lsp_settings#get('steep', 'args', []))},
+    \ 'root_uri': {server_info->lsp#utils#path_to_uri(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), 'Steepfile'))},
+    \ 'initialization_options': lsp_settings#get('steep', 'initialization_options', {'diagnostics': 'true'}),
+    \ 'allowlist': lsp_settings#get('steep', 'allowlist', {x->empty(lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'Steepfile')) ? [] : ['ruby']}),
+    \ 'blocklist': lsp_settings#get('steep', 'blocklist', []),
+    \ 'config': lsp_settings#get('steep', 'config', lsp_settings#server_config('steep')),
+    \ 'workspace_config': lsp_settings#get('steep', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('steep', 'semantic_highlight', {}),
+    \ })

--- a/settings/steep.vim
+++ b/settings/steep.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_steep
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'steep',
       \ 'cmd': {server_info->lsp_settings#get('steep', 'cmd', [lsp_settings#exec_path('steep'), 'langserver', printf('--steepfile=%s', lsp#utils#find_nearest_parent_file(lsp#utils#get_buffer_path(), 'Steepfile'))]+lsp_settings#get('steep', 'args', []))},
       \ 'root_uri': {server_info->lsp#utils#path_to_uri(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), 'Steepfile'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_steep
       \ 'config': lsp_settings#get('steep', 'config', lsp_settings#server_config('steep')),
       \ 'workspace_config': lsp_settings#get('steep', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('steep', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/sumneko-lua-language-server.vim
+++ b/settings/sumneko-lua-language-server.vim
@@ -42,7 +42,7 @@ augroup vim_lsp_settings_sumneko_lua_language_server
         \}
 
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'sumneko-lua-language-server',
       \ 'cmd': {server_info->lsp_settings#get('sumneko-lua-language-server', 'cmd', [lsp_settings#exec_path('sumneko-lua-language-server')]+lsp_settings#get('sumneko-lua-language-server', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('sumneko-lua-language-server', 'root_uri', lsp_settings#root_uri('sumneko-lua-language-server'))},
@@ -52,5 +52,5 @@ augroup vim_lsp_settings_sumneko_lua_language_server
       \ 'config': lsp_settings#get('sumneko-lua-language-server', 'config', lsp_settings#server_config('sumneko-lua-language-server')),
       \ 'workspace_config': lsp_settings#get('sumneko-lua-language-server', 'workspace_config', g:vim_lsp_settings_sumneko_lua_language_server_workspace_config),
       \ 'semantic_highlight': lsp_settings#get('sumneko-lua-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/sumneko-lua-language-server.vim
+++ b/settings/sumneko-lua-language-server.vim
@@ -1,56 +1,53 @@
-augroup vim_lsp_settings_sumneko_lua_language_server
-  let g:vim_lsp_settings_sumneko_lua_language_server_workspace_config = {
-        \  'Lua': {
-        \    'color': {
-        \      'mode': 'Semantic'
-        \    },
-        \    'completion': {
-        \      'callSnippet': 'Disable',
-        \      'enable': v:true,
-        \      'keywordSnippet': 'Replace'
-        \    },
-        \    'develop': {
-        \      'debuggerPort': 11412,
-        \      'debuggerWait': v:false,
-        \      'enable': v:false
-        \    },
-        \    'diagnostics': {
-        \      'enable': v:true,
-        \      'globals': '',
-        \      'severity': {}
-        \    },
-        \    'hover': {
-        \      'enable': v:true,
-        \      'viewNumber': v:true,
-        \      'viewString': v:true,
-        \      'viewStringMax': 1000
-        \    },
-        \    'runtime': {
-        \      'path': ['?.lua', '?/init.lua', '?/?.lua'],
-        \      'version': 'Lua 5.3'
-        \    },
-        \    'signatureHelp': {
-        \      'enable': v:true
-        \    },
-        \    'workspace': {
-        \      'ignoreDir': [],
-        \      'maxPreload': 1000,
-        \      'preloadFileSize': 100,
-        \      'useGitIgnore': v:true
-        \    }
-        \  }
-        \}
+let g:vim_lsp_settings_sumneko_lua_language_server_workspace_config = {
+      \  'Lua': {
+      \    'color': {
+      \      'mode': 'Semantic'
+      \    },
+      \    'completion': {
+      \      'callSnippet': 'Disable',
+      \      'enable': v:true,
+      \      'keywordSnippet': 'Replace'
+      \    },
+      \    'develop': {
+      \      'debuggerPort': 11412,
+      \      'debuggerWait': v:false,
+      \      'enable': v:false
+      \    },
+      \    'diagnostics': {
+      \      'enable': v:true,
+      \      'globals': '',
+      \      'severity': {}
+      \    },
+      \    'hover': {
+      \      'enable': v:true,
+      \      'viewNumber': v:true,
+      \      'viewString': v:true,
+      \      'viewStringMax': 1000
+      \    },
+      \    'runtime': {
+      \      'path': ['?.lua', '?/init.lua', '?/?.lua'],
+      \      'version': 'Lua 5.3'
+      \    },
+      \    'signatureHelp': {
+      \      'enable': v:true
+      \    },
+      \    'workspace': {
+      \      'ignoreDir': [],
+      \      'maxPreload': 1000,
+      \      'preloadFileSize': 100,
+      \      'useGitIgnore': v:true
+      \    }
+      \  }
+      \}
 
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'sumneko-lua-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('sumneko-lua-language-server', 'cmd', [lsp_settings#exec_path('sumneko-lua-language-server')]+lsp_settings#get('sumneko-lua-language-server', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('sumneko-lua-language-server', 'root_uri', lsp_settings#root_uri('sumneko-lua-language-server'))},
-      \ 'initialization_options': lsp_settings#get('sumneko-lua-language-server', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('sumneko-lua-language-server', 'allowlist', ['lua']),
-      \ 'blocklist': lsp_settings#get('sumneko-lua-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('sumneko-lua-language-server', 'config', lsp_settings#server_config('sumneko-lua-language-server')),
-      \ 'workspace_config': lsp_settings#get('sumneko-lua-language-server', 'workspace_config', g:vim_lsp_settings_sumneko_lua_language_server_workspace_config),
-      \ 'semantic_highlight': lsp_settings#get('sumneko-lua-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'sumneko-lua-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('sumneko-lua-language-server', 'cmd', [lsp_settings#exec_path('sumneko-lua-language-server')]+lsp_settings#get('sumneko-lua-language-server', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('sumneko-lua-language-server', 'root_uri', lsp_settings#root_uri('sumneko-lua-language-server'))},
+    \ 'initialization_options': lsp_settings#get('sumneko-lua-language-server', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('sumneko-lua-language-server', 'allowlist', ['lua']),
+    \ 'blocklist': lsp_settings#get('sumneko-lua-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('sumneko-lua-language-server', 'config', lsp_settings#server_config('sumneko-lua-language-server')),
+    \ 'workspace_config': lsp_settings#get('sumneko-lua-language-server', 'workspace_config', g:vim_lsp_settings_sumneko_lua_language_server_workspace_config),
+    \ 'semantic_highlight': lsp_settings#get('sumneko-lua-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/svelte-language-server.vim
+++ b/settings/svelte-language-server.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_svelte_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'svelte-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('svelte-language-server', 'cmd', [lsp_settings#exec_path('svelte-language-server')]+lsp_settings#get('svelte-language-server', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('svelte-language-server', 'root_uri', lsp_settings#root_uri('svelte-language-server'))},
-      \ 'initialization_options': lsp_settings#get('svelte-language-server', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('svelte-language-server', 'allowlist', ['svelte']),
-      \ 'blocklist': lsp_settings#get('svelte-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('svelte-language-server', 'config', lsp_settings#server_config('svelte-language-server')),
-      \ 'workspace_config': lsp_settings#get('svelte-language-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('svelte-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'svelte-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('svelte-language-server', 'cmd', [lsp_settings#exec_path('svelte-language-server')]+lsp_settings#get('svelte-language-server', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('svelte-language-server', 'root_uri', lsp_settings#root_uri('svelte-language-server'))},
+    \ 'initialization_options': lsp_settings#get('svelte-language-server', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('svelte-language-server', 'allowlist', ['svelte']),
+    \ 'blocklist': lsp_settings#get('svelte-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('svelte-language-server', 'config', lsp_settings#server_config('svelte-language-server')),
+    \ 'workspace_config': lsp_settings#get('svelte-language-server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('svelte-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/svelte-language-server.vim
+++ b/settings/svelte-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_svelte_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'svelte-language-server',
       \ 'cmd': {server_info->lsp_settings#get('svelte-language-server', 'cmd', [lsp_settings#exec_path('svelte-language-server')]+lsp_settings#get('svelte-language-server', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('svelte-language-server', 'root_uri', lsp_settings#root_uri('svelte-language-server'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_svelte_language_server
       \ 'config': lsp_settings#get('svelte-language-server', 'config', lsp_settings#server_config('svelte-language-server')),
       \ 'workspace_config': lsp_settings#get('svelte-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('svelte-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/svls.vim
+++ b/settings/svls.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_svls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'svls',
       \ 'cmd': {server_info->lsp_settings#get('svls', 'cmd', [lsp_settings#exec_path('svls')]+lsp_settings#get('svls', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('svls', 'root_uri', lsp_settings#root_uri('svls'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_svls
       \ 'config': lsp_settings#get('svls', 'config', lsp_settings#server_config('svls')),
       \ 'workspace_config': lsp_settings#get('svls', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('svls', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/svls.vim
+++ b/settings/svls.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_svls
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'svls',
-      \ 'cmd': {server_info->lsp_settings#get('svls', 'cmd', [lsp_settings#exec_path('svls')]+lsp_settings#get('svls', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('svls', 'root_uri', lsp_settings#root_uri('svls'))},
-      \ 'initialization_options': lsp_settings#get('svls', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('svls', 'allowlist', ['systemverilog']),
-      \ 'blocklist': lsp_settings#get('svls', 'blocklist', []),
-      \ 'config': lsp_settings#get('svls', 'config', lsp_settings#server_config('svls')),
-      \ 'workspace_config': lsp_settings#get('svls', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('svls', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'svls',
+    \ 'cmd': {server_info->lsp_settings#get('svls', 'cmd', [lsp_settings#exec_path('svls')]+lsp_settings#get('svls', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('svls', 'root_uri', lsp_settings#root_uri('svls'))},
+    \ 'initialization_options': lsp_settings#get('svls', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('svls', 'allowlist', ['systemverilog']),
+    \ 'blocklist': lsp_settings#get('svls', 'blocklist', []),
+    \ 'config': lsp_settings#get('svls', 'config', lsp_settings#server_config('svls')),
+    \ 'workspace_config': lsp_settings#get('svls', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('svls', 'semantic_highlight', {}),
+    \ })

--- a/settings/systemd-lsp.vim
+++ b/settings/systemd-lsp.vim
@@ -1,18 +1,15 @@
-augroup vim_lsp_settings_system_lsp
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'systemd-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('systemd-lsp', 'cmd', [lsp_settings#exec_path('systemd-lsp')]+lsp_settings#get('systemd-lsp', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('systemd-lsp', 'root_uri', lsp_settings#root_uri('systemd-lsp'))},
-      \ 'initialization_options': lsp_settings#get('systemd-lsp', 'initialization_options', {
-      \     'completion': {
-      \         'autoimport': { 'enable': v:true },
-      \     },
-      \ }),
-      \ 'allowlist': lsp_settings#get('systemd-lsp', 'allowlist', ['systemd']),
-      \ 'blocklist': lsp_settings#get('systemd-lsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('systemd-lsp', 'config', lsp_settings#server_config('systemd-lsp')),
-      \ 'workspace_config': lsp_settings#get('systemd-lsp', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('systemd-lsp', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'systemd-lsp',
+    \ 'cmd': {server_info->lsp_settings#get('systemd-lsp', 'cmd', [lsp_settings#exec_path('systemd-lsp')]+lsp_settings#get('systemd-lsp', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('systemd-lsp', 'root_uri', lsp_settings#root_uri('systemd-lsp'))},
+    \ 'initialization_options': lsp_settings#get('systemd-lsp', 'initialization_options', {
+    \     'completion': {
+    \         'autoimport': { 'enable': v:true },
+    \     },
+    \ }),
+    \ 'allowlist': lsp_settings#get('systemd-lsp', 'allowlist', ['systemd']),
+    \ 'blocklist': lsp_settings#get('systemd-lsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('systemd-lsp', 'config', lsp_settings#server_config('systemd-lsp')),
+    \ 'workspace_config': lsp_settings#get('systemd-lsp', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('systemd-lsp', 'semantic_highlight', {}),
+    \ })

--- a/settings/systemd-lsp.vim
+++ b/settings/systemd-lsp.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_system_lsp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'systemd-lsp',
       \ 'cmd': {server_info->lsp_settings#get('systemd-lsp', 'cmd', [lsp_settings#exec_path('systemd-lsp')]+lsp_settings#get('systemd-lsp', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('systemd-lsp', 'root_uri', lsp_settings#root_uri('systemd-lsp'))},
@@ -14,5 +14,5 @@ augroup vim_lsp_settings_system_lsp
       \ 'config': lsp_settings#get('systemd-lsp', 'config', lsp_settings#server_config('systemd-lsp')),
       \ 'workspace_config': lsp_settings#get('systemd-lsp', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('systemd-lsp', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/tailwindcss-intellisense.vim
+++ b/settings/tailwindcss-intellisense.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_tailwindcss-intellisense
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'tailwindcss-intellisense',
       \ 'cmd': {server_info->lsp_settings#get('tailwindcss-intellisense', 'cmd', [lsp_settings#exec_path('tailwindcss-intellisense')]+lsp_settings#get('tailwindcss-intellisense', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('tailwindcss-intellisense', 'root_uri', lsp_settings#root_uri('tailwindcss-intellisense'))},
@@ -11,5 +11,5 @@ augroup vim_lsp_settings_tailwindcss-intellisense
       \ 'workspace_config': lsp_settings#get('tailwindcss-intellisense', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('tailwindcss-intellisense', 'semantic_highlight', {}),
       \ 'languageId': {server_info->lsp_settings#get('tailwindcss-intellisense', 'languageId', {x->&filetype})},
-      \ }
+      \ })
 augroup END

--- a/settings/tailwindcss-intellisense.vim
+++ b/settings/tailwindcss-intellisense.vim
@@ -1,15 +1,12 @@
-augroup vim_lsp_settings_tailwindcss-intellisense
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'tailwindcss-intellisense',
-      \ 'cmd': {server_info->lsp_settings#get('tailwindcss-intellisense', 'cmd', [lsp_settings#exec_path('tailwindcss-intellisense')]+lsp_settings#get('tailwindcss-intellisense', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('tailwindcss-intellisense', 'root_uri', lsp_settings#root_uri('tailwindcss-intellisense'))},
-      \ 'initialization_options': lsp_settings#get('tailwindcss-intellisense', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('tailwindcss-intellisense', 'allowlist', {x-> empty(lsp_settings#root_path(['tailwind.config.js'])) ? [] : ['html', 'css', 'svelte']}),
-      \ 'blocklist': lsp_settings#get('tailwindcss-intellisense', 'blocklist', []),
-      \ 'config': lsp_settings#get('tailwindcss-intellisense', 'config', lsp_settings#server_config('tailwindcss-intellisense')),
-      \ 'workspace_config': lsp_settings#get('tailwindcss-intellisense', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('tailwindcss-intellisense', 'semantic_highlight', {}),
-      \ 'languageId': {server_info->lsp_settings#get('tailwindcss-intellisense', 'languageId', {x->&filetype})},
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'tailwindcss-intellisense',
+    \ 'cmd': {server_info->lsp_settings#get('tailwindcss-intellisense', 'cmd', [lsp_settings#exec_path('tailwindcss-intellisense')]+lsp_settings#get('tailwindcss-intellisense', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('tailwindcss-intellisense', 'root_uri', lsp_settings#root_uri('tailwindcss-intellisense'))},
+    \ 'initialization_options': lsp_settings#get('tailwindcss-intellisense', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('tailwindcss-intellisense', 'allowlist', {x-> empty(lsp_settings#root_path(['tailwind.config.js'])) ? [] : ['html', 'css', 'svelte']}),
+    \ 'blocklist': lsp_settings#get('tailwindcss-intellisense', 'blocklist', []),
+    \ 'config': lsp_settings#get('tailwindcss-intellisense', 'config', lsp_settings#server_config('tailwindcss-intellisense')),
+    \ 'workspace_config': lsp_settings#get('tailwindcss-intellisense', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('tailwindcss-intellisense', 'semantic_highlight', {}),
+    \ 'languageId': {server_info->lsp_settings#get('tailwindcss-intellisense', 'languageId', {x->&filetype})},
+    \ })

--- a/settings/taplo-lsp.vim
+++ b/settings/taplo-lsp.vim
@@ -37,19 +37,20 @@ let g:vim_lsp_settings_taplo_lsp_options = {
 \   'debug': v:false
 \ }
 
+call lsp_settings#register_server({
+    \ 'name': 'taplo-lsp',
+    \ 'cmd': {server_info->lsp_settings#get('taplo-lsp', 'cmd', [lsp_settings#exec_path('taplo-lsp')]+lsp_settings#get('taplo-lsp', 'args', ['lsp','stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('taplo-lsp', 'root_uri', lsp_settings#root_uri('taplo-lsp'))},
+    \ 'initialization_options': lsp_settings#get('taplo-lsp', 'initialization_options', g:vim_lsp_settings_taplo_lsp_options),
+    \ 'allowlist': lsp_settings#get('taplo-lsp', 'allowlist', ['toml']),
+    \ 'blocklist': lsp_settings#get('taplo-lsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('taplo-lsp', 'config', lsp_settings#server_config('taplo-lsp')),
+    \ 'workspace_config': lsp_settings#get('taplo-lsp', 'workspace_config', {'evenBetterToml': g:vim_lsp_settings_taplo_lsp_options}),
+    \ 'semantic_highlight': lsp_settings#get('taplo-lsp', 'semantic_highlight', {}),
+    \ })
+
 augroup vim_lsp_settings_taplo_lsp
   au!
-  call lsp_settings#register_server({
-      \ 'name': 'taplo-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('taplo-lsp', 'cmd', [lsp_settings#exec_path('taplo-lsp')]+lsp_settings#get('taplo-lsp', 'args', ['lsp','stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('taplo-lsp', 'root_uri', lsp_settings#root_uri('taplo-lsp'))},
-      \ 'initialization_options': lsp_settings#get('taplo-lsp', 'initialization_options', g:vim_lsp_settings_taplo_lsp_options),
-      \ 'allowlist': lsp_settings#get('taplo-lsp', 'allowlist', ['toml']),
-      \ 'blocklist': lsp_settings#get('taplo-lsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('taplo-lsp', 'config', lsp_settings#server_config('taplo-lsp')),
-      \ 'workspace_config': lsp_settings#get('taplo-lsp', 'workspace_config', {'evenBetterToml': g:vim_lsp_settings_taplo_lsp_options}),
-      \ 'semantic_highlight': lsp_settings#get('taplo-lsp', 'semantic_highlight', {}),
-      \ })
   autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled()
 augroup END
 

--- a/settings/taplo-lsp.vim
+++ b/settings/taplo-lsp.vim
@@ -39,7 +39,7 @@ let g:vim_lsp_settings_taplo_lsp_options = {
 
 augroup vim_lsp_settings_taplo_lsp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'taplo-lsp',
       \ 'cmd': {server_info->lsp_settings#get('taplo-lsp', 'cmd', [lsp_settings#exec_path('taplo-lsp')]+lsp_settings#get('taplo-lsp', 'args', ['lsp','stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('taplo-lsp', 'root_uri', lsp_settings#root_uri('taplo-lsp'))},
@@ -49,7 +49,7 @@ augroup vim_lsp_settings_taplo_lsp
       \ 'config': lsp_settings#get('taplo-lsp', 'config', lsp_settings#server_config('taplo-lsp')),
       \ 'workspace_config': lsp_settings#get('taplo-lsp', 'workspace_config', {'evenBetterToml': g:vim_lsp_settings_taplo_lsp_options}),
       \ 'semantic_highlight': lsp_settings#get('taplo-lsp', 'semantic_highlight', {}),
-      \ }
+      \ })
   autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled()
 augroup END
 

--- a/settings/terraform-ls.vim
+++ b/settings/terraform-ls.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_terraform_ls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'terraform-ls',
       \ 'cmd': {server_info->lsp_settings#get('terraform-ls', 'cmd', [lsp_settings#exec_path('terraform-ls')]+lsp_settings#get('terraform-ls', 'args', ['serve']))},
       \ 'root_uri':{server_info->lsp_settings#get('terraform-ls', 'root_uri', lsp_settings#root_uri('terraform-ls'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_terraform_ls
       \ 'config': lsp_settings#get('terraform-ls', 'config', lsp_settings#server_config('terraform-ls')),
       \ 'workspace_config': lsp_settings#get('terraform-ls', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('terraform-ls', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/terraform-ls.vim
+++ b/settings/terraform-ls.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_terraform_ls
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'terraform-ls',
-      \ 'cmd': {server_info->lsp_settings#get('terraform-ls', 'cmd', [lsp_settings#exec_path('terraform-ls')]+lsp_settings#get('terraform-ls', 'args', ['serve']))},
-      \ 'root_uri':{server_info->lsp_settings#get('terraform-ls', 'root_uri', lsp_settings#root_uri('terraform-ls'))},
-      \ 'initialization_options': lsp_settings#get('terraform-ls', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('terraform-ls', 'allowlist', ['terraform']),
-      \ 'blocklist': lsp_settings#get('terraform-ls', 'blocklist', []),
-      \ 'config': lsp_settings#get('terraform-ls', 'config', lsp_settings#server_config('terraform-ls')),
-      \ 'workspace_config': lsp_settings#get('terraform-ls', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('terraform-ls', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'terraform-ls',
+    \ 'cmd': {server_info->lsp_settings#get('terraform-ls', 'cmd', [lsp_settings#exec_path('terraform-ls')]+lsp_settings#get('terraform-ls', 'args', ['serve']))},
+    \ 'root_uri':{server_info->lsp_settings#get('terraform-ls', 'root_uri', lsp_settings#root_uri('terraform-ls'))},
+    \ 'initialization_options': lsp_settings#get('terraform-ls', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('terraform-ls', 'allowlist', ['terraform']),
+    \ 'blocklist': lsp_settings#get('terraform-ls', 'blocklist', []),
+    \ 'config': lsp_settings#get('terraform-ls', 'config', lsp_settings#server_config('terraform-ls')),
+    \ 'workspace_config': lsp_settings#get('terraform-ls', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('terraform-ls', 'semantic_highlight', {}),
+    \ })

--- a/settings/terraform-lsp.vim
+++ b/settings/terraform-lsp.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_terraform_lsp
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'terraform-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('terraform-lsp', 'cmd', [lsp_settings#exec_path('terraform-lsp')]+lsp_settings#get('terraform-lsp', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('terraform-lsp', 'root_uri', lsp_settings#root_uri('terraform-lsp'))},
-      \ 'initialization_options': lsp_settings#get('terraform-lsp', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('terraform-lsp', 'allowlist', ['terraform']),
-      \ 'blocklist': lsp_settings#get('terraform-lsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('terraform-lsp', 'config', lsp_settings#server_config('terraform-lsp')),
-      \ 'workspace_config': lsp_settings#get('terraform-lsp', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('terraform-lsp', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'terraform-lsp',
+    \ 'cmd': {server_info->lsp_settings#get('terraform-lsp', 'cmd', [lsp_settings#exec_path('terraform-lsp')]+lsp_settings#get('terraform-lsp', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('terraform-lsp', 'root_uri', lsp_settings#root_uri('terraform-lsp'))},
+    \ 'initialization_options': lsp_settings#get('terraform-lsp', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('terraform-lsp', 'allowlist', ['terraform']),
+    \ 'blocklist': lsp_settings#get('terraform-lsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('terraform-lsp', 'config', lsp_settings#server_config('terraform-lsp')),
+    \ 'workspace_config': lsp_settings#get('terraform-lsp', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('terraform-lsp', 'semantic_highlight', {}),
+    \ })

--- a/settings/terraform-lsp.vim
+++ b/settings/terraform-lsp.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_terraform_lsp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'terraform-lsp',
       \ 'cmd': {server_info->lsp_settings#get('terraform-lsp', 'cmd', [lsp_settings#exec_path('terraform-lsp')]+lsp_settings#get('terraform-lsp', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('terraform-lsp', 'root_uri', lsp_settings#root_uri('terraform-lsp'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_terraform_lsp
       \ 'config': lsp_settings#get('terraform-lsp', 'config', lsp_settings#server_config('terraform-lsp')),
       \ 'workspace_config': lsp_settings#get('terraform-lsp', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('terraform-lsp', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/texlab.vim
+++ b/settings/texlab.vim
@@ -1,24 +1,21 @@
-augroup vim_lsp_settings_texlab
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'texlab',
-      \ 'cmd': {server_info->lsp_settings#get('texlab', 'cmd', [lsp_settings#exec_path('texlab')]+lsp_settings#get('texlab', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('texlab', 'root_uri', lsp_settings#root_uri('texlab'))},
-      \ 'initialization_options': lsp_settings#get('texlab', 'initialization_options', {'diagnostics': 'true'}),
-      \ 'allowlist': lsp_settings#get('texlab', 'allowlist', ['plaintex', 'tex']),
-      \ 'blocklist': lsp_settings#get('texlab', 'blocklist', []),
-      \ 'config': lsp_settings#get('texlab', 'config', lsp_settings#server_config('texlab')),
-      \ 'workspace_config': lsp_settings#get('texlab', 'workspace_config', {
-      \   'texlab': {
-      \     'build': {
-      \       'executable': 'latexmk',
-      \       'args': []
-      \     }
-      \   }
-      \ }),
-      \ 'semantic_highlight': lsp_settings#get('texlab', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'texlab',
+    \ 'cmd': {server_info->lsp_settings#get('texlab', 'cmd', [lsp_settings#exec_path('texlab')]+lsp_settings#get('texlab', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('texlab', 'root_uri', lsp_settings#root_uri('texlab'))},
+    \ 'initialization_options': lsp_settings#get('texlab', 'initialization_options', {'diagnostics': 'true'}),
+    \ 'allowlist': lsp_settings#get('texlab', 'allowlist', ['plaintex', 'tex']),
+    \ 'blocklist': lsp_settings#get('texlab', 'blocklist', []),
+    \ 'config': lsp_settings#get('texlab', 'config', lsp_settings#server_config('texlab')),
+    \ 'workspace_config': lsp_settings#get('texlab', 'workspace_config', {
+    \   'texlab': {
+    \     'build': {
+    \       'executable': 'latexmk',
+    \       'args': []
+    \     }
+    \   }
+    \ }),
+    \ 'semantic_highlight': lsp_settings#get('texlab', 'semantic_highlight', {}),
+    \ })
 
 let s:build_status_success = 0
 let s:build_status_error = 1

--- a/settings/texlab.vim
+++ b/settings/texlab.vim
@@ -151,7 +151,7 @@ function! s:on_lsp_buffer_enabled() abort
   nnoremap <buffer> <plug>(lsp-document-forwardsearch) :<c-u>call <SID>document_forwardsearch()<cr>
 endfunction
 
-augroup lsp_install_texlab
+augroup vim_lsp_settings_texlab
   au!
   autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled()
 augroup END

--- a/settings/texlab.vim
+++ b/settings/texlab.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_texlab
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'texlab',
       \ 'cmd': {server_info->lsp_settings#get('texlab', 'cmd', [lsp_settings#exec_path('texlab')]+lsp_settings#get('texlab', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('texlab', 'root_uri', lsp_settings#root_uri('texlab'))},
@@ -17,7 +17,7 @@ augroup vim_lsp_settings_texlab
       \   }
       \ }),
       \ 'semantic_highlight': lsp_settings#get('texlab', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END
 
 let s:build_status_success = 0

--- a/settings/tinymist.vim
+++ b/settings/tinymist.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_tinymist
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'tinymist',
       \ 'cmd': {server_info->lsp_settings#get('tinymist', 'cmd', [lsp_settings#exec_path('tinymist')]+lsp_settings#get('tinymist', 'args', ['lsp']))},
       \ 'root_uri':{server_info->lsp_settings#get('tinymist', 'root_uri', lsp_settings#root_uri('tinymist'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_tinymist
       \ 'config': lsp_settings#get('tinymist', 'config', lsp_settings#server_config('tinymist')),
       \ 'workspace_config': lsp_settings#get('tinymist', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('tinymist', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/tinymist.vim
+++ b/settings/tinymist.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_tinymist
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'tinymist',
-      \ 'cmd': {server_info->lsp_settings#get('tinymist', 'cmd', [lsp_settings#exec_path('tinymist')]+lsp_settings#get('tinymist', 'args', ['lsp']))},
-      \ 'root_uri':{server_info->lsp_settings#get('tinymist', 'root_uri', lsp_settings#root_uri('tinymist'))},
-      \ 'initialization_options': lsp_settings#get('tinymist', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('tinymist', 'allowlist', ['typst', 'typ']),
-      \ 'blocklist': lsp_settings#get('tinymist', 'blocklist', []),
-      \ 'config': lsp_settings#get('tinymist', 'config', lsp_settings#server_config('tinymist')),
-      \ 'workspace_config': lsp_settings#get('tinymist', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('tinymist', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'tinymist',
+    \ 'cmd': {server_info->lsp_settings#get('tinymist', 'cmd', [lsp_settings#exec_path('tinymist')]+lsp_settings#get('tinymist', 'args', ['lsp']))},
+    \ 'root_uri':{server_info->lsp_settings#get('tinymist', 'root_uri', lsp_settings#root_uri('tinymist'))},
+    \ 'initialization_options': lsp_settings#get('tinymist', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('tinymist', 'allowlist', ['typst', 'typ']),
+    \ 'blocklist': lsp_settings#get('tinymist', 'blocklist', []),
+    \ 'config': lsp_settings#get('tinymist', 'config', lsp_settings#server_config('tinymist')),
+    \ 'workspace_config': lsp_settings#get('tinymist', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('tinymist', 'semantic_highlight', {}),
+    \ })

--- a/settings/tsp-server.vim
+++ b/settings/tsp-server.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_tsp_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'tsp-server',
-      \ 'cmd': {server_info->lsp_settings#get('tsp-server', 'cmd', [lsp_settings#exec_path('tsp-server')]+lsp_settings#get('tsp-server', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('tsp-server', 'root_uri', lsp_settings#root_uri('tsp-server'))},
-      \ 'initialization_options': lsp_settings#get('tsp-server', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('tsp-server', 'allowlist', ['typespec']),
-      \ 'blocklist': lsp_settings#get('tsp-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('tsp-server', 'config', {}),
-      \ 'workspace_config': lsp_settings#get('tsp-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('tsp-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'tsp-server',
+    \ 'cmd': {server_info->lsp_settings#get('tsp-server', 'cmd', [lsp_settings#exec_path('tsp-server')]+lsp_settings#get('tsp-server', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('tsp-server', 'root_uri', lsp_settings#root_uri('tsp-server'))},
+    \ 'initialization_options': lsp_settings#get('tsp-server', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('tsp-server', 'allowlist', ['typespec']),
+    \ 'blocklist': lsp_settings#get('tsp-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('tsp-server', 'config', {}),
+    \ 'workspace_config': lsp_settings#get('tsp-server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('tsp-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/tsp-server.vim
+++ b/settings/tsp-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_tsp_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'tsp-server',
       \ 'cmd': {server_info->lsp_settings#get('tsp-server', 'cmd', [lsp_settings#exec_path('tsp-server')]+lsp_settings#get('tsp-server', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('tsp-server', 'root_uri', lsp_settings#root_uri('tsp-server'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_tsp_server
       \ 'config': lsp_settings#get('tsp-server', 'config', {}),
       \ 'workspace_config': lsp_settings#get('tsp-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('tsp-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/ty.vim
+++ b/settings/ty.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_ty
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'ty',
       \ 'cmd': {server_info->lsp_settings#get('ty', 'cmd', [lsp_settings#exec_path('ty')]+lsp_settings#get('ty', 'args', ['server']))},
       \ 'root_uri':{server_info->lsp_settings#get('ty', 'root_uri', lsp_settings#root_uri('ty'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_ty
       \ 'config': lsp_settings#get('ty', 'config', lsp_settings#server_config('ty')),
       \ 'workspace_config': lsp_settings#get('ty', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('ty', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/ty.vim
+++ b/settings/ty.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_ty
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'ty',
-      \ 'cmd': {server_info->lsp_settings#get('ty', 'cmd', [lsp_settings#exec_path('ty')]+lsp_settings#get('ty', 'args', ['server']))},
-      \ 'root_uri':{server_info->lsp_settings#get('ty', 'root_uri', lsp_settings#root_uri('ty'))},
-      \ 'initialization_options': lsp_settings#get('ty', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('ty', 'allowlist', ['python']),
-      \ 'blocklist': lsp_settings#get('ty', 'blocklist', []),
-      \ 'config': lsp_settings#get('ty', 'config', lsp_settings#server_config('ty')),
-      \ 'workspace_config': lsp_settings#get('ty', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('ty', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'ty',
+    \ 'cmd': {server_info->lsp_settings#get('ty', 'cmd', [lsp_settings#exec_path('ty')]+lsp_settings#get('ty', 'args', ['server']))},
+    \ 'root_uri':{server_info->lsp_settings#get('ty', 'root_uri', lsp_settings#root_uri('ty'))},
+    \ 'initialization_options': lsp_settings#get('ty', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('ty', 'allowlist', ['python']),
+    \ 'blocklist': lsp_settings#get('ty', 'blocklist', []),
+    \ 'config': lsp_settings#get('ty', 'config', lsp_settings#server_config('ty')),
+    \ 'workspace_config': lsp_settings#get('ty', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('ty', 'semantic_highlight', {}),
+    \ })

--- a/settings/typeprof.vim
+++ b/settings/typeprof.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_typeprof
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'typeprof',
       \ 'cmd': {server_info->lsp_settings#get('typeprof', 'cmd', [lsp_settings#exec_path('typeprof')]+lsp_settings#get('typeprof', 'args', ['--lsp', '--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('typeprof', 'root_uri', lsp_settings#root_uri('typeprof'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_typeprof
       \ 'config': lsp_settings#get('typeprof', 'config', lsp_settings#server_config('typeprof')),
       \ 'workspace_config': lsp_settings#get('typeprof', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('typeprof', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/typeprof.vim
+++ b/settings/typeprof.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_typeprof
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'typeprof',
-      \ 'cmd': {server_info->lsp_settings#get('typeprof', 'cmd', [lsp_settings#exec_path('typeprof')]+lsp_settings#get('typeprof', 'args', ['--lsp', '--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('typeprof', 'root_uri', lsp_settings#root_uri('typeprof'))},
-      \ 'initialization_options': lsp_settings#get('typeprof', 'initialization_options', {'diagnostics': 'true'}),
-      \ 'allowlist': lsp_settings#get('typeprof', 'allowlist', ['ruby']),
-      \ 'blocklist': lsp_settings#get('typeprof', 'blocklist', []),
-      \ 'config': lsp_settings#get('typeprof', 'config', lsp_settings#server_config('typeprof')),
-      \ 'workspace_config': lsp_settings#get('typeprof', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('typeprof', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'typeprof',
+    \ 'cmd': {server_info->lsp_settings#get('typeprof', 'cmd', [lsp_settings#exec_path('typeprof')]+lsp_settings#get('typeprof', 'args', ['--lsp', '--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('typeprof', 'root_uri', lsp_settings#root_uri('typeprof'))},
+    \ 'initialization_options': lsp_settings#get('typeprof', 'initialization_options', {'diagnostics': 'true'}),
+    \ 'allowlist': lsp_settings#get('typeprof', 'allowlist', ['ruby']),
+    \ 'blocklist': lsp_settings#get('typeprof', 'blocklist', []),
+    \ 'config': lsp_settings#get('typeprof', 'config', lsp_settings#server_config('typeprof')),
+    \ 'workspace_config': lsp_settings#get('typeprof', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('typeprof', 'semantic_highlight', {}),
+    \ })

--- a/settings/typescript-language-server.vim
+++ b/settings/typescript-language-server.vim
@@ -9,27 +9,24 @@ function! s:get_blocklist() abort
     return []
 endfunction
 
-augroup vim_lsp_settings_typescript_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'typescript-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('typescript-language-server', 'cmd', [lsp_settings#exec_path('typescript-language-server')]+lsp_settings#get('typescript-language-server', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('typescript-language-server', 'root_uri', lsp_settings#root_uri('typescript-language-server'))},
-      \ 'initialization_options': lsp_settings#get('typescript-language-server', 'initialization_options', {
-      \   'preferences': {
-      \     'includeInlayParameterNameHintsWhenArgumentMatchesName': v:true,
-      \     'includeInlayParameterNameHints': 'all',
-      \     'includeInlayVariableTypeHints': v:true,
-      \     'includeInlayPropertyDeclarationTypeHints': v:true,
-      \     'includeInlayFunctionParameterTypeHints': v:true,
-      \     'includeInlayEnumMemberValueHints': v:true,
-      \     'includeInlayFunctionLikeReturnTypeHints': v:true
-      \   },
-      \ }),
-      \ 'allowlist': lsp_settings#get('typescript-language-server', 'allowlist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact', 'typescript.tsx']),
-      \ 'blocklist': lsp_settings#get('typescript-language-server', 'blocklist', s:get_blocklist()),
-      \ 'config': lsp_settings#get('typescript-language-server', 'config', lsp_settings#server_config('typescript-language-server')),
-      \ 'workspace_config': lsp_settings#get('typescript-language-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('typescript-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'typescript-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('typescript-language-server', 'cmd', [lsp_settings#exec_path('typescript-language-server')]+lsp_settings#get('typescript-language-server', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('typescript-language-server', 'root_uri', lsp_settings#root_uri('typescript-language-server'))},
+    \ 'initialization_options': lsp_settings#get('typescript-language-server', 'initialization_options', {
+    \   'preferences': {
+    \     'includeInlayParameterNameHintsWhenArgumentMatchesName': v:true,
+    \     'includeInlayParameterNameHints': 'all',
+    \     'includeInlayVariableTypeHints': v:true,
+    \     'includeInlayPropertyDeclarationTypeHints': v:true,
+    \     'includeInlayFunctionParameterTypeHints': v:true,
+    \     'includeInlayEnumMemberValueHints': v:true,
+    \     'includeInlayFunctionLikeReturnTypeHints': v:true
+    \   },
+    \ }),
+    \ 'allowlist': lsp_settings#get('typescript-language-server', 'allowlist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact', 'typescript.tsx']),
+    \ 'blocklist': lsp_settings#get('typescript-language-server', 'blocklist', s:get_blocklist()),
+    \ 'config': lsp_settings#get('typescript-language-server', 'config', lsp_settings#server_config('typescript-language-server')),
+    \ 'workspace_config': lsp_settings#get('typescript-language-server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('typescript-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/typescript-language-server.vim
+++ b/settings/typescript-language-server.vim
@@ -1,4 +1,4 @@
-function! Vim_lsp_settings_typescript_language_server_get_blocklist() abort
+function! s:get_blocklist() abort
     if empty(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), 'node_modules/'))
         return ['typescript', 'javascript', 'typescriptreact', 'javascriptreact']
     endif
@@ -11,7 +11,7 @@ endfunction
 
 augroup vim_lsp_settings_typescript_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'typescript-language-server',
       \ 'cmd': {server_info->lsp_settings#get('typescript-language-server', 'cmd', [lsp_settings#exec_path('typescript-language-server')]+lsp_settings#get('typescript-language-server', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('typescript-language-server', 'root_uri', lsp_settings#root_uri('typescript-language-server'))},
@@ -27,9 +27,9 @@ augroup vim_lsp_settings_typescript_language_server
       \   },
       \ }),
       \ 'allowlist': lsp_settings#get('typescript-language-server', 'allowlist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact', 'typescript.tsx']),
-      \ 'blocklist': lsp_settings#get('typescript-language-server', 'blocklist', Vim_lsp_settings_typescript_language_server_get_blocklist()),
+      \ 'blocklist': lsp_settings#get('typescript-language-server', 'blocklist', s:get_blocklist()),
       \ 'config': lsp_settings#get('typescript-language-server', 'config', lsp_settings#server_config('typescript-language-server')),
       \ 'workspace_config': lsp_settings#get('typescript-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('typescript-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/typos-lsp.vim
+++ b/settings/typos-lsp.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_typos_lsp
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'typos-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('typos-lsp', 'cmd', [lsp_settings#exec_path('typos-lsp')]+lsp_settings#get('typos-lsp', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('typos-lsp', 'root_uri', lsp_settings#root_uri('typos-lsp'))},
-      \ 'initialization_options': lsp_settings#get('typos-lsp', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('typos-lsp', 'allowlist', ['*']),
-      \ 'blocklist': lsp_settings#get('typos-lsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('typos-lsp', 'config', lsp_settings#server_config('typos-lsp')),
-      \ 'workspace_config': lsp_settings#get('typos-lsp', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('typos-lsp', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'typos-lsp',
+    \ 'cmd': {server_info->lsp_settings#get('typos-lsp', 'cmd', [lsp_settings#exec_path('typos-lsp')]+lsp_settings#get('typos-lsp', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('typos-lsp', 'root_uri', lsp_settings#root_uri('typos-lsp'))},
+    \ 'initialization_options': lsp_settings#get('typos-lsp', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('typos-lsp', 'allowlist', ['*']),
+    \ 'blocklist': lsp_settings#get('typos-lsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('typos-lsp', 'config', lsp_settings#server_config('typos-lsp')),
+    \ 'workspace_config': lsp_settings#get('typos-lsp', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('typos-lsp', 'semantic_highlight', {}),
+    \ })

--- a/settings/typos-lsp.vim
+++ b/settings/typos-lsp.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_typos_lsp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'typos-lsp',
       \ 'cmd': {server_info->lsp_settings#get('typos-lsp', 'cmd', [lsp_settings#exec_path('typos-lsp')]+lsp_settings#get('typos-lsp', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('typos-lsp', 'root_uri', lsp_settings#root_uri('typos-lsp'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_typos_lsp
       \ 'config': lsp_settings#get('typos-lsp', 'config', lsp_settings#server_config('typos-lsp')),
       \ 'workspace_config': lsp_settings#get('typos-lsp', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('typos-lsp', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/typst-lsp.vim
+++ b/settings/typst-lsp.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_typst_lsp
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'typst-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('typst-lsp', 'cmd', [lsp_settings#exec_path('typst-lsp')]+lsp_settings#get('typst-lsp', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('typst-lsp', 'root_uri', lsp_settings#root_uri('typst-lsp'))},
-      \ 'initialization_options': lsp_settings#get('typst-lsp', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('typst-lsp', 'allowlist', ['typst', 'typ']),
-      \ 'blocklist': lsp_settings#get('typst-lsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('typst-lsp', 'config', lsp_settings#server_config('typst-lsp')),
-      \ 'workspace_config': lsp_settings#get('typst-lsp', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('typst-lsp', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'typst-lsp',
+    \ 'cmd': {server_info->lsp_settings#get('typst-lsp', 'cmd', [lsp_settings#exec_path('typst-lsp')]+lsp_settings#get('typst-lsp', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('typst-lsp', 'root_uri', lsp_settings#root_uri('typst-lsp'))},
+    \ 'initialization_options': lsp_settings#get('typst-lsp', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('typst-lsp', 'allowlist', ['typst', 'typ']),
+    \ 'blocklist': lsp_settings#get('typst-lsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('typst-lsp', 'config', lsp_settings#server_config('typst-lsp')),
+    \ 'workspace_config': lsp_settings#get('typst-lsp', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('typst-lsp', 'semantic_highlight', {}),
+    \ })

--- a/settings/typst-lsp.vim
+++ b/settings/typst-lsp.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_typst_lsp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'typst-lsp',
       \ 'cmd': {server_info->lsp_settings#get('typst-lsp', 'cmd', [lsp_settings#exec_path('typst-lsp')]+lsp_settings#get('typst-lsp', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('typst-lsp', 'root_uri', lsp_settings#root_uri('typst-lsp'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_typst_lsp
       \ 'config': lsp_settings#get('typst-lsp', 'config', lsp_settings#server_config('typst-lsp')),
       \ 'workspace_config': lsp_settings#get('typst-lsp', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('typst-lsp', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/v-analyzer.vim
+++ b/settings/v-analyzer.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_vlang_vls
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'v-analyzer',
-      \ 'cmd': {server_info->lsp_settings#get('v-analyzer', 'cmd', [lsp_settings#exec_path('v-analyzer')]+lsp_settings#get('v-analyzer', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('v-analyzer', 'root_uri', lsp_settings#root_uri('v-analyzer'))},
-      \ 'initialization_options': lsp_settings#get('v-analyzer', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('v-analyzer', 'allowlist', ['vlang']),
-      \ 'blocklist': lsp_settings#get('v-analyzer', 'blocklist', []),
-      \ 'config': lsp_settings#get('v-analyzer', 'config', lsp_settings#server_config('v-analyzer')),
-      \ 'workspace_config': lsp_settings#get('v-analyzer', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('v-analyzer', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'v-analyzer',
+    \ 'cmd': {server_info->lsp_settings#get('v-analyzer', 'cmd', [lsp_settings#exec_path('v-analyzer')]+lsp_settings#get('v-analyzer', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('v-analyzer', 'root_uri', lsp_settings#root_uri('v-analyzer'))},
+    \ 'initialization_options': lsp_settings#get('v-analyzer', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('v-analyzer', 'allowlist', ['vlang']),
+    \ 'blocklist': lsp_settings#get('v-analyzer', 'blocklist', []),
+    \ 'config': lsp_settings#get('v-analyzer', 'config', lsp_settings#server_config('v-analyzer')),
+    \ 'workspace_config': lsp_settings#get('v-analyzer', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('v-analyzer', 'semantic_highlight', {}),
+    \ })

--- a/settings/v-analyzer.vim
+++ b/settings/v-analyzer.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_vlang_vls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'v-analyzer',
       \ 'cmd': {server_info->lsp_settings#get('v-analyzer', 'cmd', [lsp_settings#exec_path('v-analyzer')]+lsp_settings#get('v-analyzer', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('v-analyzer', 'root_uri', lsp_settings#root_uri('v-analyzer'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_vlang_vls
       \ 'config': lsp_settings#get('v-analyzer', 'config', lsp_settings#server_config('v-analyzer')),
       \ 'workspace_config': lsp_settings#get('v-analyzer', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('v-analyzer', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/vala-language-server.vim
+++ b/settings/vala-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_vala_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'vala-language-server',
       \ 'cmd': {server_info->lsp_settings#get('vala-language-server', 'cmd', [lsp_settings#exec_path('vala-language-server')]+lsp_settings#get('vala-language-server', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('vala-language-server', 'root_uri', lsp_settings#root_uri('vala-language-server'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_vala_language_server
       \ 'config': lsp_settings#get('vala-language-server', 'config', lsp_settings#server_config('vala-language-server')),
       \ 'workspace_config': lsp_settings#get('vala-language-server', 'workspace_config', {name, key->{'json': {'format': {'enable': v:true}, 'schemas': lsp_settings#utils#load_schemas('vala-language-server')}}}),
       \ 'semantic_highlight': lsp_settings#get('vala-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/vala-language-server.vim
+++ b/settings/vala-language-server.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_vala_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'vala-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('vala-language-server', 'cmd', [lsp_settings#exec_path('vala-language-server')]+lsp_settings#get('vala-language-server', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('vala-language-server', 'root_uri', lsp_settings#root_uri('vala-language-server'))},
-      \ 'initialization_options': lsp_settings#get('vala-language-server', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('vala-language-server', 'allowlist', ['vala']),
-      \ 'blocklist': lsp_settings#get('vala-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('vala-language-server', 'config', lsp_settings#server_config('vala-language-server')),
-      \ 'workspace_config': lsp_settings#get('vala-language-server', 'workspace_config', {name, key->{'json': {'format': {'enable': v:true}, 'schemas': lsp_settings#utils#load_schemas('vala-language-server')}}}),
-      \ 'semantic_highlight': lsp_settings#get('vala-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'vala-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('vala-language-server', 'cmd', [lsp_settings#exec_path('vala-language-server')]+lsp_settings#get('vala-language-server', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('vala-language-server', 'root_uri', lsp_settings#root_uri('vala-language-server'))},
+    \ 'initialization_options': lsp_settings#get('vala-language-server', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('vala-language-server', 'allowlist', ['vala']),
+    \ 'blocklist': lsp_settings#get('vala-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('vala-language-server', 'config', lsp_settings#server_config('vala-language-server')),
+    \ 'workspace_config': lsp_settings#get('vala-language-server', 'workspace_config', {name, key->{'json': {'format': {'enable': v:true}, 'schemas': lsp_settings#utils#load_schemas('vala-language-server')}}}),
+    \ 'semantic_highlight': lsp_settings#get('vala-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/verible-verilog-ls.vim
+++ b/settings/verible-verilog-ls.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_verible_verilog_ls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'verible-verilog-ls',
       \ 'cmd': {server_info->lsp_settings#get('verible-verilog-ls', 'cmd', [lsp_settings#exec_path('verible-verilog-ls')]+lsp_settings#get('verible-verilog-ls', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('verible-verilog-ls', 'root_uri', lsp_settings#root_uri('verible-verilog-ls'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_verible_verilog_ls
       \ 'config': lsp_settings#get('verible-verilog-ls', 'config', lsp_settings#server_config('verible-verilog-ls')),
       \ 'workspace_config': lsp_settings#get('verible-verilog-ls', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('verible-verilog-ls', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/verible-verilog-ls.vim
+++ b/settings/verible-verilog-ls.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_verible_verilog_ls
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'verible-verilog-ls',
-      \ 'cmd': {server_info->lsp_settings#get('verible-verilog-ls', 'cmd', [lsp_settings#exec_path('verible-verilog-ls')]+lsp_settings#get('verible-verilog-ls', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('verible-verilog-ls', 'root_uri', lsp_settings#root_uri('verible-verilog-ls'))},
-      \ 'initialization_options': lsp_settings#get('verible-verilog-ls', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('verible-verilog-ls', 'allowlist', ['verilog', 'systemverilog']),
-      \ 'blocklist': lsp_settings#get('verible-verilog-ls', 'blocklist', []),
-      \ 'config': lsp_settings#get('verible-verilog-ls', 'config', lsp_settings#server_config('verible-verilog-ls')),
-      \ 'workspace_config': lsp_settings#get('verible-verilog-ls', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('verible-verilog-ls', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'verible-verilog-ls',
+    \ 'cmd': {server_info->lsp_settings#get('verible-verilog-ls', 'cmd', [lsp_settings#exec_path('verible-verilog-ls')]+lsp_settings#get('verible-verilog-ls', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('verible-verilog-ls', 'root_uri', lsp_settings#root_uri('verible-verilog-ls'))},
+    \ 'initialization_options': lsp_settings#get('verible-verilog-ls', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('verible-verilog-ls', 'allowlist', ['verilog', 'systemverilog']),
+    \ 'blocklist': lsp_settings#get('verible-verilog-ls', 'blocklist', []),
+    \ 'config': lsp_settings#get('verible-verilog-ls', 'config', lsp_settings#server_config('verible-verilog-ls')),
+    \ 'workspace_config': lsp_settings#get('verible-verilog-ls', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('verible-verilog-ls', 'semantic_highlight', {}),
+    \ })

--- a/settings/veryl-ls.vim
+++ b/settings/veryl-ls.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_veryl_ls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'veryl-ls',
       \ 'cmd': {server_info->lsp_settings#get('veryl-ls', 'cmd', [lsp_settings#exec_path('veryl-ls')]+lsp_settings#get('veryl-ls', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('veryl-ls', 'root_uri', lsp_settings#root_uri('veryl-ls'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_veryl_ls
       \ 'config': lsp_settings#get('veryl-ls', 'config', lsp_settings#server_config('veryl-ls')),
       \ 'workspace_config': lsp_settings#get('veryl-ls', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('veryl-ls', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/veryl-ls.vim
+++ b/settings/veryl-ls.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_veryl_ls
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'veryl-ls',
-      \ 'cmd': {server_info->lsp_settings#get('veryl-ls', 'cmd', [lsp_settings#exec_path('veryl-ls')]+lsp_settings#get('veryl-ls', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('veryl-ls', 'root_uri', lsp_settings#root_uri('veryl-ls'))},
-      \ 'initialization_options': lsp_settings#get('veryl-ls', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('veryl-ls', 'allowlist', ['veryl']),
-      \ 'blocklist': lsp_settings#get('veryl-ls', 'blocklist', []),
-      \ 'config': lsp_settings#get('veryl-ls', 'config', lsp_settings#server_config('veryl-ls')),
-      \ 'workspace_config': lsp_settings#get('veryl-ls', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('veryl-ls', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'veryl-ls',
+    \ 'cmd': {server_info->lsp_settings#get('veryl-ls', 'cmd', [lsp_settings#exec_path('veryl-ls')]+lsp_settings#get('veryl-ls', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('veryl-ls', 'root_uri', lsp_settings#root_uri('veryl-ls'))},
+    \ 'initialization_options': lsp_settings#get('veryl-ls', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('veryl-ls', 'allowlist', ['veryl']),
+    \ 'blocklist': lsp_settings#get('veryl-ls', 'blocklist', []),
+    \ 'config': lsp_settings#get('veryl-ls', 'config', lsp_settings#server_config('veryl-ls')),
+    \ 'workspace_config': lsp_settings#get('veryl-ls', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('veryl-ls', 'semantic_highlight', {}),
+    \ })

--- a/settings/vim-language-server.vim
+++ b/settings/vim-language-server.vim
@@ -1,20 +1,17 @@
-augroup vim_lsp_settings_vim_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'vim-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('vim-language-server', 'cmd', [lsp_settings#exec_path('vim-language-server')]+lsp_settings#get('vim-language-server', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('vim-language-server', 'root_uri', lsp_settings#root_uri('vim-language-server'))},
-      \ 'initialization_options': extend({
-      \   'isNeovim': has('nvim'),
-      \   'vimruntime': $VIMRUNTIME,
-      \   'runtimepath': &rtp,
-      \   'iskeyword': &isk . ',:',
-      \   'diagnostic': {'enable': v:true}
-      \  }, lsp_settings#get('vim-language-server', 'initialization_options', {}), 'force'),
-      \ 'allowlist': lsp_settings#get('vim-language-server', 'allowlist', ['vim']),
-      \ 'blocklist': lsp_settings#get('vimbash-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('vim-language-server', 'config', lsp_settings#server_config('vim-language-server')),
-      \ 'workspace_config': lsp_settings#get('vim-language-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('vim-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'vim-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('vim-language-server', 'cmd', [lsp_settings#exec_path('vim-language-server')]+lsp_settings#get('vim-language-server', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('vim-language-server', 'root_uri', lsp_settings#root_uri('vim-language-server'))},
+    \ 'initialization_options': extend({
+    \   'isNeovim': has('nvim'),
+    \   'vimruntime': $VIMRUNTIME,
+    \   'runtimepath': &rtp,
+    \   'iskeyword': &isk . ',:',
+    \   'diagnostic': {'enable': v:true}
+    \  }, lsp_settings#get('vim-language-server', 'initialization_options', {}), 'force'),
+    \ 'allowlist': lsp_settings#get('vim-language-server', 'allowlist', ['vim']),
+    \ 'blocklist': lsp_settings#get('vimbash-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('vim-language-server', 'config', lsp_settings#server_config('vim-language-server')),
+    \ 'workspace_config': lsp_settings#get('vim-language-server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('vim-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/vim-language-server.vim
+++ b/settings/vim-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_vim_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'vim-language-server',
       \ 'cmd': {server_info->lsp_settings#get('vim-language-server', 'cmd', [lsp_settings#exec_path('vim-language-server')]+lsp_settings#get('vim-language-server', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('vim-language-server', 'root_uri', lsp_settings#root_uri('vim-language-server'))},
@@ -16,5 +16,5 @@ augroup vim_lsp_settings_vim_language_server
       \ 'config': lsp_settings#get('vim-language-server', 'config', lsp_settings#server_config('vim-language-server')),
       \ 'workspace_config': lsp_settings#get('vim-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('vim-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/vlang-vls.vim
+++ b/settings/vlang-vls.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_vlang_vls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'vlang-vls',
       \ 'cmd': {server_info->lsp_settings#get('vlang-vls', 'cmd', [lsp_settings#exec_path('vlang-vls')]+lsp_settings#get('vlang-vls', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('vlang-vls', 'root_uri', lsp_settings#root_uri('vlang-vls'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_vlang_vls
       \ 'config': lsp_settings#get('vlang-vls', 'config', lsp_settings#server_config('vlang-vls')),
       \ 'workspace_config': lsp_settings#get('vlang-vls', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('vlang-vls', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/vlang-vls.vim
+++ b/settings/vlang-vls.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_vlang_vls
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'vlang-vls',
-      \ 'cmd': {server_info->lsp_settings#get('vlang-vls', 'cmd', [lsp_settings#exec_path('vlang-vls')]+lsp_settings#get('vlang-vls', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('vlang-vls', 'root_uri', lsp_settings#root_uri('vlang-vls'))},
-      \ 'initialization_options': lsp_settings#get('vlang-vls', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('vlang-vls', 'allowlist', ['vlang']),
-      \ 'blocklist': lsp_settings#get('vlang-vls', 'blocklist', []),
-      \ 'config': lsp_settings#get('vlang-vls', 'config', lsp_settings#server_config('vlang-vls')),
-      \ 'workspace_config': lsp_settings#get('vlang-vls', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('vlang-vls', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'vlang-vls',
+    \ 'cmd': {server_info->lsp_settings#get('vlang-vls', 'cmd', [lsp_settings#exec_path('vlang-vls')]+lsp_settings#get('vlang-vls', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('vlang-vls', 'root_uri', lsp_settings#root_uri('vlang-vls'))},
+    \ 'initialization_options': lsp_settings#get('vlang-vls', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('vlang-vls', 'allowlist', ['vlang']),
+    \ 'blocklist': lsp_settings#get('vlang-vls', 'blocklist', []),
+    \ 'config': lsp_settings#get('vlang-vls', 'config', lsp_settings#server_config('vlang-vls')),
+    \ 'workspace_config': lsp_settings#get('vlang-vls', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('vlang-vls', 'semantic_highlight', {}),
+    \ })

--- a/settings/vls.vim
+++ b/settings/vls.vim
@@ -42,7 +42,7 @@ augroup vim_lsp_settings_vls
   \ }
 
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
   \ 'name': 'vls',
   \ 'cmd': {server_info->lsp_settings#get('vls', 'cmd', [lsp_settings#exec_path('vls')]+lsp_settings#get('vls', 'args', ['--stdio']))},
   \ 'root_uri':{server_info->lsp_settings#get('vls', 'root_uri', lsp_settings#root_uri('vls'))},
@@ -52,5 +52,5 @@ augroup vim_lsp_settings_vls
   \ 'config': lsp_settings#get('vls', 'config', lsp_settings#server_config('vls')),
   \ 'workspace_config': lsp_settings#get('vls', 'workspace_config', g:vim_lsp_settings_vls_config),
   \ 'semantic_highlight': lsp_settings#get('vls', 'semantic_highlight', {}),
-  \ }
+  \ })
 augroup END

--- a/settings/vls.vim
+++ b/settings/vls.vim
@@ -1,56 +1,53 @@
-augroup vim_lsp_settings_vls
-  let g:vim_lsp_settings_vls_config = {
-  \   'vetur': {
-  \     'useWorkspaceDependencies': v:false,
-  \     'validation': {
-  \       'template': v:true,
-  \       'style': v:true,
-  \       'script': v:true
-  \     },
-  \     'completion': {
-  \       'autoImport': v:true,
-  \       'useScaffoldSnippets': v:true,
-  \       'tagCasing': 'kebab'
-  \     },
-  \     'format': {
-  \       'enable': v:true,
-  \       'options': {},
-  \       'defaultFormatter': {
-  \         'js': '',
-  \         'ts': ''
-  \       },
-  \       'defaultFormatterOptions': {},
-  \       'scriptInitialIndent': v:false,
-  \       'styleInitialIndent': v:false
-  \     },
-  \     'dev': {
-  \       'logLevel': 'DEBUG'
-  \     }
-  \   },
-  \   'css': {},
-  \   'html': {
-  \     'suggest': {}
-  \   },
-  \   'javascript': {
-  \     'format': {}
-  \   },
-  \   'typescript': {
-  \     'format': {}
-  \   },
-  \   'emmet': {},
-  \   'stylusSupremacy': {}
-  \ }
+let g:vim_lsp_settings_vls_config = {
+\   'vetur': {
+\     'useWorkspaceDependencies': v:false,
+\     'validation': {
+\       'template': v:true,
+\       'style': v:true,
+\       'script': v:true
+\     },
+\     'completion': {
+\       'autoImport': v:true,
+\       'useScaffoldSnippets': v:true,
+\       'tagCasing': 'kebab'
+\     },
+\     'format': {
+\       'enable': v:true,
+\       'options': {},
+\       'defaultFormatter': {
+\         'js': '',
+\         'ts': ''
+\       },
+\       'defaultFormatterOptions': {},
+\       'scriptInitialIndent': v:false,
+\       'styleInitialIndent': v:false
+\     },
+\     'dev': {
+\       'logLevel': 'DEBUG'
+\     }
+\   },
+\   'css': {},
+\   'html': {
+\     'suggest': {}
+\   },
+\   'javascript': {
+\     'format': {}
+\   },
+\   'typescript': {
+\     'format': {}
+\   },
+\   'emmet': {},
+\   'stylusSupremacy': {}
+\ }
 
-  au!
-  call lsp_settings#register_server({
-  \ 'name': 'vls',
-  \ 'cmd': {server_info->lsp_settings#get('vls', 'cmd', [lsp_settings#exec_path('vls')]+lsp_settings#get('vls', 'args', ['--stdio']))},
-  \ 'root_uri':{server_info->lsp_settings#get('vls', 'root_uri', lsp_settings#root_uri('vls'))},
-  \ 'initialization_options': lsp_settings#get('vls', 'initialization_options', { 'config': g:vim_lsp_settings_vls_config }),
-  \ 'allowlist': lsp_settings#get('vls', 'allowlist', ['vue']),
-  \ 'blocklist': lsp_settings#get('vls', 'blocklist', []),
-  \ 'config': lsp_settings#get('vls', 'config', lsp_settings#server_config('vls')),
-  \ 'workspace_config': lsp_settings#get('vls', 'workspace_config', g:vim_lsp_settings_vls_config),
-  \ 'semantic_highlight': lsp_settings#get('vls', 'semantic_highlight', {}),
-  \ })
-augroup END
+call lsp_settings#register_server({
+\ 'name': 'vls',
+\ 'cmd': {server_info->lsp_settings#get('vls', 'cmd', [lsp_settings#exec_path('vls')]+lsp_settings#get('vls', 'args', ['--stdio']))},
+\ 'root_uri':{server_info->lsp_settings#get('vls', 'root_uri', lsp_settings#root_uri('vls'))},
+\ 'initialization_options': lsp_settings#get('vls', 'initialization_options', { 'config': g:vim_lsp_settings_vls_config }),
+\ 'allowlist': lsp_settings#get('vls', 'allowlist', ['vue']),
+\ 'blocklist': lsp_settings#get('vls', 'blocklist', []),
+\ 'config': lsp_settings#get('vls', 'config', lsp_settings#server_config('vls')),
+\ 'workspace_config': lsp_settings#get('vls', 'workspace_config', g:vim_lsp_settings_vls_config),
+\ 'semantic_highlight': lsp_settings#get('vls', 'semantic_highlight', {}),
+\ })

--- a/settings/volar-server.vim
+++ b/settings/volar-server.vim
@@ -1,15 +1,12 @@
-augroup vim_lsp_settings_volar_server
-  au!
-  call lsp_settings#register_server({
-  \ 'name': 'volar-server',
-  \ 'cmd': {server_info->lsp_settings#get('volar-server', 'cmd', [lsp_settings#exec_path('volar-server')]+lsp_settings#get('volar-server', 'args', ['--stdio']))},
-  \ 'root_uri':{server_info->lsp_settings#get('volar-server', 'root_uri', lsp_settings#root_uri('volar-server'))},
-  \ 'initialization_options': lsp_settings#get('volar-server', 'initialization_options', v:null),
-  \ 'allowlist': lsp_settings#get('volar-server', 'allowlist', ['vue', 'typescript']),
-  \ 'blocklist': lsp_settings#get('volar-server', 'blocklist', []),
-  \ 'config': lsp_settings#get('volar-server', 'config', lsp_settings#server_config('volar-server')),
-  \ })
-augroup END
+call lsp_settings#register_server({
+\ 'name': 'volar-server',
+\ 'cmd': {server_info->lsp_settings#get('volar-server', 'cmd', [lsp_settings#exec_path('volar-server')]+lsp_settings#get('volar-server', 'args', ['--stdio']))},
+\ 'root_uri':{server_info->lsp_settings#get('volar-server', 'root_uri', lsp_settings#root_uri('volar-server'))},
+\ 'initialization_options': lsp_settings#get('volar-server', 'initialization_options', v:null),
+\ 'allowlist': lsp_settings#get('volar-server', 'allowlist', ['vue', 'typescript']),
+\ 'blocklist': lsp_settings#get('volar-server', 'blocklist', []),
+\ 'config': lsp_settings#get('volar-server', 'config', lsp_settings#server_config('volar-server')),
+\ })
 
 function s:on_tsserver_request(id, data) abort
   let body = a:data['response']['result']['body']

--- a/settings/volar-server.vim
+++ b/settings/volar-server.vim
@@ -70,7 +70,7 @@ function! s:on_lsp_buffer_enabled() abort
   endif
 endfunction
 
-augroup lsp_install_volar_server
+augroup vim_lsp_settings_volar_server
   au!
   autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled()
 augroup END

--- a/settings/volar-server.vim
+++ b/settings/volar-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_volar_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
   \ 'name': 'volar-server',
   \ 'cmd': {server_info->lsp_settings#get('volar-server', 'cmd', [lsp_settings#exec_path('volar-server')]+lsp_settings#get('volar-server', 'args', ['--stdio']))},
   \ 'root_uri':{server_info->lsp_settings#get('volar-server', 'root_uri', lsp_settings#root_uri('volar-server'))},
@@ -8,7 +8,7 @@ augroup vim_lsp_settings_volar_server
   \ 'allowlist': lsp_settings#get('volar-server', 'allowlist', ['vue', 'typescript']),
   \ 'blocklist': lsp_settings#get('volar-server', 'blocklist', []),
   \ 'config': lsp_settings#get('volar-server', 'config', lsp_settings#server_config('volar-server')),
-  \ }
+  \ })
 augroup END
 
 function s:on_tsserver_request(id, data) abort

--- a/settings/vscode-css-language-server.vim
+++ b/settings/vscode-css-language-server.vim
@@ -1,19 +1,16 @@
-augroup vim_lsp_settings_vscode_css_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'vscode-css-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('vscode-css-language-server', 'cmd', [lsp_settings#exec_path('vscode-css-language-server')]+lsp_settings#get('vscode-css-language-server', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('vscode-css-language-server', 'root_uri', lsp_settings#root_uri('vscode-css-language-server'))},
-      \ 'initialization_options': lsp_settings#get('vscode-css-language-server', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('vscode-css-language-server', 'allowlist', ['css', 'less', 'sass', 'scss']),
-      \ 'blocklist': lsp_settings#get('vscode-css-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('vscode-css-language-server', 'config', lsp_settings#server_config('vscode-css-language-server')),
-      \ 'workspace_config': lsp_settings#get('vscode-css-language-server', 'workspace_config', {
-      \   'css': {'lint': {'validProperties': []}},
-      \   'less': {'lint': {'validProperties': []}},
-      \   'sass': {'lint': {'validProperties': []}},
-      \   'scss': {'lint': {'validProperties': []}},
-      \ }),
-      \ 'semantic_highlight': lsp_settings#get('vscode-css-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'vscode-css-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('vscode-css-language-server', 'cmd', [lsp_settings#exec_path('vscode-css-language-server')]+lsp_settings#get('vscode-css-language-server', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('vscode-css-language-server', 'root_uri', lsp_settings#root_uri('vscode-css-language-server'))},
+    \ 'initialization_options': lsp_settings#get('vscode-css-language-server', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('vscode-css-language-server', 'allowlist', ['css', 'less', 'sass', 'scss']),
+    \ 'blocklist': lsp_settings#get('vscode-css-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('vscode-css-language-server', 'config', lsp_settings#server_config('vscode-css-language-server')),
+    \ 'workspace_config': lsp_settings#get('vscode-css-language-server', 'workspace_config', {
+    \   'css': {'lint': {'validProperties': []}},
+    \   'less': {'lint': {'validProperties': []}},
+    \   'sass': {'lint': {'validProperties': []}},
+    \   'scss': {'lint': {'validProperties': []}},
+    \ }),
+    \ 'semantic_highlight': lsp_settings#get('vscode-css-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/vscode-css-language-server.vim
+++ b/settings/vscode-css-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_vscode_css_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'vscode-css-language-server',
       \ 'cmd': {server_info->lsp_settings#get('vscode-css-language-server', 'cmd', [lsp_settings#exec_path('vscode-css-language-server')]+lsp_settings#get('vscode-css-language-server', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('vscode-css-language-server', 'root_uri', lsp_settings#root_uri('vscode-css-language-server'))},
@@ -15,5 +15,5 @@ augroup vim_lsp_settings_vscode_css_language_server
       \   'scss': {'lint': {'validProperties': []}},
       \ }),
       \ 'semantic_highlight': lsp_settings#get('vscode-css-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/vscode-eslint-language-server.vim
+++ b/settings/vscode-eslint-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_eslint_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'vscode-eslint-language-server',
       \ 'cmd': {server_info->lsp_settings#get('vscode-eslint-language-server', 'cmd', [lsp_settings#exec_path('vscode-eslint-language-server')]+lsp_settings#get('vscode-eslint-language-server', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('vscode-eslint-language-server', 'root_uri', lsp_settings#root_uri('vscode-eslint-language-server'))},
@@ -36,5 +36,5 @@ augroup vim_lsp_settings_eslint_language_server
       \   'nodePath': v:null,
       \ }),
       \ 'semantic_highlight': lsp_settings#get('vscode-eslint-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/vscode-eslint-language-server.vim
+++ b/settings/vscode-eslint-language-server.vim
@@ -1,40 +1,37 @@
-augroup vim_lsp_settings_eslint_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'vscode-eslint-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('vscode-eslint-language-server', 'cmd', [lsp_settings#exec_path('vscode-eslint-language-server')]+lsp_settings#get('vscode-eslint-language-server', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('vscode-eslint-language-server', 'root_uri', lsp_settings#root_uri('vscode-eslint-language-server'))},
-      \ 'initialization_options': lsp_settings#get('vscode-eslint-language-server', 'initialization_options', {'diagnostics': 'true'}),
-      \ 'allowlist': lsp_settings#get('vscode-eslint-language-server', 'allowlist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact']),
-      \ 'blocklist': lsp_settings#get('vscode-eslint-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('vscode-eslint-language-server', 'config', lsp_settings#server_config('vscode-eslint-language-server')),
-      \ 'workspace_config': lsp_settings#get('vscode-eslint-language-server', 'workspace_config', {
-      \   'validate': 'probe',
-      \   'packageManager': 'npm',
-      \   'useESLintClass': v:false,
-      \   'experimental': { 'useFlatConfig': v:false },
-      \   'codeAction': {
-      \     'disableRuleComment': {
-      \       'enable': v:true,
-      \       'location': 'separateLine',
-      \     },
-      \     'showDocumentation': {
-      \       'enable': v:true,
-      \     },
-      \   },
-      \   'codeActionOnSave': {
-      \     'enable': v:true,
-      \     'mode': 'all',
-      \   },
-      \   'format': v:false,
-      \   'quiet': v:false,
-      \   'onIgnoredFiles': 'off',
-      \   'options': {},
-      \   'rulesCustomizations': [],
-      \   'run': 'onType',
-      \   'problems': { 'shortenToSingleLine': v:true },
-      \   'nodePath': v:null,
-      \ }),
-      \ 'semantic_highlight': lsp_settings#get('vscode-eslint-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'vscode-eslint-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('vscode-eslint-language-server', 'cmd', [lsp_settings#exec_path('vscode-eslint-language-server')]+lsp_settings#get('vscode-eslint-language-server', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('vscode-eslint-language-server', 'root_uri', lsp_settings#root_uri('vscode-eslint-language-server'))},
+    \ 'initialization_options': lsp_settings#get('vscode-eslint-language-server', 'initialization_options', {'diagnostics': 'true'}),
+    \ 'allowlist': lsp_settings#get('vscode-eslint-language-server', 'allowlist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact']),
+    \ 'blocklist': lsp_settings#get('vscode-eslint-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('vscode-eslint-language-server', 'config', lsp_settings#server_config('vscode-eslint-language-server')),
+    \ 'workspace_config': lsp_settings#get('vscode-eslint-language-server', 'workspace_config', {
+    \   'validate': 'probe',
+    \   'packageManager': 'npm',
+    \   'useESLintClass': v:false,
+    \   'experimental': { 'useFlatConfig': v:false },
+    \   'codeAction': {
+    \     'disableRuleComment': {
+    \       'enable': v:true,
+    \       'location': 'separateLine',
+    \     },
+    \     'showDocumentation': {
+    \       'enable': v:true,
+    \     },
+    \   },
+    \   'codeActionOnSave': {
+    \     'enable': v:true,
+    \     'mode': 'all',
+    \   },
+    \   'format': v:false,
+    \   'quiet': v:false,
+    \   'onIgnoredFiles': 'off',
+    \   'options': {},
+    \   'rulesCustomizations': [],
+    \   'run': 'onType',
+    \   'problems': { 'shortenToSingleLine': v:true },
+    \   'nodePath': v:null,
+    \ }),
+    \ 'semantic_highlight': lsp_settings#get('vscode-eslint-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/vscode-html-language-server.vim
+++ b/settings/vscode-html-language-server.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_vscode_html_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'vscode-html-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('vscode-html-language-server', 'cmd', [lsp_settings#exec_path('vscode-html-language-server')]+lsp_settings#get('vscode-html-language-server', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('vscode-html-langserver', 'root_uri', lsp_settings#root_uri('vscode-html-language-server'))},
-      \ 'initialization_options': lsp_settings#get('vscode-html-language-server', 'initialization_options', {'embeddedLanguages': {'css': v:true, 'javascript': v:true}}),
-      \ 'allowlist': lsp_settings#get('vscode-html-language-server', 'allowlist', ['html']),
-      \ 'blocklist': lsp_settings#get('vscode-html-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('vscode-html-language-server', 'config', lsp_settings#server_config('vscode-html-language-server')),
-      \ 'workspace_config': lsp_settings#get('vscode-html-language-server', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('vscode-html-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'vscode-html-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('vscode-html-language-server', 'cmd', [lsp_settings#exec_path('vscode-html-language-server')]+lsp_settings#get('vscode-html-language-server', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('vscode-html-langserver', 'root_uri', lsp_settings#root_uri('vscode-html-language-server'))},
+    \ 'initialization_options': lsp_settings#get('vscode-html-language-server', 'initialization_options', {'embeddedLanguages': {'css': v:true, 'javascript': v:true}}),
+    \ 'allowlist': lsp_settings#get('vscode-html-language-server', 'allowlist', ['html']),
+    \ 'blocklist': lsp_settings#get('vscode-html-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('vscode-html-language-server', 'config', lsp_settings#server_config('vscode-html-language-server')),
+    \ 'workspace_config': lsp_settings#get('vscode-html-language-server', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('vscode-html-language-server', 'semantic_highlight', {}),
+    \ })

--- a/settings/vscode-html-language-server.vim
+++ b/settings/vscode-html-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_vscode_html_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'vscode-html-language-server',
       \ 'cmd': {server_info->lsp_settings#get('vscode-html-language-server', 'cmd', [lsp_settings#exec_path('vscode-html-language-server')]+lsp_settings#get('vscode-html-language-server', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('vscode-html-langserver', 'root_uri', lsp_settings#root_uri('vscode-html-language-server'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_vscode_html_language_server
       \ 'config': lsp_settings#get('vscode-html-language-server', 'config', lsp_settings#server_config('vscode-html-language-server')),
       \ 'workspace_config': lsp_settings#get('vscode-html-language-server', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('vscode-html-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/vscode-json-language-server.vim
+++ b/settings/vscode-json-language-server.vim
@@ -29,7 +29,7 @@ function! s:on_lsp_buffer_enabled() abort
   command! -buffer -nargs=1 LspJsonSetSchema call <SID>set_schema(<q-args>)
 endfunction
 
-augroup lsp_install_json
+augroup vim_lsp_settings_vscode_json_language_server
   au!
   autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled()
 augroup END

--- a/settings/vscode-json-language-server.vim
+++ b/settings/vscode-json-language-server.vim
@@ -1,4 +1,4 @@
-function! Vim_lsp_settings_vscode_json_language_server_capabilities() abort
+function! s:capabilities() abort
   let l:capabilities = lsp#default_get_supported_capabilities('vscode-json-language-server')
   " Override snippetSupport: true for enable completion
   let l:capabilities.textDocument.completion.completionItem.snippetSupport = v:true
@@ -7,18 +7,18 @@ endfunction
 
 augroup vim_lsp_settings_vscode_json_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'vscode-json-language-server',
       \ 'cmd': {server_info->lsp_settings#get('vscode-json-language-server', 'cmd', [lsp_settings#exec_path('vscode-json-language-server')]+lsp_settings#get('vscode-json-language-server', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('vscode-json-language-server', 'root_uri', lsp_settings#root_uri('vscode-json-language-server'))},
       \ 'initialization_options': lsp_settings#get('vscode-json-language-server', 'initialization_options', {'provideFormatter': v:true}),
-      \ 'capabilities': lsp_settings#get('vscode-json-language-server', 'capabilities', Vim_lsp_settings_vscode_json_language_server_capabilities()),
+      \ 'capabilities': lsp_settings#get('vscode-json-language-server', 'capabilities', s:capabilities()),
       \ 'allowlist': lsp_settings#get('vscode-json-language-server', 'allowlist', ['json', 'jsonc']),
       \ 'blocklist': lsp_settings#get('vscode-json-language-server', 'blocklist', []),
       \ 'config': lsp_settings#get('vscode-json-language-server', 'config', lsp_settings#server_config('vscode-json-language-server')),
       \ 'workspace_config': lsp_settings#get('vscode-json-language-server', 'workspace_config', {name, key->{'json': {'format': {'enable': v:true}, 'schemas': lsp_settings#utils#load_schemas('vscode-json-language-server') + [{'fileMatch':['/vim-lsp-settings/settings.json', '/.vim-lsp-settings/settings.json'], 'url': 'https://mattn.github.io/vim-lsp-settings/local-schema.json'}]}}}),
       \ 'semantic_highlight': lsp_settings#get('vscode-json-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END
 
 function! s:set_schema(url) abort

--- a/settings/vscode-json-language-server.vim
+++ b/settings/vscode-json-language-server.vim
@@ -5,21 +5,18 @@ function! s:capabilities() abort
   return l:capabilities
 endfunction
 
-augroup vim_lsp_settings_vscode_json_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'vscode-json-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('vscode-json-language-server', 'cmd', [lsp_settings#exec_path('vscode-json-language-server')]+lsp_settings#get('vscode-json-language-server', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('vscode-json-language-server', 'root_uri', lsp_settings#root_uri('vscode-json-language-server'))},
-      \ 'initialization_options': lsp_settings#get('vscode-json-language-server', 'initialization_options', {'provideFormatter': v:true}),
-      \ 'capabilities': lsp_settings#get('vscode-json-language-server', 'capabilities', s:capabilities()),
-      \ 'allowlist': lsp_settings#get('vscode-json-language-server', 'allowlist', ['json', 'jsonc']),
-      \ 'blocklist': lsp_settings#get('vscode-json-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('vscode-json-language-server', 'config', lsp_settings#server_config('vscode-json-language-server')),
-      \ 'workspace_config': lsp_settings#get('vscode-json-language-server', 'workspace_config', {name, key->{'json': {'format': {'enable': v:true}, 'schemas': lsp_settings#utils#load_schemas('vscode-json-language-server') + [{'fileMatch':['/vim-lsp-settings/settings.json', '/.vim-lsp-settings/settings.json'], 'url': 'https://mattn.github.io/vim-lsp-settings/local-schema.json'}]}}}),
-      \ 'semantic_highlight': lsp_settings#get('vscode-json-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'vscode-json-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('vscode-json-language-server', 'cmd', [lsp_settings#exec_path('vscode-json-language-server')]+lsp_settings#get('vscode-json-language-server', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('vscode-json-language-server', 'root_uri', lsp_settings#root_uri('vscode-json-language-server'))},
+    \ 'initialization_options': lsp_settings#get('vscode-json-language-server', 'initialization_options', {'provideFormatter': v:true}),
+    \ 'capabilities': lsp_settings#get('vscode-json-language-server', 'capabilities', s:capabilities()),
+    \ 'allowlist': lsp_settings#get('vscode-json-language-server', 'allowlist', ['json', 'jsonc']),
+    \ 'blocklist': lsp_settings#get('vscode-json-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('vscode-json-language-server', 'config', lsp_settings#server_config('vscode-json-language-server')),
+    \ 'workspace_config': lsp_settings#get('vscode-json-language-server', 'workspace_config', {name, key->{'json': {'format': {'enable': v:true}, 'schemas': lsp_settings#utils#load_schemas('vscode-json-language-server') + [{'fileMatch':['/vim-lsp-settings/settings.json', '/.vim-lsp-settings/settings.json'], 'url': 'https://mattn.github.io/vim-lsp-settings/local-schema.json'}]}}}),
+    \ 'semantic_highlight': lsp_settings#get('vscode-json-language-server', 'semantic_highlight', {}),
+    \ })
 
 function! s:set_schema(url) abort
   let l:name = fnamemodify(lsp#utils#get_buffer_uri(), ':t')

--- a/settings/vtsls.vim
+++ b/settings/vtsls.vim
@@ -1,4 +1,4 @@
-function! Vim_lsp_settings_vtsls_get_blocklist() abort
+function! s:get_blocklist() abort
     if empty(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), 'node_modules/'))
         return ['typescript', 'javascript', 'typescriptreact', 'javascriptreact', 'vue']
     endif
@@ -23,7 +23,7 @@ function! s:find_vue_plugin() abort
   \ }
 endfunction
 
-function! Vim_lsp_settings_vtsls_setup_plugins() abort
+function! s:setup_plugins() abort
   let plugins = []
 
   let vue_plugin = s:find_vue_plugin()
@@ -36,13 +36,13 @@ endfunction
 
 augroup vim_lsp_settings_vtsls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'vtsls',
       \ 'cmd': {server_info->lsp_settings#get('vtsls', 'cmd', [lsp_settings#exec_path('vtsls')]+lsp_settings#get('vtsls', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('vtsls', 'root_uri', lsp_settings#root_uri('vtsls'))},
       \ 'initialization_options': lsp_settings#get('vtsls', 'initialization_options', {}),
       \ 'allowlist': lsp_settings#get('vtsls', 'allowlist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact', 'typescript.tsx', 'vue']),
-      \ 'blocklist': lsp_settings#get('vtsls', 'blocklist', Vim_lsp_settings_vtsls_get_blocklist()),
+      \ 'blocklist': lsp_settings#get('vtsls', 'blocklist', s:get_blocklist()),
       \ 'config': lsp_settings#get('vtsls', 'config', lsp_settings#server_config('vtsls')),
       \ 'workspace_config': lsp_settings#get('vtsls', 'workspace_config', {
       \   'typescript': {
@@ -91,10 +91,10 @@ augroup vim_lsp_settings_vtsls
       \   },
       \   'vtsls': {
       \     'tsserver': {
-      \       'globalPlugins': Vim_lsp_settings_vtsls_setup_plugins(),
+      \       'globalPlugins': s:setup_plugins(),
       \     },
       \   },
       \ }),
       \ 'semantic_highlight': lsp_settings#get('vtsls', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/vtsls.vim
+++ b/settings/vtsls.vim
@@ -34,67 +34,64 @@ function! s:setup_plugins() abort
   return plugins
 endfunction
 
-augroup vim_lsp_settings_vtsls
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'vtsls',
-      \ 'cmd': {server_info->lsp_settings#get('vtsls', 'cmd', [lsp_settings#exec_path('vtsls')]+lsp_settings#get('vtsls', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('vtsls', 'root_uri', lsp_settings#root_uri('vtsls'))},
-      \ 'initialization_options': lsp_settings#get('vtsls', 'initialization_options', {}),
-      \ 'allowlist': lsp_settings#get('vtsls', 'allowlist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact', 'typescript.tsx', 'vue']),
-      \ 'blocklist': lsp_settings#get('vtsls', 'blocklist', s:get_blocklist()),
-      \ 'config': lsp_settings#get('vtsls', 'config', lsp_settings#server_config('vtsls')),
-      \ 'workspace_config': lsp_settings#get('vtsls', 'workspace_config', {
-      \   'typescript': {
-      \     'inlayHints': {
-      \       'parameterNames': {
-      \         'enabled': 'all',
-      \       },
-      \       'parameterTypes': {
-      \         'enabled': v:true,
-      \       },
-      \       'variableTypes': {
-      \         'enabled': v:true,
-      \       },
-      \       'propertyDeclarationTypes': {
-      \         'enabled': v:true,
-      \       },
-      \       'functionLikeReturnTypes': {
-      \         'enabled': v:true,
-      \       },
-      \       'enumMemberValues': {
-      \         'enabled': v:true,
-      \       },
-      \     },
-      \   },
-      \   'javascript': {
-      \     'inlayHints': {
-      \       'parameterNames': {
-      \         'enabled': 'all',
-      \       },
-      \       'parameterTypes': {
-      \         'enabled': v:true,
-      \       },
-      \       'variableTypes': {
-      \         'enabled': v:true,
-      \       },
-      \       'propertyDeclarationTypes': {
-      \         'enabled': v:true,
-      \       },
-      \       'functionLikeReturnTypes': {
-      \         'enabled': v:true,
-      \       },
-      \       'enumMemberValues': {
-      \         'enabled': v:true,
-      \       },
-      \     },
-      \   },
-      \   'vtsls': {
-      \     'tsserver': {
-      \       'globalPlugins': s:setup_plugins(),
-      \     },
-      \   },
-      \ }),
-      \ 'semantic_highlight': lsp_settings#get('vtsls', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'vtsls',
+    \ 'cmd': {server_info->lsp_settings#get('vtsls', 'cmd', [lsp_settings#exec_path('vtsls')]+lsp_settings#get('vtsls', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('vtsls', 'root_uri', lsp_settings#root_uri('vtsls'))},
+    \ 'initialization_options': lsp_settings#get('vtsls', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('vtsls', 'allowlist', ['javascript', 'javascriptreact', 'typescript', 'typescriptreact', 'typescript.tsx', 'vue']),
+    \ 'blocklist': lsp_settings#get('vtsls', 'blocklist', s:get_blocklist()),
+    \ 'config': lsp_settings#get('vtsls', 'config', lsp_settings#server_config('vtsls')),
+    \ 'workspace_config': lsp_settings#get('vtsls', 'workspace_config', {
+    \   'typescript': {
+    \     'inlayHints': {
+    \       'parameterNames': {
+    \         'enabled': 'all',
+    \       },
+    \       'parameterTypes': {
+    \         'enabled': v:true,
+    \       },
+    \       'variableTypes': {
+    \         'enabled': v:true,
+    \       },
+    \       'propertyDeclarationTypes': {
+    \         'enabled': v:true,
+    \       },
+    \       'functionLikeReturnTypes': {
+    \         'enabled': v:true,
+    \       },
+    \       'enumMemberValues': {
+    \         'enabled': v:true,
+    \       },
+    \     },
+    \   },
+    \   'javascript': {
+    \     'inlayHints': {
+    \       'parameterNames': {
+    \         'enabled': 'all',
+    \       },
+    \       'parameterTypes': {
+    \         'enabled': v:true,
+    \       },
+    \       'variableTypes': {
+    \         'enabled': v:true,
+    \       },
+    \       'propertyDeclarationTypes': {
+    \         'enabled': v:true,
+    \       },
+    \       'functionLikeReturnTypes': {
+    \         'enabled': v:true,
+    \       },
+    \       'enumMemberValues': {
+    \         'enabled': v:true,
+    \       },
+    \     },
+    \   },
+    \   'vtsls': {
+    \     'tsserver': {
+    \       'globalPlugins': s:setup_plugins(),
+    \     },
+    \   },
+    \ }),
+    \ 'semantic_highlight': lsp_settings#get('vtsls', 'semantic_highlight', {}),
+    \ })

--- a/settings/yaml-language-server.vim
+++ b/settings/yaml-language-server.vim
@@ -1,17 +1,14 @@
-augroup vim_lsp_settings_yaml_language_server
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'yaml-language-server',
-      \ 'cmd': {server_info->lsp_settings#get('yaml-language-server', 'cmd', [lsp_settings#exec_path('yaml-language-server')]+lsp_settings#get('yaml-language-server', 'args', ['--stdio']))},
-      \ 'root_uri':{server_info->lsp_settings#get('yaml-language-server', 'root_uri', lsp_settings#root_uri('yaml-language-server'))},
-      \ 'initialization_options': lsp_settings#get('yaml-language-server', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('yaml-language-server', 'allowlist', ['yaml']),
-      \ 'blocklist': lsp_settings#get('yaml-language-server', 'blocklist', []),
-      \ 'config': lsp_settings#get('yaml-language-server', 'config', lsp_settings#server_config('yaml-language-server')),
-      \ 'workspace_config': lsp_settings#merge('yaml-language-server', 'workspace_config', {'yaml': {'format': {'enable': v:true}, 'schemas': lsp_settings#utils#load_schemas_map('yaml-language-server')}}),
-      \ 'semantic_highlight': lsp_settings#get('yaml-language-server', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'yaml-language-server',
+    \ 'cmd': {server_info->lsp_settings#get('yaml-language-server', 'cmd', [lsp_settings#exec_path('yaml-language-server')]+lsp_settings#get('yaml-language-server', 'args', ['--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('yaml-language-server', 'root_uri', lsp_settings#root_uri('yaml-language-server'))},
+    \ 'initialization_options': lsp_settings#get('yaml-language-server', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('yaml-language-server', 'allowlist', ['yaml']),
+    \ 'blocklist': lsp_settings#get('yaml-language-server', 'blocklist', []),
+    \ 'config': lsp_settings#get('yaml-language-server', 'config', lsp_settings#server_config('yaml-language-server')),
+    \ 'workspace_config': lsp_settings#merge('yaml-language-server', 'workspace_config', {'yaml': {'format': {'enable': v:true}, 'schemas': lsp_settings#utils#load_schemas_map('yaml-language-server')}}),
+    \ 'semantic_highlight': lsp_settings#get('yaml-language-server', 'semantic_highlight', {}),
+    \ })
 
 function! s:set_schema(url) abort
   let l:name = fnamemodify(lsp#utils#get_buffer_uri(), ':t')

--- a/settings/yaml-language-server.vim
+++ b/settings/yaml-language-server.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_yaml_language_server
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'yaml-language-server',
       \ 'cmd': {server_info->lsp_settings#get('yaml-language-server', 'cmd', [lsp_settings#exec_path('yaml-language-server')]+lsp_settings#get('yaml-language-server', 'args', ['--stdio']))},
       \ 'root_uri':{server_info->lsp_settings#get('yaml-language-server', 'root_uri', lsp_settings#root_uri('yaml-language-server'))},
@@ -10,7 +10,7 @@ augroup vim_lsp_settings_yaml_language_server
       \ 'config': lsp_settings#get('yaml-language-server', 'config', lsp_settings#server_config('yaml-language-server')),
       \ 'workspace_config': lsp_settings#merge('yaml-language-server', 'workspace_config', {'yaml': {'format': {'enable': v:true}, 'schemas': lsp_settings#utils#load_schemas_map('yaml-language-server')}}),
       \ 'semantic_highlight': lsp_settings#get('yaml-language-server', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END
 
 function! s:set_schema(url) abort

--- a/settings/yaml-language-server.vim
+++ b/settings/yaml-language-server.vim
@@ -26,7 +26,7 @@ function! s:on_lsp_buffer_enabled() abort
   endif
 endfunction
 
-augroup lsp_install_yaml
+augroup vim_lsp_settings_yaml_language_server
   au!
   autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled()
 augroup END

--- a/settings/yang-lsp.vim
+++ b/settings/yang-lsp.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_yang_lsp
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'yang-lsp',
-      \ 'cmd': {server_info->lsp_settings#get('yang-lsp', 'cmd', [lsp_settings#exec_path('yang-lsp')]+lsp_settings#get('yang-lsp', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('yang-lsp', 'root_uri', lsp_settings#root_uri('yang-lsp'))},
-      \ 'initialization_options': lsp_settings#get('yang-lsp', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('yang-lsp', 'allowlist', ['yang']),
-      \ 'blocklist': lsp_settings#get('yang-lsp', 'blocklist', []),
-      \ 'config': lsp_settings#get('yang-lsp', 'config', lsp_settings#server_config('yang-lsp')),
-      \ 'workspace_config': lsp_settings#get('yang-lsp', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('yang-lsp', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'yang-lsp',
+    \ 'cmd': {server_info->lsp_settings#get('yang-lsp', 'cmd', [lsp_settings#exec_path('yang-lsp')]+lsp_settings#get('yang-lsp', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('yang-lsp', 'root_uri', lsp_settings#root_uri('yang-lsp'))},
+    \ 'initialization_options': lsp_settings#get('yang-lsp', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('yang-lsp', 'allowlist', ['yang']),
+    \ 'blocklist': lsp_settings#get('yang-lsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('yang-lsp', 'config', lsp_settings#server_config('yang-lsp')),
+    \ 'workspace_config': lsp_settings#get('yang-lsp', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('yang-lsp', 'semantic_highlight', {}),
+    \ })

--- a/settings/yang-lsp.vim
+++ b/settings/yang-lsp.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_yang_lsp
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'yang-lsp',
       \ 'cmd': {server_info->lsp_settings#get('yang-lsp', 'cmd', [lsp_settings#exec_path('yang-lsp')]+lsp_settings#get('yang-lsp', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('yang-lsp', 'root_uri', lsp_settings#root_uri('yang-lsp'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_yang_lsp
       \ 'config': lsp_settings#get('yang-lsp', 'config', lsp_settings#server_config('yang-lsp')),
       \ 'workspace_config': lsp_settings#get('yang-lsp', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('yang-lsp', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/zls.vim
+++ b/settings/zls.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_zls
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'zls',
-      \ 'cmd': {server_info->lsp_settings#get('zls', 'cmd', [lsp_settings#exec_path('zls')]+lsp_settings#get('zls', 'args', []))},
-      \ 'root_uri':{server_info->lsp_settings#get('zls', 'root_uri', lsp_settings#root_uri('zls'))},
-      \ 'initialization_options': lsp_settings#get('zls', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('zls', 'allowlist', ['zig']),
-      \ 'blocklist': lsp_settings#get('zls', 'blocklist', []),
-      \ 'config': lsp_settings#get('zls', 'config', lsp_settings#server_config('zls')),
-      \ 'workspace_config': lsp_settings#get('zls', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('zls', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'zls',
+    \ 'cmd': {server_info->lsp_settings#get('zls', 'cmd', [lsp_settings#exec_path('zls')]+lsp_settings#get('zls', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('zls', 'root_uri', lsp_settings#root_uri('zls'))},
+    \ 'initialization_options': lsp_settings#get('zls', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('zls', 'allowlist', ['zig']),
+    \ 'blocklist': lsp_settings#get('zls', 'blocklist', []),
+    \ 'config': lsp_settings#get('zls', 'config', lsp_settings#server_config('zls')),
+    \ 'workspace_config': lsp_settings#get('zls', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('zls', 'semantic_highlight', {}),
+    \ })

--- a/settings/zls.vim
+++ b/settings/zls.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_zls
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'zls',
       \ 'cmd': {server_info->lsp_settings#get('zls', 'cmd', [lsp_settings#exec_path('zls')]+lsp_settings#get('zls', 'args', []))},
       \ 'root_uri':{server_info->lsp_settings#get('zls', 'root_uri', lsp_settings#root_uri('zls'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_zls
       \ 'config': lsp_settings#get('zls', 'config', lsp_settings#server_config('zls')),
       \ 'workspace_config': lsp_settings#get('zls', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('zls', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/zuban.vim
+++ b/settings/zuban.vim
@@ -1,6 +1,6 @@
 augroup vim_lsp_settings_zuban
   au!
-  LspRegisterServer {
+  call lsp_settings#register_server({
       \ 'name': 'zuban',
       \ 'cmd': {server_info->lsp_settings#get('zuban', 'cmd', [lsp_settings#exec_path('zuban')]+lsp_settings#get('zuban', 'args', ['server']))},
       \ 'root_uri':{server_info->lsp_settings#get('zuban', 'root_uri', lsp_settings#root_uri('zuban'))},
@@ -10,5 +10,5 @@ augroup vim_lsp_settings_zuban
       \ 'config': lsp_settings#get('zuban', 'config', lsp_settings#server_config('zuban')),
       \ 'workspace_config': lsp_settings#get('zuban', 'workspace_config', {}),
       \ 'semantic_highlight': lsp_settings#get('zuban', 'semantic_highlight', {}),
-      \ }
+      \ })
 augroup END

--- a/settings/zuban.vim
+++ b/settings/zuban.vim
@@ -1,14 +1,11 @@
-augroup vim_lsp_settings_zuban
-  au!
-  call lsp_settings#register_server({
-      \ 'name': 'zuban',
-      \ 'cmd': {server_info->lsp_settings#get('zuban', 'cmd', [lsp_settings#exec_path('zuban')]+lsp_settings#get('zuban', 'args', ['server']))},
-      \ 'root_uri':{server_info->lsp_settings#get('zuban', 'root_uri', lsp_settings#root_uri('zuban'))},
-      \ 'initialization_options': lsp_settings#get('zuban', 'initialization_options', v:null),
-      \ 'allowlist': lsp_settings#get('zuban', 'allowlist', ['python']),
-      \ 'blocklist': lsp_settings#get('zuban', 'blocklist', []),
-      \ 'config': lsp_settings#get('zuban', 'config', lsp_settings#server_config('zuban')),
-      \ 'workspace_config': lsp_settings#get('zuban', 'workspace_config', {}),
-      \ 'semantic_highlight': lsp_settings#get('zuban', 'semantic_highlight', {}),
-      \ })
-augroup END
+call lsp_settings#register_server({
+    \ 'name': 'zuban',
+    \ 'cmd': {server_info->lsp_settings#get('zuban', 'cmd', [lsp_settings#exec_path('zuban')]+lsp_settings#get('zuban', 'args', ['server']))},
+    \ 'root_uri':{server_info->lsp_settings#get('zuban', 'root_uri', lsp_settings#root_uri('zuban'))},
+    \ 'initialization_options': lsp_settings#get('zuban', 'initialization_options', v:null),
+    \ 'allowlist': lsp_settings#get('zuban', 'allowlist', ['python']),
+    \ 'blocklist': lsp_settings#get('zuban', 'blocklist', []),
+    \ 'config': lsp_settings#get('zuban', 'config', lsp_settings#server_config('zuban')),
+    \ 'workspace_config': lsp_settings#get('zuban', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('zuban', 'semantic_highlight', {}),
+    \ })


### PR DESCRIPTION
This replaces the `LspRegisterServer {...}` user command invocation in all settings files with a direct `call lsp_settings#register_server({...})`.

The user command was introduced in #7 to centralize the version-dependent `:autocmd User lsp_setup ++once` boilerplate, but registration has been immediate since loading became lazy per filetype, so the command is now just an indirection. Because a user command's replacement text is evaluated in the script context where the command was defined, settings files could not reference their own script-local functions and had to define global `Vim_lsp_settings_*` helpers. With a direct function call the argument is evaluated in each settings file's own context, so those helpers are now script-local. The `LspRegisterServer` command itself is kept for backward compatibility.

All 154 settings files were converted mechanically and the themis test suite passes.