### PR TITLE
Add just-lsp

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ You can change the directory to install servers by set `g:lsp_settings_servers_d
 | JavaScript        | oxlint                              |    Yes    |      Yes      |
 | JavaScript        | oxfmt                               |    Yes    |      Yes      |
 | Julia             | LanguageServer.jl                   |    Yes    |      No       |
+| Just              | just-lsp                            |    Yes    |      Yes      |
 | Kotlin            | kotlin-language-server              |    Yes    |      Yes      |
 | Kotlin            | kotlin-lsp                          |    Yes    |      Yes      |
 | Lisp              | cl-lsp                              |    Yes    |      No       |

--- a/installer/install-just-lsp.cmd
+++ b/installer/install-just-lsp.cmd
@@ -1,0 +1,17 @@
+@echo off
+
+setlocal
+
+set PLATFORM=x86_64-pc-windows-msvc
+
+rem Get latest release version
+for /f "tokens=7 delims=/" %%i in ('curl -si "https://github.com/terror/just-lsp/releases/latest" ^| findstr /i "location:"') do (
+    set "VERSION=%%i"
+)
+
+curl -L -o "just-lsp.zip" "https://github.com/terror/just-lsp/releases/download/%VERSION%/just-lsp-%VERSION%-%PLATFORM%.zip"
+call "%~dp0\run_unzip.cmd" just-lsp.zip
+del /F just-lsp.zip
+del /F /Q Cargo.lock Cargo.toml LICENSE README.md 2>nul
+echo just-lsp
+.\just-lsp.exe --version

--- a/installer/install-just-lsp.sh
+++ b/installer/install-just-lsp.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+set -e
+
+os=$(uname -s | tr "[:upper:]" "[:lower:]")
+arch="$(uname -m)"
+ext="tar.gz"
+
+case $os in
+linux)
+  if [ "$arch" = "x86_64" ]; then
+    platform="x86_64-unknown-linux-gnu"
+  elif [ "$arch" = "aarch64" ]; then
+    platform="aarch64-unknown-linux-gnu"
+  else
+    echo "unknown architecture: $arch"
+    exit 1
+  fi
+  ;;
+darwin)
+  if [ "$arch" = "x86_64" ]; then
+    platform="x86_64-apple-darwin"
+  elif [ "$arch" = "aarch64" ] || [ "$arch" = "arm64" ]; then
+    platform="aarch64-apple-darwin"
+  else
+    echo "unknown architecture: $arch"
+    exit 1
+  fi
+  ;;
+mingw64_nt*)
+  if [ "$arch" = "x86_64" ]; then
+    platform="x86_64-pc-windows-msvc"
+  elif [ "$arch" = "aarch64" ] || [ "$arch" = "arm64" ]; then
+    platform="aarch64-pc-windows-msvc"
+  else
+    echo "unknown architecture: $arch"
+    exit 1
+  fi
+  ext="zip"
+  ;;
+*)
+  echo "unknown platform: $os"
+  exit 1
+  ;;
+esac
+
+# Get latest release version
+version=$(curl -si 'https://github.com/terror/just-lsp/releases/latest' | grep -ioE '^location: \S+')
+version=${version##*/}
+
+curl -L -o "just-lsp.$ext" "https://github.com/terror/just-lsp/releases/download/$version/just-lsp-$version-$platform.$ext"
+if [ "$ext" = "zip" ]; then
+  unzip -o "just-lsp.$ext" "just-lsp.exe"
+else
+  tar -xf "just-lsp.$ext" "./just-lsp"
+fi
+rm -f "just-lsp.$ext"
+echo "just-lsp"
+./just-lsp --version

--- a/settings.json
+++ b/settings.json
@@ -1106,6 +1106,18 @@
       }
     }
   ],
+  "just": [
+    {
+      "command": "just-lsp",
+      "url": "https://github.com/terror/just-lsp",
+      "description": "A language server for just",
+      "requires": [],
+      "root_uri_patterns": [
+        "justfile",
+        ".justfile"
+      ]
+    }
+  ],
   "kotlin": [
     {
       "command": "kotlin-language-server",

--- a/settings/just-lsp.vim
+++ b/settings/just-lsp.vim
@@ -1,0 +1,11 @@
+call lsp_settings#register_server({
+    \ 'name': 'just-lsp',
+    \ 'cmd': {server_info->lsp_settings#get('just-lsp', 'cmd', [lsp_settings#exec_path('just-lsp')]+lsp_settings#get('just-lsp', 'args', []))},
+    \ 'root_uri':{server_info->lsp_settings#get('just-lsp', 'root_uri', lsp_settings#root_uri('just-lsp'))},
+    \ 'initialization_options': lsp_settings#get('just-lsp', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('just-lsp', 'allowlist', ['just']),
+    \ 'blocklist': lsp_settings#get('just-lsp', 'blocklist', []),
+    \ 'config': lsp_settings#get('just-lsp', 'config', lsp_settings#server_config('just-lsp')),
+    \ 'workspace_config': lsp_settings#get('just-lsp', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('just-lsp', 'semantic_highlight', {}),
+    \ })


### PR DESCRIPTION
Add support for [just-lsp](https://github.com/terror/just-lsp), a language server for justfiles. Binaries are downloaded from GitHub releases for Linux/macOS/Windows, registered for the `just` filetype.