### PR TITLE
Fix pin typescript@^6.0.0 as latests doesnt ship tsserver

### DIFF
--- a/installer/install-typescript-language-server.cmd
+++ b/installer/install-typescript-language-server.cmd
@@ -1,4 +1,4 @@
 @echo off
 
-call "%~dp0\npm_install.cmd" tsserver typescript
+call "%~dp0\npm_install.cmd" tsserver typescript@6
 call "%~dp0\npm_install.cmd" typescript-language-server typescript-language-server

--- a/installer/install-typescript-language-server.sh
+++ b/installer/install-typescript-language-server.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-"$(dirname "$0")/npm_install.sh" tsserver typescript
+"$(dirname "$0")/npm_install.sh" tsserver typescript@^6.0.0
 "$(dirname "$0")/npm_install.sh" typescript-language-server typescript-language-server

--- a/installer/install-typescript-language-server.sh
+++ b/installer/install-typescript-language-server.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-"$(dirname "$0")/npm_install.sh" tsserver typescript@^6.0.0
+"$(dirname "$0")/npm_install.sh" tsserver typescript@6
 "$(dirname "$0")/npm_install.sh" typescript-language-server typescript-language-server


### PR DESCRIPTION
As TypeScript 7 no longer ships with the legacy lib/tsserver.js or bin/tsserver files, and because typescript-language-server installation script specify no version, npm blindly grabs the latest release (which is now 7.0+).

So, for now, to get typescript-language-server working and automatically configured by vim-lsp-setting it is needed to lock the dependency to the 6.x release.

Source: [zed editor repository](https://github.com/zed-industries/zed/issues/60618)