### PR TITLE
Fix @vue/language-server version range on Windows cmd

### DIFF
--- a/installer/install-volar-server.cmd
+++ b/installer/install-volar-server.cmd
@@ -1,5 +1,5 @@
 @echo off
 
-call "%~dp0\npm_install.cmd" vue-language-server @vue/language-server@^3.0.0
+call "%~dp0\npm_install.cmd" vue-language-server @vue/language-server@3
 ren vue-language-server.cmd volar-server.cmd
 call npm install typescript@5.8.3

--- a/installer/install-volar-server.sh
+++ b/installer/install-volar-server.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-"$(dirname "$0")/npm_install.sh" vue-language-server @vue/language-server@^3.0.0
+"$(dirname "$0")/npm_install.sh" vue-language-server @vue/language-server@3
 mv vue-language-server volar-server
 npm install typescript@5.8.3


### PR DESCRIPTION
The caret in `@vue/language-server@^3.0.0` was swallowed by cmd.exe escaping, so the installer pinned `3.0.0` instead of `^3.0.0`. Escaping or quoting the caret only turns it into an `EINVALIDTAGNAME` error (`^^3.0.0`). Switch to the caret-free equivalent range `@3` (`>=3.0.0 <4.0.0`), which survives cmd parsing and still resolves to the latest 3.x. Applied the same change to the `.sh` installer for consistency.