### PR TITLE
Add support tsc --lsp

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ You can change the directory to install servers by set `g:lsp_settings_servers_d
 | Terraform         | terraform-ls                        |    Yes    |      Yes      |
 | TOML              | taplo-lsp                           |    No     |      Yes      |
 | TTCN-3            | ntt                                 |    Yes    |      Yes      |
+| TypeScript        | tsc(typeScript-go)                  |    Yes    |      Yes      |
 | TypeScript        | typescript-language-server          |    Yes    |      Yes      |
 | TypeScript        | vtsls                               |    Yes    |      Yes      |
 | TypeScript        | tsp-server                          |    Yes    |      Yes      |

--- a/installer/install-tsc.cmd
+++ b/installer/install-tsc.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+call "%~dp0\npm_install.cmd" tsc typescript

--- a/installer/install-tsc.sh
+++ b/installer/install-tsc.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+"$(dirname "$0")/npm_install.sh" tsc typescript

--- a/settings.json
+++ b/settings.json
@@ -2173,6 +2173,18 @@
   ],
   "typescript": [
     {
+      "command": "tsc",
+      "url": "https://github.com/microsoft/typescript",
+      "description": "Staging repo for development of native port of TypeScript (tsc --lsp)",
+      "requires": [
+          "npx"
+      ],
+      "root_uri_patterns": [
+        "package.json",
+        "tsconfig.json"
+      ]
+    },
+    {
       "command": "typescript-go",
       "url": "https://github.com/microsoft/typescript-go",
       "description": "Staging repo for development of native port of TypeScript",
@@ -2278,6 +2290,18 @@
     }
   ],
   "typescriptreact": [
+    {
+      "command": "tsc",
+      "url": "https://github.com/microsoft/typescript",
+      "description": "Staging repo for development of native port of TypeScript (tsc --lsp)",
+      "requires": [
+          "npx"
+      ],
+      "root_uri_patterns": [
+        "package.json",
+        "tsconfig.json"
+      ]
+    },
     {
       "command": "typescript-language-server",
       "url": "https://github.com/typescript-language-server/typescript-language-server",

--- a/settings/tsc.vim
+++ b/settings/tsc.vim
@@ -1,0 +1,62 @@
+call lsp_settings#register_server({
+    \ 'name': 'tsc',
+    \ 'cmd': {server_info->lsp_settings#get('tsc', 'cmd', [lsp_settings#exec_path('tsc')]+lsp_settings#get('tsc', 'args', ['--lsp', '--stdio']))},
+    \ 'root_uri':{server_info->lsp_settings#get('tsc', 'root_uri', lsp_settings#root_uri('tsc'))},
+    \ 'initialization_options': lsp_settings#get('tsc', 'initialization_options', {}),
+    \ 'allowlist': lsp_settings#get('tsc', 'allowlist', ['typescript', 'typescriptreact', 'typescript.tsx']),
+    \ 'blocklist': lsp_settings#get('tsc', 'blocklist', []),
+    \ 'config': lsp_settings#get('tsc', 'config', {}),
+    \ 'workspace_config': lsp_settings#get('tsc', 'workspace_config', {}),
+    \ 'semantic_highlight': lsp_settings#get('tsc', 'semantic_highlight', {}),
+    \ })
+
+let s:vimlsp_send_response = v:null
+
+function! s:resolve_send_response() abort
+  if exists('*getscriptinfo')
+    let l:matches = getscriptinfo({'name': 'vim-lsp/autoload/lsp.vim'})
+    if !empty(l:matches)
+      let s:vimlsp_send_response =
+        \ function('<SNR>' . l:matches[0].sid . '_send_response')
+    endif
+    return
+  endif
+  let l:lines = filter(
+    \ split(execute('scriptnames'), "\n"),
+    \ 'v:val =~# ''vim-lsp/autoload/lsp\.vim$''')
+  if !empty(l:lines)
+    let s:vimlsp_send_response =
+      \ function('<SNR>' . matchstr(l:lines[0], '\d\+') . '_send_response')
+  endif
+endfunction
+
+function! s:on_tsc_request(data) abort
+  if get(a:data, 'server', '') !=# 'tsc'
+    return
+  endif
+  let l:request = a:data['request']
+  if l:request['method'] !=# 'client/registerCapability' && l:request['method'] !=# 'client/unregisterCapability'
+    return
+  endif
+  if s:vimlsp_send_response is v:null
+    return
+  endif
+  call s:vimlsp_send_response('tsc', { 'id': l:request['id'], 'result': v:null })
+endfunction
+
+function! s:on_lsp_setup() abort
+  call s:resolve_send_response()
+  call lsp#callbag#pipe(
+    \ lsp#stream(),
+    \ lsp#callbag#filter({x->
+    \     has_key(x, 'request') && !has_key(x, 'response') &&
+    \     has_key(x['request'], 'method')
+    \ }),
+    \ lsp#callbag#subscribe({'next': function('s:on_tsc_request')})
+    \ )
+endfunction
+
+augroup vim_lsp_settings_tsc
+  au!
+  autocmd User lsp_setup call s:on_lsp_setup()
+augroup END


### PR DESCRIPTION
Hi

I've implemented `tsc --lsp --stdio`, formerly known as tsgo.
`typescript-go` installs `tsgo` from `@typescript/native-preview` (staging build),
 but since TypeScript 7.0.2, built-in tsc command support lsp option. It can be installed from npm (npm i typescript@7)

Note:
This pull request includes a workaround for vim-lsp(respond to `client/registerCapability`).
~~And when `g:lsp_use_native_client = 1`, tsc uses string ids like `"ts1"`, and vim-lsp's native LSP channel does not support them The following vim-lsp PR must also be merged~~
↑https://github.com/prabirshrestha/vim-lsp/pull/1686 has been merged(Thank you). So now we can use tsc --lsp with `g:lsp_use_native_client = 1` mode.

ref: https://github.com/prabirshrestha/vim-lsp/pull/1686

@mattn 
It would be very appliciated to review and merge the https://github.com/prabirshrestha/vim-lsp/pull/1686 🙏 
I use `g:lsp_use_native_client = 1`, but currently I can't use tsc --lsp with native client.

<img width="740" height="170" alt="スクリーンショット 2026-08-04 0 07 13" src="https://github.com/user-attachments/assets/37b4673f-7ef2-43dd-9c99-19ce76e01e43" />

Thank you